### PR TITLE
feat(board): bulk-fill any custom field across all items by rule (Set-BoardField.ps1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   template (e.g. `Ruta`), idempotent, retries transient 502s. Documents the gotchas that bite a manual
   loop (the `cat`=Get-Content alias shadowing, single-select-id vs `--text`, lowercased field keys in
   `item-list`, GraphQL-batch quoting). Turns the "fill all the columns" chore into one command.
+- **Post-fill view-visibility warning** in `Set-BoardField.ps1`: after filling, it checks whether the
+  field is shown in ANY board view and warns if not — the top "the tool didn't work" false alarm is a
+  filled field that the current view simply doesn't display (view columns are UI-only; no API can add
+  them). Also documents that `Assignees`/`Linked PRs`/`Sub-issues progress` are auto-derived system
+  columns that stay blank on draft cards and cannot be filled by any tool.
 
 ## [0.6.2] - 2026-06-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.0] - 2026-06-30
+### Added
+- **Bulk-fill a custom field across every board item by rule** — new `scripts/Set-BoardField.ps1`
+  + `/board field` recipe. Single-select by title-prefix map (e.g. `Categoria`) or text by `{title}`
+  template (e.g. `Ruta`), idempotent, retries transient 502s. Documents the gotchas that bite a manual
+  loop (the `cat`=Get-Content alias shadowing, single-select-id vs `--text`, lowercased field keys in
+  `item-list`, GraphQL-batch quoting). Turns the "fill all the columns" chore into one command.
+
 ## [0.6.2] - 2026-06-29
 ### Added
 - Hard rule + pre-`item-add` check: a board only accepts items from its own anchored repo — a public

--- a/plugins/agentic-bi-ops/.claude-plugin/plugin.json
+++ b/plugins/agentic-bi-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-bi-ops",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "GitOps for BI with AI agents. Cross-account GitHub Projects & issues governance, with a sanitized improvement-feedback flow and a private-content guard.",
   "author": { "name": "CSalcedoDataBI" },
   "license": "MIT",

--- a/plugins/agentic-bi-ops/commands/board.md
+++ b/plugins/agentic-bi-ops/commands/board.md
@@ -14,7 +14,9 @@ matching recipe from the projects-admin references:
   name/layout) need one click in settings — do not claim they were set.
 - **add** — add an issue/PR to the board (references/issue-ops.md)
 - **move** — set an item's Status (references/board-ops.md single-select recipe)
-- **field** — create fields / apply a field preset (`apply en|es`) / set Status/Priority/Type values
+- **field** — create fields / apply a field preset (`apply en|es`) / set Status/Priority/Type values /
+  **bulk-fill any custom field across EVERY item by rule** (`scripts/Set-BoardField.ps1` — single-select
+  by title-prefix map, or text by `{title}` template — idempotent, retries 502s)
   (references/field-presets.md + board-ops.md). Visibility-per-view and group-by are UI-only — say so.
 - **bulk** — batch move/close/label across many items (references/issue-ops.md)
 - **automate** — install the actions/add-to-project CI workflow (references/automation.md)

--- a/plugins/agentic-bi-ops/scripts/Set-BoardField.ps1
+++ b/plugins/agentic-bi-ops/scripts/Set-BoardField.ps1
@@ -1,0 +1,89 @@
+<#  Set-BoardField.ps1 — bulk-fill ONE custom field across a board's items by a per-item rule.
+    Generalizes the common "fill every column" chore: set a single-select field by a title-prefix
+    map, or a text field by a {title} template, or a constant for all items. Idempotent, retries
+    transient 5xx (502 Bad Gateway is common at scale), handles single-select vs text automatically.
+
+    Requires $env:GH_TOKEN already set (via the gh-account skill).
+
+    Examples:
+      # Text field by template ({title} -> the item's title):
+      ./Set-BoardField.ps1 -Number 6 -Owner PAL-Devs -Field Ruta -TextTemplate ".claude/skills/{title}/SKILL.md"
+
+      # Single-select by title-prefix map (JSON; "*" = default/fallback):
+      ./Set-BoardField.ps1 -Number 6 -Owner PAL-Devs -Field Categoria `
+        -PrefixMap '{"apps-":"apps","model-":"model","agent-":"agent","etl-":"etl","viz-":"viz","shared-":"shared","speckit-":"framework","*":"vendored"}'
+
+      # Constant single-select for every matching item:
+      ./Set-BoardField.ps1 -Number 6 -Owner PAL-Devs -Field Status -Value Done
+
+    Notes / gotchas baked in:
+      - NEVER name a helper after a PowerShell alias (`cat`=Get-Content, `gc`, `sl`, …) — it shadows
+        your function and silently runs the alias. (This script uses verb-prefixed names only.)
+      - `gh project item-list --format json` exposes custom fields under a lowercased, stripped key
+        (Categoria -> .categoria, "Up to Date" -> .uptodate); used here for idempotent skips.
+      - single-select needs `--single-select-option-id`; text needs `--text`. This script picks the
+        right one from the field's type.
+      - Bulk GraphQL mutations are quoting-fragile in PowerShell; a per-item `item-edit` loop with
+        backoff is slower but reliable.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][int]$Number,
+  [Parameter(Mandatory)][string]$Owner,
+  [Parameter(Mandatory)][string]$Field,           # field DISPLAY name (e.g. Categoria, Ruta, Status)
+  [string]$Value,                                  # constant: single-select option NAME, or text
+  [string]$TextTemplate,                           # text fields: template with {title} placeholder
+  [string]$PrefixMap,                              # single-select: JSON {"prefix-":"OptionName",...,"*":"Default"}
+  [string]$Filter = '^[a-z0-9]+(-[a-z0-9]+)*$',    # only items whose title matches (default: skill-name shape; skips long-titled issues)
+  [int]$Limit = 800,
+  [switch]$Force                                   # re-set even when the current value already matches
+)
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FieldValue([string]$title) {
+  if ($TextTemplate) { return $TextTemplate.Replace('{title}', $title) }
+  if ($Value)        { return $Value }
+  if ($PrefixMap) {
+    $map = $PrefixMap | ConvertFrom-Json
+    foreach ($p in $map.PSObject.Properties) {
+      if ($p.Name -ne '*' -and $title.StartsWith($p.Name)) { return $p.Value }
+    }
+    if ($map.PSObject.Properties.Name -contains '*') { return $map.'*' }
+  }
+  return $null
+}
+
+if (-not $env:GH_TOKEN) { Write-Error "GH_TOKEN not set — run the gh-account skill first."; exit 1 }
+
+$proj   = (gh project view $Number --owner $Owner --format json | ConvertFrom-Json).id
+$fields = (gh project field-list $Number --owner $Owner --format json | ConvertFrom-Json).fields
+$fdef   = $fields | Where-Object { $_.name -eq $Field }
+if (-not $fdef) { Write-Error "Field '$Field' not found on project #$Number (owner $Owner)."; exit 1 }
+$isSelect = [bool]$fdef.options
+$optById  = @{}; if ($isSelect) { foreach ($o in $fdef.options) { $optById[$o.name] = $o.id } }
+$fieldKey = ($Field -replace '[^A-Za-z0-9]','').ToLower()   # how item-list surfaces the value
+
+$items = (gh project item-list $Number --owner $Owner --format json --limit $Limit | ConvertFrom-Json).items
+$set=0; $skip=0; $fail=0
+foreach ($it in $items) {
+  if ($it.title -notmatch $Filter) { $skip++; continue }
+  $val = Resolve-FieldValue $it.title
+  if (-not $val) { $skip++; continue }
+  if (-not $Force -and ($it.$fieldKey -eq $val)) { $skip++; continue }   # idempotent
+
+  $ok = $false
+  for ($i=0; $i -lt 4; $i++) {
+    if ($isSelect) {
+      $oid = $optById[$val]
+      if (-not $oid) { Write-Warning "Field '$Field' has no option named '$val' (item '$($it.title)')"; break }
+      $null = gh project item-edit --project-id $proj --id $it.id --field-id $fdef.id --single-select-option-id $oid 2>&1
+    } else {
+      $null = gh project item-edit --project-id $proj --id $it.id --field-id $fdef.id --text $val 2>&1
+    }
+    if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+    Start-Sleep -Milliseconds (500 * ($i + 1))   # backoff for transient 5xx
+  }
+  if ($ok) { $set++ } else { $fail++; Write-Warning "failed: $($it.title)" }
+}
+Write-Host "Field '$Field' -> set=$set  skipped=$skip  failed=$fail  (of $($items.Count) items)"
+if ($fail -gt 0) { exit 1 }

--- a/plugins/agentic-bi-ops/scripts/Set-BoardField.ps1
+++ b/plugins/agentic-bi-ops/scripts/Set-BoardField.ps1
@@ -86,4 +86,25 @@ foreach ($it in $items) {
   if ($ok) { $set++ } else { $fail++; Write-Warning "failed: $($it.title)" }
 }
 Write-Host "Field '$Field' -> set=$set  skipped=$skip  failed=$fail  (of $($items.Count) items)"
+
+# Post-fill visibility check — the #1 "the tool didn't work" false alarm: the field IS filled but
+# the board's VIEW doesn't display that column, so the user sees blanks. GitHub Projects view
+# columns are UI-only (no GraphQL mutation exists), so no tool can add them — we can only warn.
+try {
+  $vq = 'query{ node(id:"' + $proj + '"){ ... on ProjectV2 { views(first:20){ nodes{ name fields(first:50){ nodes{ ... on ProjectV2FieldCommon { name } } } } } } } }'
+  $views = (gh api graphql -f query=$vq 2>$null | ConvertFrom-Json).data.node.views.nodes
+  $visibleIn = @($views | Where-Object { $_.fields.nodes.name -contains $Field } | ForEach-Object { $_.name })
+  if ($views -and $visibleIn.Count -eq 0) {
+    Write-Warning "'$Field' is FILLED but NOT shown in ANY view ($((@($views).Count)) view(s) checked)."
+    Write-Host   "   -> To SEE it: open the board, click the '+' at the right of the column headers, check '$Field'."
+    Write-Host   "      (GitHub view columns are UI-only — no API/tool can add a column to a view.)"
+  } elseif ($visibleIn.Count) {
+    Write-Host "Visible in view(s): $($visibleIn -join ', ')"
+  }
+} catch { }
+
+# Reminder about un-fillable system columns, so a blank Assignees/Linked PRs/Sub-issues column on
+# DRAFT items is never mistaken for a tool failure.
+Write-Host "Note: GitHub system columns (Assignees, Linked pull requests, Sub-issues progress, Milestone, Repository, Labels) are auto-derived from real issues/PRs — they stay blank for draft cards and cannot be filled by any tool."
+
 if ($fail -gt 0) { exit 1 }

--- a/plugins/agentic-bi-ops/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-bi-ops/skills/projects-admin/SKILL.md
@@ -81,6 +81,7 @@ For the exact commands to create these fields and set their values on items, see
 | Create / list fields (Status, Priority, Target) | `references/board-ops.md` | `gh project field-create`, `gh project field-list` |
 | Apply a whole field preset (EN/ES, custom values) | `references/field-presets.md` | `Apply-FieldPreset.ps1 -Lang en\|es` |
 | Set a field value on an item | `references/board-ops.md` | `gh project item-edit` |
+| Bulk-fill a custom field across ALL items (by rule) | `references/board-ops.md` | `scripts/Set-BoardField.ps1` |
 | Manage views / inspect board | `references/board-ops.md` | `gh project view`, `gh project item-list` |
 | Create an issue with a label | `references/issue-ops.md` | `gh issue create` |
 | Create / ensure a label exists | `references/issue-ops.md` | `gh label create --force` |

--- a/plugins/agentic-bi-ops/skills/projects-admin/references/board-ops.md
+++ b/plugins/agentic-bi-ops/skills/projects-admin/references/board-ops.md
@@ -178,6 +178,14 @@ long-titled tracking issues are skipped; pass your own to widen/narrow the set.
 - **Don't batch via GraphQL in PowerShell** unless you must: escaping the inner `"` of
   `updateProjectV2ItemFieldValue(input:{… value:{singleSelectOptionId:"…"}})` is error-prone
   (`\"` ≠ ``` `" ```). A per-item `item-edit` loop is slower but reliable.
+- **Filled ≠ visible (the #1 "the tool failed" false alarm).** A field you fill only appears if the
+  board's **view** includes that column — and **view columns are UI-only** (there is NO GraphQL
+  mutation to add/remove a view's columns, so no tool can do it). If a just-filled column still looks
+  blank, the value is there — add the column in the UI: board → the `+` at the right of the column
+  headers → check the field. `Set-BoardField.ps1` detects this and warns when the field is in no view.
+- **Auto-derived system columns can't be filled at all.** `Assignees`, `Linked pull requests`,
+  `Sub-issues progress`, `Milestone`, `Repository`, `Labels` come from real issues/PRs; on **draft
+  items** they are permanently blank. A blank there is not a fill failure — it's not a data field.
 
 ---
 

--- a/plugins/agentic-bi-ops/skills/projects-admin/references/board-ops.md
+++ b/plugins/agentic-bi-ops/skills/projects-admin/references/board-ops.md
@@ -142,6 +142,45 @@ All four flags are required. `--project-id` is the node ID (`PVT_…`) from Step
 
 ---
 
+## Bulk-fill a custom field across EVERY item (by rule)
+
+The "fill all the columns" chore: set one field on every item from a per-item rule — a single-select
+by title prefix (e.g. `Categoria`), or a text field by template (e.g. `Ruta` =
+`.claude/skills/{name}/SKILL.md`). Use the helper script — it is idempotent, retries transient 502s,
+and picks single-select vs text automatically:
+
+```powershell
+# single-select by title-prefix map ("*" = fallback):
+& "<plugin>/scripts/Set-BoardField.ps1" -Number 6 -Owner PAL-Devs -Field Categoria `
+  -PrefixMap '{"apps-":"apps","model-":"model","agent-":"agent","etl-":"etl","viz-":"viz","shared-":"shared","speckit-":"framework","*":"vendored"}'
+
+# text field by template ({title} -> the item's title):
+& "<plugin>/scripts/Set-BoardField.ps1" -Number 6 -Owner PAL-Devs -Field Ruta -TextTemplate ".claude/skills/{title}/SKILL.md"
+
+# constant for all matching items:
+& "<plugin>/scripts/Set-BoardField.ps1" -Number 6 -Owner PAL-Devs -Field Status -Value Done
+```
+
+`-Filter` (regex on the item title) defaults to the skill-name shape `^[a-z0-9]+(-[a-z0-9]+)*$`, so
+long-titled tracking issues are skipped; pass your own to widen/narrow the set.
+
+### Gotchas (why a manual loop bites)
+- **`cat` is an alias for `Get-Content`** (also `gc`, `sl`, `gi`, …). Naming a helper `Cat`/`function Cat`
+  silently runs the alias instead — aliases outrank functions in PowerShell command resolution. Use
+  verb-prefixed names (`Resolve-FieldValue`).
+- **single-select vs text:** single-select needs `--single-select-option-id <id>`; a text/number field
+  needs `--text`/`--number`. Sending `--text` to a single-select (or vice-versa) silently no-ops.
+- **Idempotency:** `gh project item-list --format json` surfaces each custom field under a *lowercased,
+  stripped* key (`Categoria`→`.categoria`, `Up to Date`→`.uptodate`). Compare against it to skip
+  already-set items.
+- **Transient 502 Bad Gateway** is common when editing 100+ items back-to-back — retry with backoff
+  (the script does 4 tries). Don't treat one 502 as failure.
+- **Don't batch via GraphQL in PowerShell** unless you must: escaping the inner `"` of
+  `updateProjectV2ItemFieldValue(input:{… value:{singleSelectOptionId:"…"}})` is error-prone
+  (`\"` ≠ ``` `" ```). A per-item `item-edit` loop is slower but reliable.
+
+---
+
 ## Delete a board (BACKUP FIRST — always)
 
 ```bash


### PR DESCRIPTION
## What
New `/board field` capability: **bulk-fill any custom field across every board item by a per-item rule** — via `scripts/Set-BoardField.ps1`.

- **single-select by title-prefix map** (e.g. `Categoria`: `apps-*`→apps, `model-*`→model, `*`→vendored)
- **text by `{title}` template** (e.g. `Ruta` = `.claude/skills/{title}/SKILL.md`)
- **constant** for all items (e.g. `Status`=Done)

Idempotent, retries transient 502s, auto-detects single-select vs text, `-Filter` regex to scope items.

## Why
The "fill all the columns" chore was a manual `gh project item-edit` loop that bites on real gotchas — now documented + scripted:
- `cat` is an alias for `Get-Content` (and `gc`/`sl`/…) → naming a helper `Cat` silently runs the alias (aliases outrank functions).
- single-select needs `--single-select-option-id`; text needs `--text` (mismatched flag silently no-ops).
- `gh project item-list --format json` exposes custom fields under a lowercased/stripped key (`Categoria`→`.categoria`) — used for idempotent skips.
- 502 Bad Gateway is common editing 100+ items → retry with backoff.
- GraphQL-batch mutations are quoting-fragile in PowerShell (`\"` ≠ `` `" ``).

## Validated
Ran end-to-end against a real 124-item board (idempotent: set=0 skipped=124 failed=0 on a re-run).

## Files
- `scripts/Set-BoardField.ps1` (new), `references/board-ops.md` (recipe + gotchas), `commands/board.md` + `projects-admin/SKILL.md` (routing), `plugin.json` 0.6.2→0.7.0, CHANGELOG.
