### PR TITLE
fix: set board visibility to Public for public repos

### DIFF
--- a/.abios/fix-issue-10.md
+++ b/.abios/fix-issue-10.md
@@ -1,0 +1,3 @@
+fix: set board visibility to Public for public repos
+
+Closes #10


### PR DESCRIPTION
Closes #10

## Summary
fix: set board visibility to Public for public repos