### PR TITLE
fix: fill board description, README and linked-repo on init

### DIFF
--- a/.abios/fix-issue-6.md
+++ b/.abios/fix-issue-6.md
@@ -1,0 +1,3 @@
+fix: fill board description, README and linked-repo on init
+
+Closes #6


### PR DESCRIPTION
Closes #6

## Summary
fix: fill board description, README and linked-repo on init