### PR TITLE
fix(work): make the chosen launch credential authoritative (auth precedence)

### DIFF
--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -616,6 +616,16 @@ function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefi
     }
 }
 
+# Pick which Windows USER env var each spawned session authenticates with. Pure ->
+# testable. An EXPLICIT -ClaudeAuthVar always wins; otherwise prefer the subscription
+# OAuth token (CLAUDE_CODE_OAUTH_TOKEN, billed to the plan) when it is present, else
+# fall back to the given default (ANTHROPIC_API_KEY, per-token console billing).
+function Resolve-ClaudeAuthVar([bool]$explicit, [string]$chosen, [bool]$oauthTokenPresent) {
+    if ($explicit) { return $chosen }
+    if ($oauthTokenPresent) { return 'CLAUDE_CODE_OAUTH_TOKEN' }
+    return $chosen
+}
+
 # Spawn (or -Preview) ONE visible Claude session for a started worktree.
 function Start-WorktreeSession {
     param(
@@ -966,11 +976,10 @@ if ($Parallel.Count -gt 0) {
     if ($Launch) {
         Write-Host ""
         # Auto-prefer the subscription OAuth token when the caller did not pick an
-        # auth var explicitly: CLAUDE_CODE_OAUTH_TOKEN (billed to the Claude plan) is
-        # cheaper than the per-token ANTHROPIC_API_KEY, so use it when it is present.
-        if (-not $PSBoundParameters.ContainsKey('ClaudeAuthVar') -and
-            [System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN', 'User')) {
-            $ClaudeAuthVar = 'CLAUDE_CODE_OAUTH_TOKEN'
+        # auth var explicitly (see Resolve-ClaudeAuthVar).
+        $oauthPresent  = [bool][System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN', 'User')
+        $ClaudeAuthVar = Resolve-ClaudeAuthVar $PSBoundParameters.ContainsKey('ClaudeAuthVar') $ClaudeAuthVar $oauthPresent
+        if ($ClaudeAuthVar -eq 'CLAUDE_CODE_OAUTH_TOKEN') {
             Write-Host "  Auth: usando CLAUDE_CODE_OAUTH_TOKEN (suscripcion)." -ForegroundColor DarkGray
         }
         if ($DryRun) {

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -586,12 +586,16 @@ function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefi
     # to CLAUDE_CODE_OAUTH_TOKEN to bill the subscription instead). Only the var NAME
     # touches the command line - the secret never does. Re-reading from the registry
     # also RESTORES the value even when the launching context (Desktop) has stripped
-    # it. We drop the inherited CLAUDE_CODE_* session markers so the child starts as
-    # a clean top-level session.
+    # it. We FIRST clear every competing Anthropic credential so the chosen one is
+    # authoritative regardless of auth precedence - ANTHROPIC_API_KEY outranks
+    # CLAUDE_CODE_OAUTH_TOKEN, so an inherited API key would otherwise silently
+    # override a subscription token (or 401 if stale). We also drop the inherited
+    # CLAUDE_CODE_* session markers so the child starts as a clean top-level session.
     # Double any single quote so a repo path containing ' (valid on Windows, e.g. an
     # O'Brien user folder) can't break out of the literal or inject into -Command.
-    $safeBrief = $briefingFile -replace "'", "''"
-    $auth  = '$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User''); ' -f $claudeAuthVar
+    $safeBrief  = $briefingFile -replace "'", "''"
+    $clearAuth  = 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue; '
+    $auth  = $clearAuth + ('$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User''); ' -f $claudeAuthVar)
     $clean = 'Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue; '
     $run   = 'claude -p (Get-Content -Raw -LiteralPath ''{0}'') --permission-mode bypassPermissions --no-session-persistence --verbose' -f $safeBrief
     $claudeCmd = $auth + $clean + $run
@@ -961,12 +965,20 @@ if ($Parallel.Count -gt 0) {
     # -- Launch: one visible Claude session per worktree (-Launch) --------------
     if ($Launch) {
         Write-Host ""
+        # Auto-prefer the subscription OAuth token when the caller did not pick an
+        # auth var explicitly: CLAUDE_CODE_OAUTH_TOKEN (billed to the Claude plan) is
+        # cheaper than the per-token ANTHROPIC_API_KEY, so use it when it is present.
+        if (-not $PSBoundParameters.ContainsKey('ClaudeAuthVar') -and
+            [System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN', 'User')) {
+            $ClaudeAuthVar = 'CLAUDE_CODE_OAUTH_TOKEN'
+            Write-Host "  Auth: usando CLAUDE_CODE_OAUTH_TOKEN (suscripcion)." -ForegroundColor DarkGray
+        }
         if ($DryRun) {
             Write-Host "----- LAUNCH (preview, -DryRun no lanza nada) -----" -ForegroundColor Cyan
             foreach ($r in $planned) {
                 $repoName    = ($r.repo -split '/')[1]
                 $previewPath = Join-Path (Split-Path (Get-Location) -Parent) "$repoName--issue-$($r.issue)"
-                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -Preview | Out-Null
+                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -ClaudeAuthVar $ClaudeAuthVar -Preview | Out-Null
             }
         } else {
             Write-Host "----- LANZANDO SESIONES CLAUDE -----" -ForegroundColor Cyan

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -146,6 +146,18 @@ Describe 'Build-WorktreeLaunch' {
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
         ($p.args -join ' ') | Should -Match '\$env:ANTHROPIC_API_KEY='
     }
+    It 'clears competing Anthropic credentials so the chosen one is authoritative' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
+        # with CLAUDE_CODE_OAUTH_TOKEN chosen, the inherited ANTHROPIC_API_KEY must be cleared
+        # first (it outranks the OAuth token in auth precedence) or it would win silently.
+        $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'CLAUDE_CODE_OAUTH_TOKEN'
+        $joined = ($p.args -join ' ')
+        $joined | Should -Match 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN'
+        # ...and the clear happens BEFORE the chosen credential is set
+        $clearIdx = $joined.IndexOf('Remove-Item Env:ANTHROPIC_API_KEY')
+        $setIdx   = $joined.IndexOf('$env:CLAUDE_CODE_OAUTH_TOKEN=')
+        $clearIdx | Should -BeLessThan $setIdx
+    }
     It 'rejects an auth-var name that could inject into the spawned command' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         { Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt' 'abios-parallel' "X'); rm -rf /; #" } | Should -Throw

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -101,6 +101,18 @@ Describe 'Get-SessionBriefing' {
     }
 }
 
+Describe 'Resolve-ClaudeAuthVar' {
+    It 'honors an explicit -ClaudeAuthVar even when the OAuth token exists' {
+        Resolve-ClaudeAuthVar $true 'ANTHROPIC_API_KEY' $true | Should -Be 'ANTHROPIC_API_KEY'
+    }
+    It 'auto-prefers the subscription OAuth token when not explicit and it is present' {
+        Resolve-ClaudeAuthVar $false 'ANTHROPIC_API_KEY' $true | Should -Be 'CLAUDE_CODE_OAUTH_TOKEN'
+    }
+    It 'falls back to the default when not explicit and no OAuth token' {
+        Resolve-ClaudeAuthVar $false 'ANTHROPIC_API_KEY' $false | Should -Be 'ANTHROPIC_API_KEY'
+    }
+}
+
 Describe 'Build-WorktreeLaunch' {
     It 'builds a Windows Terminal tab command when wt is present' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }


### PR DESCRIPTION
Follow-up to #125. Makes the subscription-token path actually work.

`ANTHROPIC_API_KEY` outranks `CLAUDE_CODE_OAUTH_TOKEN` in auth precedence, so choosing `-ClaudeAuthVar CLAUDE_CODE_OAUTH_TOKEN` alone was silently overridden by the inherited API key. Now the launcher clears every competing Anthropic credential before setting the chosen one, and auto-prefers `CLAUDE_CODE_OAUTH_TOKEN` (subscription billing) when present. 29 Pester tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)