### PR TITLE
skills-bootstrap: detect gaps and install best-practice skills without duplicating

### DIFF
--- a/plugins/agentic-bi-ops/presets/recommended-skills.json
+++ b/plugins/agentic-bi-ops/presets/recommended-skills.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "skill-creator",
+    "repo": "anthropics/skills",
+    "path": "skill-creator",
+    "license": "See repo (Anthropic)",
+    "purpose": "Create, test, benchmark and optimize skills; description-triggering eval loop."
+  },
+  {
+    "name": "writing-skills",
+    "repo": "obra/superpowers",
+    "path": "skills/writing-skills",
+    "license": "MIT",
+    "purpose": "Author high-quality SKILL.md — discovery optimization, RED/GREEN pressure tests."
+  },
+  {
+    "name": "skill-improver",
+    "repo": "trailofbits/skills",
+    "path": "skill-improver",
+    "license": "CC BY-SA 4.0",
+    "purpose": "Iterative fix-review loop to raise an existing skill to standard."
+  },
+  {
+    "name": "second-opinion",
+    "repo": "trailofbits/skills",
+    "path": "second-opinion",
+    "license": "CC BY-SA 4.0",
+    "purpose": "External LLM review (Codex/Gemini) of uncommitted changes — an extra reviewer."
+  }
+]

--- a/plugins/agentic-bi-ops/scripts/Get-SkillGaps.ps1
+++ b/plugins/agentic-bi-ops/scripts/Get-SkillGaps.ps1
@@ -1,0 +1,46 @@
+<#  Get-SkillGaps.ps1 — which recommended best-practice skills are missing?
+
+    Reads the curated catalog (presets/recommended-skills.json), compares it against the
+    skills actually installed (any scope, matched by name), and reports installed vs gaps.
+    It NEVER installs anything and never duplicates — install is the agentic step the
+    SKILL.md drives (git clone + copy + preserve license). Detection is deterministic.
+
+    -InstalledNames overrides the detected install set (used by tests; defaults to the
+    live inventory across all scopes).
+
+    EXAMPLES
+      .\Get-SkillGaps.ps1
+      .\Get-SkillGaps.ps1 -Json
+#>
+[CmdletBinding()]
+param(
+    [string]$CatalogPath = (Join-Path $PSScriptRoot '..' 'presets' 'recommended-skills.json'),
+    [string[]]$InstalledNames,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $CatalogPath)) { throw "Catalog not found: $CatalogPath" }
+$catalog = Get-Content -LiteralPath $CatalogPath -Raw | ConvertFrom-Json
+
+if (-not $PSBoundParameters.ContainsKey('InstalledNames')) {
+    $engine = Join-Path $PSScriptRoot 'Get-SkillInventory.ps1'
+    $InstalledNames = (& $engine -Scope all).skills.name
+}
+$have = @{}
+foreach ($n in $InstalledNames) { if ($n) { $have[$n.ToLower()] = $true } }
+
+$installed = [System.Collections.Generic.List[object]]::new()
+$gaps      = [System.Collections.Generic.List[object]]::new()
+foreach ($c in $catalog) {
+    if ($have.ContainsKey($c.name.ToLower())) { $installed.Add($c) } else { $gaps.Add($c) }
+}
+
+$result = [pscustomobject]@{
+    summary   = [pscustomobject]@{ recommended = @($catalog).Count; installed = $installed.Count; gaps = $gaps.Count }
+    installed = $installed
+    gaps      = $gaps
+}
+
+if ($Json) { $result | ConvertTo-Json -Depth 5 } else { $result }

--- a/plugins/agentic-bi-ops/scripts/Install-SkillFromRepo.ps1
+++ b/plugins/agentic-bi-ops/scripts/Install-SkillFromRepo.ps1
@@ -1,0 +1,57 @@
+<#  Install-SkillFromRepo.ps1 — clean-clone a single skill from a GitHub repo.
+
+    Shallow-clones the source repo to a temp dir, copies ONLY the requested skill folder
+    into the personal skills dir (~/.claude/skills/<name>), preserves the source LICENSE
+    next to it (required for CC BY-SA and friends), and deletes the temp clone. Idempotent:
+    refuses to overwrite an existing skill unless -Force.
+
+    This is the install half of skills-bootstrap. Pair it with Get-SkillGaps.ps1 (which
+    decides WHAT is missing) — never install something already present (no duplicates).
+
+    EXAMPLE
+      .\Install-SkillFromRepo.ps1 -Repo trailofbits/skills -Path skill-improver -Name skill-improver
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Repo,
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$Name,
+    [string]$Dest,
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $Dest) {
+    $userHome = $env:USERPROFILE; if (-not $userHome) { $userHome = $HOME }
+    $Dest = Join-Path $userHome '.claude/skills'
+}
+$target = Join-Path $Dest $Name
+if ((Test-Path $target) -and -not $Force) {
+    Write-Host "  SKIP  $Name already installed at $target (use -Force to overwrite)." -ForegroundColor DarkYellow
+    return [pscustomobject]@{ name=$Name; installed=$false; reason='already-present'; path=$target }
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("skillclone-" + [guid]::NewGuid().ToString('N'))
+try {
+    Write-Host "  Cloning $Repo (depth 1)..." -ForegroundColor Cyan
+    git clone --depth 1 "https://github.com/$Repo.git" $tmp 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "git clone failed for $Repo" }
+
+    $src = Join-Path $tmp $Path
+    if (-not (Test-Path $src)) { throw "Skill path '$Path' not found in $Repo." }
+
+    if (Test-Path $target) { Remove-Item $target -Recurse -Force }
+    New-Item -ItemType Directory -Path $target -Force | Out-Null
+    Copy-Item (Join-Path $src '*') $target -Recurse -Force
+
+    # Preserve attribution: copy the repo LICENSE if the skill folder lacks one.
+    if (-not (Get-ChildItem $target -Filter 'LICENSE*' -ErrorAction SilentlyContinue)) {
+        $lic = Get-ChildItem $tmp -Filter 'LICENSE*' -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($lic) { Copy-Item $lic.FullName (Join-Path $target 'LICENSE') -Force }
+    }
+    Write-Host "  OK  installed $Name -> $target" -ForegroundColor Green
+    [pscustomobject]@{ name=$Name; installed=$true; source="$Repo/$Path"; path=$target }
+}
+finally {
+    if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue }
+}

--- a/plugins/agentic-bi-ops/skills/skills-bootstrap/SKILL.md
+++ b/plugins/agentic-bi-ops/skills/skills-bootstrap/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: skills-bootstrap
+description: Use to install curated best-practice skills for authoring and evaluating skills (skill-creator, writing-skills, skill-improver, second-opinion) WITHOUT duplicating what is already installed. Detects the gap against the live inventory, recommends only what is missing, and clean-clones each from its source repo into ~/.claude/skills preserving the LICENSE/attribution. Use when setting up a machine for skill development, or when you want the recommended skill-quality toolkit. NOT for organizing or auditing existing skills — use skills-organize or skills-audit for that. Triggers — "instala las skills de buenas prácticas", "bootstrap skills", "qué skills de calidad me faltan", "setup skill toolkit", /skills bootstrap.
+---
+
+# skills-bootstrap — the recommended skill toolkit, no duplicates
+
+Part of the **skills-ops** module. Detects gaps, then installs only what is missing —
+never re-installing a skill you already have (in any scope).
+
+## Step 1 — Detect the gap (deterministic)
+
+```powershell
+$g = & "${CLAUDE_PLUGIN_ROOT}/scripts/Get-SkillGaps.ps1"
+$g.summary
+"Installed:"; $g.installed | Select-Object name,purpose | Format-Table
+"Gaps:";      $g.gaps      | Select-Object name,repo,license,purpose | Format-Table
+```
+
+The catalog is `presets/recommended-skills.json`. A recommended skill counts as installed
+if its `name` appears anywhere in the inventory (plugin / personal / project) — so
+`anthropic-skills:skill-creator` already covers `skill-creator`, and nothing is duplicated.
+
+## Step 2 — Install only the gaps (clean clone, license preserved)
+
+For each gap, confirm with the user, then:
+
+```powershell
+& "${CLAUDE_PLUGIN_ROOT}/scripts/Install-SkillFromRepo.ps1" `
+    -Repo <owner/name> -Path <subpath> -Name <skill-name>
+```
+
+It shallow-clones to a temp dir, copies only that skill folder into `~/.claude/skills/<name>`,
+copies the source `LICENSE` next to it (mandatory for CC BY-SA sources), and cleans up. It
+**skips** an already-present skill unless `-Force`.
+
+## Step 3 — Verify
+
+Re-run `Get-SkillGaps.ps1` — `summary.gaps` should drop. Restart the session so the new
+skills' descriptions load. Report what was installed, from where, and under which license.
+
+## Rules
+- Never install a skill that already exists in any scope (Step 1 enforces this).
+- Always preserve the upstream LICENSE/attribution — especially CC BY-SA.
+- General-purpose skills go to the global `~/.claude/skills/`; project-specific ones go to the
+  repo's `.claude/skills/` instead.

--- a/plugins/agentic-bi-ops/tests/Get-SkillGaps.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Get-SkillGaps.Tests.ps1
@@ -1,0 +1,29 @@
+#Requires -Modules Pester
+<#  Pester tests for Get-SkillGaps.ps1 — gap detection against an injected install set. #>
+
+BeforeAll {
+    $script:Gaps = Join-Path $PSScriptRoot '..' 'scripts' 'Get-SkillGaps.ps1' | Resolve-Path
+    $script:Catalog = Join-Path $PSScriptRoot '..' 'presets' 'recommended-skills.json' | Resolve-Path
+}
+
+Describe 'Get-SkillGaps' {
+    It 'reports every recommended skill as a gap when none are installed' {
+        $r = & $script:Gaps -InstalledNames @() -CatalogPath $script:Catalog
+        $r.summary.installed | Should -Be 0
+        $r.summary.gaps | Should -Be $r.summary.recommended
+    }
+    It 'detects an installed skill by name (case-insensitive) and never lists it as a gap' {
+        $r = & $script:Gaps -InstalledNames @('Skill-Creator') -CatalogPath $script:Catalog
+        $r.installed.name | Should -Contain 'skill-creator'
+        $r.gaps.name | Should -Not -Contain 'skill-creator'
+    }
+    It 'counts installed + gaps to the full catalog (no double-count, no duplicates)' {
+        $r = & $script:Gaps -InstalledNames @('writing-skills','second-opinion') -CatalogPath $script:Catalog
+        ($r.summary.installed + $r.summary.gaps) | Should -Be $r.summary.recommended
+        $r.summary.installed | Should -Be 2
+    }
+    It 'produces valid JSON' {
+        $json = & $script:Gaps -InstalledNames @() -CatalogPath $script:Catalog -Json
+        { $json | ConvertFrom-Json } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
Adds the `skills-bootstrap` skill: detect which recommended best-practice skills
(skill-creator, writing-skills, skill-improver, second-opinion) are missing vs the
live inventory, and install only the gaps via a clean shallow clone that preserves
the source LICENSE. Never duplicates an already-installed skill. 4 Pester tests.

Closes #93