### PR TITLE
fix: restrict code-marker regex to TAG: convention

### DIFF
--- a/.abios/fix-issue-8.md
+++ b/.abios/fix-issue-8.md
@@ -1,0 +1,3 @@
+fix: restrict code-marker regex to TAG: convention
+
+Closes #8


### PR DESCRIPTION
Closes #8

## Summary
fix: restrict code-marker regex to TAG: convention