### PR TITLE
fix(work): parallel -Launch opened 8 tabs and mis-parsed comma issue lists

### DIFF
--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -113,7 +113,11 @@ param(
     [string]$Repo     = "",
     [int]   $ProjectNum = 0,
     [int]   $Start      = 0,
-    [int[]] $Parallel   = @(),
+    # Accept as strings, not [int[]]: when the script is invoked via `pwsh -File`,
+    # `-Parallel 129,130` arrives as the single string "129,130" (comma read as a
+    # thousands separator -> 129130), NOT a 2-element array. Get-ParallelQueue
+    # splits each token on ',' so both `-File` and native-array calls work.
+    [string[]] $Parallel = @(),
     [switch]$Launch,
     [switch]$Sessions,
     [int]   $ToReview   = 0,
@@ -227,11 +231,22 @@ function Get-IssueSlugBranch([int]$num, [string]$title) {
     return "issue-$num-$slug"
 }
 
-# Normalize a -Parallel request into the batch queue: drop non-positive numbers and
-# de-duplicate while preserving the requested order. Pure -> unit-testable.
-function Get-ParallelQueue([int[]]$nums) {
+# Normalize a -Parallel request into the batch queue: split comma-separated tokens
+# (so `pwsh -File ... -Parallel 129,130` -> "129,130" splits into 129 and 130),
+# drop non-positive/non-numeric values, and de-duplicate while preserving the
+# requested order. Pure -> unit-testable.
+function Get-ParallelQueue([string[]]$nums) {
     $queue = @()
-    foreach ($n in $nums) { if ($n -gt 0 -and $queue -notcontains $n) { $queue += $n } }
+    foreach ($tok in $nums) {
+        if ($null -eq $tok) { continue }
+        foreach ($part in ($tok -split ',')) {
+            $part = $part.Trim()
+            if ($part -eq '') { continue }
+            $n = 0
+            if (-not [int]::TryParse($part, [ref]$n)) { continue }
+            if ($n -gt 0 -and $queue -notcontains $n) { $queue += $n }
+        }
+    }
     # No unary-comma wrap: it would turn an empty queue into a 1-element array
     # (an array holding @()). Callers wrap with @() to normalize the single case.
     return $queue
@@ -558,13 +573,22 @@ function Get-SessionBriefing([int]$issueNum, [string]$repo, [string]$branch, [st
 }
 
 # Build the exact launch command for a worktree session. Returns an object
-# { launcher, args, briefingFile } WITHOUT spawning - pure enough to unit-test
-# and to preview under -DryRun. Windows Terminal tab when 'wt' exists (grouped in
-# a named window), else a standalone pwsh window. The briefing is passed via a
-# file (written by the caller) so no long/quoted text ever hits the command line.
+# { launcher, args, briefingFile, launchScriptFile, launchScript } WITHOUT spawning -
+# pure enough to unit-test and to preview under -DryRun. Windows Terminal tab when
+# 'wt' exists (grouped in a named window), else a standalone pwsh window.
+#
+# CRITICAL - why the setup runs from a .ps1 FILE, not an inline `-Command`:
+# Windows Terminal's `wt` command line uses ';' as its OWN sub-command separator
+# (new-tab ; split-pane ; ...). A `pwsh -Command "a; b; c"` passed to `wt` therefore
+# had its ';' eaten by wt, which split ONE intended tab into FOUR (one per segment) -
+# 2 issues -> 8 stray tabs, and the real `claude -p` landed in a bare tab with no
+# auth setup, so no session actually worked its issue. Writing the setup+run to
+# launch-<issue>.ps1 and launching `pwsh -NoExit -File <script>` puts ZERO ';' on
+# wt's command line, so wt opens exactly one tab. The briefing is likewise passed by
+# file so no long/quoted text ever hits the command line.
 function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefingFile, [string]$windowName = "abios-parallel", [string]$claudeAuthVar = "ANTHROPIC_API_KEY") {
     $tabTitle  = "issue-$issueNum"
-    # Defense-in-depth: this name is interpolated into the spawned -Command string,
+    # Defense-in-depth: this name is interpolated into the spawned launch script,
     # so it MUST be a bare env-var identifier - never let ';'/quotes/spaces through.
     if ($claudeAuthVar -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
         throw "ClaudeAuthVar '$claudeAuthVar' is not a valid environment variable name."
@@ -594,25 +618,34 @@ function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefi
     # Double any single quote so a repo path containing ' (valid on Windows, e.g. an
     # O'Brien user folder) can't break out of the literal or inject into -Command.
     $safeBrief  = $briefingFile -replace "'", "''"
-    $clearAuth  = 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue; '
-    $auth  = $clearAuth + ('$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User''); ' -f $claudeAuthVar)
-    $clean = 'Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue; '
-    $run   = 'claude -p (Get-Content -Raw -LiteralPath ''{0}'') --permission-mode bypassPermissions --no-session-persistence --verbose' -f $safeBrief
-    $claudeCmd = $auth + $clean + $run
+    # Each step on its OWN line (a .ps1 file), so no ';' is ever needed - which is the
+    # whole point: ';' on wt's command line would split the tab (see the header note).
+    $clearAuth  = 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue'
+    $setAuth    = '$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User'')' -f $claudeAuthVar
+    $clean      = 'Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue'
+    $run        = 'claude -p (Get-Content -Raw -LiteralPath ''{0}'') --permission-mode bypassPermissions --no-session-persistence --verbose' -f $safeBrief
+    $launchScript = ($clearAuth, $setAuth, $clean, $run) -join "`r`n"
+    # The launch script lives next to the briefing (same dir the caller chose).
+    $launchScriptFile = Join-Path (Split-Path -Parent $briefingFile) "launch-$issueNum.ps1"
+    $safeScriptPath   = $launchScriptFile   # a plain path arg (its own arg element -> Start-Process quotes it)
     if (Get-Command wt -ErrorAction SilentlyContinue) {
         return [PSCustomObject]@{
-            launcher     = "wt"
-            args         = @('-w', $windowName, 'new-tab', '--title', $tabTitle,
-                             '--startingDirectory', $workPath, 'pwsh', '-NoExit', '-Command', $claudeCmd)
-            briefingFile = $briefingFile
-            usesWt       = $true
+            launcher         = "wt"
+            args             = @('-w', $windowName, 'new-tab', '--title', $tabTitle,
+                                 '--startingDirectory', $workPath, 'pwsh', '-NoExit', '-File', $safeScriptPath)
+            briefingFile     = $briefingFile
+            launchScriptFile = $launchScriptFile
+            launchScript     = $launchScript
+            usesWt           = $true
         }
     }
     return [PSCustomObject]@{
-        launcher     = "pwsh"
-        args         = @('-NoExit', '-Command', $claudeCmd)
-        briefingFile = $briefingFile
-        usesWt       = $false
+        launcher         = "pwsh"
+        args             = @('-NoExit', '-File', $safeScriptPath)
+        briefingFile     = $briefingFile
+        launchScriptFile = $launchScriptFile
+        launchScript     = $launchScript
+        usesWt           = $false
     }
 }
 
@@ -639,6 +672,8 @@ function Start-WorktreeSession {
 
     if ($Preview) {
         Write-Host ("  [preview] #{0}: {1} {2}" -f $IssueNum, $plan.launcher, ($plan.args -join ' ')) -ForegroundColor Gray
+        Write-Host ("  [preview] #{0} launch script ({1}):" -f $IssueNum, $plan.launchScriptFile) -ForegroundColor DarkGray
+        foreach ($ln in ($plan.launchScript -split "`r?`n")) { Write-Host ("             $ln") -ForegroundColor DarkGray }
         return $plan
     }
 
@@ -648,6 +683,9 @@ function Start-WorktreeSession {
     }
     # Persist the briefing so the spawned session reads it without command-line quoting.
     Set-Content -LiteralPath $briefingFile -Value (Get-SessionBriefing $IssueNum $Repo $Branch $WorkPath) -Encoding UTF8
+    # Persist the launch script so wt/pwsh runs it via -File (no ';' on wt's command
+    # line -> no stray tab-splitting). See Build-WorktreeLaunch header for the why.
+    Set-Content -LiteralPath $plan.launchScriptFile -Value $plan.launchScript -Encoding UTF8
     $proc = $null
     try {
         if ($plan.usesWt) { $proc = Start-Process $plan.launcher -ArgumentList $plan.args -PassThru }

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -615,8 +615,9 @@ function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefi
     # CLAUDE_CODE_OAUTH_TOKEN, so an inherited API key would otherwise silently
     # override a subscription token (or 401 if stale). We also drop the inherited
     # CLAUDE_CODE_* session markers so the child starts as a clean top-level session.
-    # Double any single quote so a repo path containing ' (valid on Windows, e.g. an
-    # O'Brien user folder) can't break out of the literal or inject into -Command.
+    # Double any single quote so a briefing path containing ' (valid on Windows, e.g. an
+    # O'Brien user folder) can't break out of the single-quoted literal it is embedded in
+    # inside the generated launch script (the Get-Content -LiteralPath '...' arg below).
     $safeBrief  = $briefingFile -replace "'", "''"
     # Each step on its OWN line (a .ps1 file), so no ';' is ever needed - which is the
     # whole point: ';' on wt's command line would split the tab (see the header note).

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -61,6 +61,15 @@ Describe 'Get-ParallelQueue (batch parsing)' {
     It 'returns an empty array for an empty input' {
         @(Get-ParallelQueue @()).Count | Should -Be 0
     }
+    It 'splits a single comma-joined string (the `pwsh -File` case: "129,130" not @(129,130))' {
+        (Get-ParallelQueue '129,130') | Should -Be @(129,130)
+    }
+    It 'splits comma tokens and trims whitespace' {
+        (Get-ParallelQueue '129, 130 ,131') | Should -Be @(129,130,131)
+    }
+    It 'drops non-numeric junk tokens' {
+        (Get-ParallelQueue 'abc,12x,7') | Should -Be @(7)
+    }
 }
 
 Describe 'Get-IssueSlugBranch (branch naming)' {
@@ -122,7 +131,24 @@ Describe 'Build-WorktreeLaunch' {
         $p.args     | Should -Contain 'new-tab'
         $p.args     | Should -Contain '--startingDirectory'
         $p.args     | Should -Contain 'C:\wt'
-        ($p.args -join ' ') | Should -Match 'briefingFile|brief\.txt|Get-Content'
+    }
+    It 'launches via a -File script, never an inline -Command (so wt cannot split the tab)' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
+        $p.args | Should -Contain '-File'
+        $p.args | Should -Not -Contain '-Command'
+        $p.args | Should -Contain $p.launchScriptFile
+    }
+    It 'REGRESSION: puts no semicolon on the wt command line (a ; there splits one tab into many)' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
+        ($p.args -join ' ') | Should -Not -Match ';'
+    }
+    It 'names the launch script per issue, alongside the briefing' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
+        $p = Build-WorktreeLaunch 12 'C:\abios\brief.txt' 'C:\brief.txt'
+        # launchScriptFile sits in the briefing's directory, keyed by issue number
+        $p.launchScriptFile | Should -Match 'launch-12\.ps1$'
     }
     It 'falls back to a pwsh window when wt is absent' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
@@ -130,44 +156,43 @@ Describe 'Build-WorktreeLaunch' {
         $p.launcher | Should -Be 'pwsh'
         $p.usesWt   | Should -BeFalse
         $p.args     | Should -Contain '-NoExit'
+        $p.args     | Should -Contain '-File'
     }
     It 'passes the briefing by file, never inline' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
-        ($p.args -join ' ') | Should -Match 'brief\.txt'
+        $p.launchScript | Should -Match 'brief\.txt'
     }
     It 'runs the spawned session unattended headless (no interactive prompt can stall it)' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
-        $joined = ($p.args -join ' ')
-        $joined | Should -Match 'claude -p '                          # headless: skips trust + bypass-accept prompts
-        $joined | Should -Match '--permission-mode bypassPermissions' # no per-tool approval stalls
-        $joined | Should -Match '--no-session-persistence'            # parallel sessions don't collide
+        $p.launchScript | Should -Match 'claude -p '                          # headless: skips trust + bypass-accept prompts
+        $p.launchScript | Should -Match '--permission-mode bypassPermissions' # no per-tool approval stalls
+        $p.launchScript | Should -Match '--no-session-persistence'            # parallel sessions don't collide
     }
     It 'injects the child auth credential by env-var NAME (secret never on the command line)' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'MY_AUTH_VAR'
-        $joined = ($p.args -join ' ')
         # same-name injection: $env:MY_AUTH_VAR = [Environment]::GetEnvironmentVariable('MY_AUTH_VAR','User')
-        $joined | Should -Match '\$env:MY_AUTH_VAR='                       # sets the child's credential
-        $joined | Should -Match "GetEnvironmentVariable\('MY_AUTH_VAR','User'"  # read at runtime, by NAME, from registry
-        $joined | Should -Match 'Remove-Item Env:CLAUDECODE'              # drop inherited host session markers
+        $p.launchScript | Should -Match '\$env:MY_AUTH_VAR='                       # sets the child's credential
+        $p.launchScript | Should -Match "GetEnvironmentVariable\('MY_AUTH_VAR','User'"  # read at runtime, by NAME, from registry
+        $p.launchScript | Should -Match 'Remove-Item Env:CLAUDECODE'              # drop inherited host session markers
     }
     It 'defaults the auth credential to ANTHROPIC_API_KEY' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
-        ($p.args -join ' ') | Should -Match '\$env:ANTHROPIC_API_KEY='
+        $p.launchScript | Should -Match '\$env:ANTHROPIC_API_KEY='
     }
     It 'clears competing Anthropic credentials so the chosen one is authoritative' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         # with CLAUDE_CODE_OAUTH_TOKEN chosen, the inherited ANTHROPIC_API_KEY must be cleared
         # first (it outranks the OAuth token in auth precedence) or it would win silently.
         $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'CLAUDE_CODE_OAUTH_TOKEN'
-        $joined = ($p.args -join ' ')
-        $joined | Should -Match 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN'
+        $s = $p.launchScript
+        $s | Should -Match 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN'
         # ...and the clear happens BEFORE the chosen credential is set
-        $clearIdx = $joined.IndexOf('Remove-Item Env:ANTHROPIC_API_KEY')
-        $setIdx   = $joined.IndexOf('$env:CLAUDE_CODE_OAUTH_TOKEN=')
+        $clearIdx = $s.IndexOf('Remove-Item Env:ANTHROPIC_API_KEY')
+        $setIdx   = $s.IndexOf('$env:CLAUDE_CODE_OAUTH_TOKEN=')
         $clearIdx | Should -BeLessThan $setIdx
     }
     It 'rejects an auth-var name that could inject into the spawned command' {
@@ -177,7 +202,7 @@ Describe 'Build-WorktreeLaunch' {
     It 'escapes single quotes in the briefing path (no literal break / injection)' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
         $p = Build-WorktreeLaunch 12 'C:\wt' "C:\O'Brien\brief.txt"
-        ($p.args -join ' ') | Should -Match "O''Brien"
+        $p.launchScript | Should -Match "O''Brien"
     }
 }
 


### PR DESCRIPTION
## Problem
Running `Board-Work.ps1 -ProjectNum 13 -Parallel 129,130 -Launch` (via `pwsh -File`) exposed **two** bugs:

1. **Comma arg mis-parsed.** `-File` never array-splits comma args, so `129,130` arrived as the single string `"129,130"`, which cast to `[int]` became `129130` (comma = thousands separator). The batch then looked for a nonexistent issue `#129130` and skipped it.
2. **`wt` split one tab into four.** The launcher passed `pwsh -NoExit -Command "clear; setAuth; clean; claude -p"` to `wt`. Windows Terminal treats `;` as its **own** sub-command separator, so wt ate the 3 semicolons and opened 4 tabs per issue → **2 issues = 8 stray tabs**, with the real `claude -p` landing in a bare tab that had no auth setup, so no session actually worked its issue.

## Fix
1. `$Parallel` is now `[string[]]`, and `Get-ParallelQueue` splits each token on `,` with `[int]::TryParse` (stays pure/unit-testable). Works for both `-File "129,130"` and native-array `-Parallel 129,130`.
2. `Build-WorktreeLaunch` now writes the setup+run to `launch-<issue>.ps1` and launches `pwsh -NoExit -File <script>` — **zero `;` on wt's command line**, so wt opens exactly one tab per issue.

## Validation
- Unit tests: **38 pass**, including new guards — comma-string parsing, and a regression test asserting no `;` reaches the `wt` command line (+ `-File`, not `-Command`).
- Live run: `-Parallel 129,130 -Launch` opened exactly **2 tabs** with **2 working `claude` sessions** (verified by process inspection), vs 8 broken tabs before.