### PR TITLE
chore: remove throwaway parallel-launch test fixtures

### DIFF
--- a/docs/parallel-test/session-a.md
+++ b/docs/parallel-test/session-a.md
@@ -1,1 +1,0 @@
-Parallel test A - this session reached PR + review gate + merge autonomously.

--- a/docs/parallel-test/session-b.md
+++ b/docs/parallel-test/session-b.md
@@ -1,1 +1,0 @@
-Parallel test B - this session reached PR + review gate + merge autonomously.


### PR DESCRIPTION
Removes `docs/parallel-test/session-a.md` and `session-b.md` — test litter created by the two autonomous sessions (#129/#130) that validated parallel `-Launch` end-to-end (see #131). Validation done; the files carry no value.