### PR TITLE
plan: board fleet - Phase 1 (multi-CLI launch)

### DIFF
--- a/plugins/agentic-bi-ops/commands/board.md
+++ b/plugins/agentic-bi-ops/commands/board.md
@@ -121,7 +121,10 @@ matching recipe from the projects-admin references:
     Add `-Launch` to open one visible Claude session per worktree — a Windows Terminal (`wt`)
     tab when available, else a `pwsh` window — each briefed to take its issue through step 5
     (PR + review gate). `-DryRun` plans (and previews the launch commands) without mutating or
-    spawning. Monitor the fleet with `scripts/Board-Work.ps1 -Sessions`. Only parallelize issues
+    spawning. Add `-Parallel <nums> -Fleet` instead of `-Launch` to probe the available AI CLIs,
+    pick one per issue (auto-fallback to `claude` when a choice is unavailable), and launch each
+    in its worktree; `-DryRun` shows the probe table without prompting or spawning.
+    Monitor the fleet with `scripts/Board-Work.ps1 -Sessions`. Only parallelize issues
     that DON'T depend on each other; clean each worktree with `git worktree remove` after its PR
     merges. Requires Windows Terminal for tabs (Windows-only launcher).
   - If many pending items lack Priority/Size, suggest `/board fill` to triage them first.

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -804,6 +804,30 @@ function Show-SessionFleet {
 }
 
 # ==============================================================================
+# CLI adapter registry: one record per launchable AI CLI. Generalizes the
+# previously Claude-only launch path (Build-WorktreeLaunch / Get-SessionBriefing).
+# Kind: 'repl' = live tab in the worktree; 'async' = dispatches a cloud task.
+# Hooks are scriptblocks so they stay pure/testable and are invoked with &.
+# ==============================================================================
+function Get-CliAdapters {
+    @(
+        [PSCustomObject]@{
+            Name         = 'claude'
+            Command      = 'claude'
+            Kind         = 'repl'
+            IsDefault    = $true
+            InstallCmd   = ''
+            Probe        = { param($ctx) $null }
+            BuildLaunch  = { param($ctx) $null }
+        }
+        [PSCustomObject]@{ Name='gemini';  Command='gemini';  Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @google/gemini-cli'; Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
+        [PSCustomObject]@{ Name='jules';   Command='jules';   Kind='async'; IsDefault=$false; InstallCmd='npm i -g @google/jules';      Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
+        [PSCustomObject]@{ Name='codex';   Command='codex';   Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @openai/codex';       Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
+        [PSCustomObject]@{ Name='copilot'; Command='copilot'; Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @github/copilot';      Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
+    )
+}
+
+# ==============================================================================
 # Main entry. Dot-source guard: when the test harness sets ABIOS_BOARDWORK_DOTSOURCE,
 # the script returns here with only the functions defined - no token check, no gh
 # calls, no side effects - so the pure helpers can be unit-tested in isolation.

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -928,6 +928,52 @@ function Resolve-LaunchCli([string]$Chosen, [hashtable]$Availability) {
     return 'claude'
 }
 
+# Pure core of the picker: given issues + raw choices + live availability, resolve each
+# issue to an available CLI (Resolve-LaunchCli enforces fallback). Unit-testable.
+function Resolve-IssueCliMap([int[]]$Issues, [hashtable]$Choices, [hashtable]$Availability) {
+    $map = @{}
+    foreach ($i in $Issues) {
+        $chosen = if ($Choices.ContainsKey($i)) { $Choices[$i] } else { 'claude' }
+        $map[$i] = Resolve-LaunchCli -Chosen $chosen -Availability $Availability
+    }
+    return $map
+}
+
+# Render the availability table: one colored line per CLI on the console, and the
+# same plain line emitted to the pipeline so callers (and tests, via Out-String) can
+# capture the rendered text. Green ok / yellow otherwise.
+function Show-CliAvailability([hashtable]$Availability) {
+    foreach ($cli in ($Availability.Keys | Sort-Object)) {
+        $st = $Availability[$cli]
+        $color = if ($st -eq 'ok') { 'Green' } else { 'DarkYellow' }
+        $line = "  {0,-8} {1}" -f $cli, $st
+        Write-Host $line -ForegroundColor $color
+        $line
+    }
+}
+
+# Install a not-installed CLI after explicit user approval, then re-probe. Impure.
+function Install-CliOnApproval([object]$Adapter) {
+    Write-Host ("  {0} no esta instalada. Comando: {1}" -f $Adapter.Name, $Adapter.InstallCmd) -ForegroundColor Yellow
+    $ans = Read-Host "  Instalar ahora? (s/N)"
+    if ($ans -notmatch '^[sSyY]') { Write-Host "  Omitida." -ForegroundColor DarkGray; return $false }
+    Invoke-Expression $Adapter.InstallCmd
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Interactive per-issue picker: prints availability, prompts a CLI per issue, then
+# resolves through the pure core. Returns the issue->cli map.
+function Select-CliPerIssue([int[]]$Issues, [hashtable]$Availability) {
+    Show-CliAvailability $Availability | Out-Null
+    $available = @($Availability.Keys | Where-Object { $Availability[$_] -eq 'ok' })
+    $choices = @{}
+    foreach ($i in $Issues) {
+        $ans = Read-Host ("  CLI para #{0} [{1}] (enter=claude)" -f $i, ($available -join '/'))
+        if ($ans) { $choices[$i] = $ans.Trim().ToLower() }
+    }
+    return Resolve-IssueCliMap -Issues $Issues -Choices $choices -Availability $Availability
+}
+
 # ==============================================================================
 # Main entry. Dot-source guard: when the test harness sets ABIOS_BOARDWORK_DOTSOURCE,
 # the script returns here with only the functions defined - no token check, no gh

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -869,6 +869,28 @@ function Get-CliProbeStatus([int]$ExitCode, [string]$Stderr) {
     return 'error'
 }
 
+# Shared probe runner for 'repl' CLIs that accept a one-shot prompt: run the
+# adapter's probe command, capture exit code + stderr, classify. Each adapter's
+# Probe scriptblock calls this with its own argument list (filled per CLI in the
+# spike tasks). Kept separate so Test-CliAvailability can be tested with a mock Probe.
+function Invoke-CliProbe([string[]]$CommandLine) {
+    $exe  = $CommandLine[0]
+    $rest = $CommandLine[1..($CommandLine.Count-1)]
+    $err  = & $exe @rest 2>&1 | Out-String
+    return Get-CliProbeStatus $LASTEXITCODE $err
+}
+
+# Availability = installed on PATH AND (for repl CLIs) a live probe. Returns
+# { Cli, Status, Detail }. Status in ok/no-quota/auth/not-installed/error.
+function Test-CliAvailability {
+    param([Parameter(Mandatory)][object]$Adapter)
+    if (-not (Get-Command $Adapter.Command -ErrorAction SilentlyContinue)) {
+        return [PSCustomObject]@{ Cli=$Adapter.Name; Status='not-installed'; Detail="$($Adapter.Command) no esta en PATH" }
+    }
+    $status = & $Adapter.Probe $null
+    return [PSCustomObject]@{ Cli=$Adapter.Name; Status=$status; Detail='' }
+}
+
 # ==============================================================================
 # Main entry. Dot-source guard: when the test harness sets ABIOS_BOARDWORK_DOTSOURCE,
 # the script returns here with only the functions defined - no token check, no gh

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -921,6 +921,13 @@ function Test-CliAvailability {
     return [PSCustomObject]@{ Cli=$Adapter.Name; Status=$status; Detail='' }
 }
 
+# The v1 safety net: an unavailable chosen CLI silently degrades to claude (the
+# always-present default), never aborting the batch. Pure -> unit-testable.
+function Resolve-LaunchCli([string]$Chosen, [hashtable]$Availability) {
+    if ($Chosen -and $Availability[$Chosen] -eq 'ok') { return $Chosen }
+    return 'claude'
+}
+
 # ==============================================================================
 # Main entry. Dot-source guard: when the test harness sets ABIOS_BOARDWORK_DOTSOURCE,
 # the script returns here with only the functions defined - no token check, no gh

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -125,6 +125,7 @@ param(
     # splits each token on ',' so both `-File` and native-array calls work.
     [string[]] $Parallel = @(),
     [switch]$Launch,
+    [switch]$Fleet,
     [switch]$Sessions,
     [int]   $ToReview   = 0,
     [switch]$DryRun,
@@ -189,7 +190,7 @@ function Read-SessionRegistry {
 function Write-SessionRegistryEntry {
     param(
         [int]$IssueNum, [string]$Branch, [string]$WorkPath, [string]$Repo = "",
-        [int]$SessionPid = 0, [string]$Via = ""
+        [int]$SessionPid = 0, [string]$Via = "", [string]$Cli = 'claude'
     )
     $p = Get-SessionRegistryPath
     if (-not $p) { return }
@@ -216,6 +217,7 @@ function Write-SessionRegistryEntry {
         workPath   = $WorkPath
         sessionPid = $trackPid
         via        = $Via
+        cli        = $Cli
         host       = $env:COMPUTERNAME
         started    = (Get-Date -Format "yyyy-MM-dd HH:mm")
     }
@@ -749,11 +751,12 @@ function Start-WorktreeSession {
     param(
         [int]$IssueNum, [string]$Repo, [string]$Branch, [string]$WorkPath,
         [string]$ClaudeAuthVar = "ANTHROPIC_API_KEY",
+        [string]$Cli = 'claude',
         [switch]$Preview
     )
     $abios = Get-AbiosDir
     $briefingFile = if ($abios) { Join-Path $abios "briefing-$IssueNum.txt" } else { Join-Path $WorkPath "briefing-$IssueNum.txt" }
-    $plan  = Build-WorktreeLaunch $IssueNum $WorkPath $briefingFile "abios-parallel" $ClaudeAuthVar
+    $plan  = Build-WorktreeLaunch $IssueNum $WorkPath $briefingFile "abios-parallel" $ClaudeAuthVar $Cli
 
     if ($Preview) {
         Write-Host ("  [preview] #{0}: {1} {2}" -f $IssueNum, $plan.launcher, ($plan.args -join ' ')) -ForegroundColor Gray
@@ -767,7 +770,7 @@ function Start-WorktreeSession {
         return $null
     }
     # Persist the briefing so the spawned session reads it without command-line quoting.
-    Set-Content -LiteralPath $briefingFile -Value (Get-SessionBriefing $IssueNum $Repo $Branch $WorkPath) -Encoding UTF8
+    Set-Content -LiteralPath $briefingFile -Value (Get-SessionBriefing $IssueNum $Repo $Branch $WorkPath $Cli) -Encoding UTF8
     # Persist the launch script so wt/pwsh runs it via -File (no ';' on wt's command
     # line -> no stray tab-splitting). See Build-WorktreeLaunch header for the why.
     Set-Content -LiteralPath $plan.launchScriptFile -Value $plan.launchScript -Encoding UTF8
@@ -972,6 +975,14 @@ function Select-CliPerIssue([int[]]$Issues, [hashtable]$Availability) {
         if ($ans) { $choices[$i] = $ans.Trim().ToLower() }
     }
     return Resolve-IssueCliMap -Issues $Issues -Choices $choices -Availability $Availability
+}
+
+# Pair each started worktree with the CLI the picker resolved for it. Pure.
+function Build-FleetPlan([object[]]$Started, [hashtable]$CliMap) {
+    foreach ($r in $Started) {
+        $cli = if ($CliMap.ContainsKey($r.issue)) { $CliMap[$r.issue] } else { 'claude' }
+        [PSCustomObject]@{ issue=$r.issue; repo=$r.repo; branch=$r.branch; workPath=$r.workPath; cli=$cli }
+    }
 }
 
 # ==============================================================================
@@ -1245,7 +1256,7 @@ if ($Parallel.Count -gt 0) {
         Write-Host ("DRY-RUN: {0} se iniciarian, {1} se saltarian. Ningun cambio hecho." -f $planned.Count, $skipped.Count) -ForegroundColor Gray
     } else {
         Write-Host ("Iniciados: {0} / {1}. Worktrees listos, uno por issue." -f $started.Count, $queue.Count) -ForegroundColor Yellow
-        if ($started.Count -gt 0 -and -not $Launch) {
+        if ($started.Count -gt 0 -and -not $Launch -and -not $Fleet) {
             Write-Host ""
             Write-Host "Cada worktree tiene su rama y su claim. Trabaja cada issue en su carpeta:" -ForegroundColor Cyan
             foreach ($r in $started) {
@@ -1257,8 +1268,77 @@ if ($Parallel.Count -gt 0) {
         }
     }
 
-    # -- Launch: one visible Claude session per worktree (-Launch) --------------
-    if ($Launch) {
+    # -- Launch: one visible session per worktree. -Fleet probes CLIs and picks one
+    # per issue (fallback claude); plain -Launch keeps the shipped claude-only path.
+    # -Fleet TAKES OVER the launch (elseif), so the two never both spawn in one run.
+    if ($Fleet) {
+        Write-Host ""
+        Write-Host "----- FLEET (una CLI por issue, fallback claude) -----" -ForegroundColor Cyan
+        # Availability across every adapter. A not-installed CLI is offered for install
+        # (only in a real run); if still unavailable it just stays that way (fallback).
+        $availability = @{}
+        foreach ($adapter in Get-CliAdapters) {
+            $res = Test-CliAvailability -Adapter $adapter
+            if ($res.Status -eq 'not-installed' -and -not $DryRun) {
+                if (Install-CliOnApproval $adapter) { $res = Test-CliAvailability -Adapter $adapter }
+            }
+            $availability[$adapter.Name] = $res.Status
+        }
+
+        if ($DryRun) {
+            # No prompt / install / spawn under -DryRun: just show the probe table and
+            # the default plan (every started issue -> claude; the real picker runs live).
+            Write-Host "  CLIs disponibles (probe):" -ForegroundColor DarkGray
+            Show-CliAvailability $availability | Out-Null
+            $defaultMap = @{}
+            foreach ($r in $planned) { $defaultMap[$r.issue] = 'claude' }
+            $dryPlan = Build-FleetPlan -Started $planned -CliMap $defaultMap
+            Write-Host "  Plan por defecto (el picker por-issue corre en la ejecucion real):" -ForegroundColor DarkGray
+            foreach ($e in $dryPlan) { Write-Host ("    #{0,-4} -> {1}" -f $e.issue, $e.cli) -ForegroundColor Gray }
+        } else {
+            # Auth preflight: a claude fallback session is headless, so it needs an explicit
+            # user-env credential (the Desktop host's OAuth is not shared with children).
+            $oauthPresent  = [bool][System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN', 'User')
+            $ClaudeAuthVar = Resolve-ClaudeAuthVar $PSBoundParameters.ContainsKey('ClaudeAuthVar') $ClaudeAuthVar $oauthPresent
+            if ($ClaudeAuthVar -eq 'CLAUDE_CODE_OAUTH_TOKEN') {
+                Write-Host "  Auth: usando CLAUDE_CODE_OAUTH_TOKEN (suscripcion)." -ForegroundColor DarkGray
+            }
+            $claudeAuth = [System.Environment]::GetEnvironmentVariable($ClaudeAuthVar, "User")
+            if (-not $claudeAuth) {
+                Write-Host ""
+                Write-Host ("  AUTH REQUERIDA - las sesiones headless necesitan '{0}' en tus variables de usuario." -f $ClaudeAuthVar) -ForegroundColor Red
+                Write-Host "  (El login del Desktop NO se comparte con procesos hijos, darian 401.)" -ForegroundColor DarkYellow
+                Write-Host "  Opcion A (API key): setx ANTHROPIC_API_KEY <tu-api-key>" -ForegroundColor Gray
+                Write-Host "  Opcion B (suscripcion): claude setup-token ; setx CLAUDE_CODE_OAUTH_TOKEN <token> ; -ClaudeAuthVar CLAUDE_CODE_OAUTH_TOKEN" -ForegroundColor Gray
+                Write-Host "  Reinicia la terminal y re-lanza con -Fleet (los worktrees ya estan listos; monitorea con -Sessions)." -ForegroundColor Yellow
+                Write-Host ""
+                Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+                exit 0
+            }
+            # Pick a CLI per issue (interactive), then pair each worktree with its choice.
+            $issueNums = @($started | ForEach-Object { $_.issue })
+            $map       = Select-CliPerIssue -Issues $issueNums -Availability $availability
+            $fleetPlan = Build-FleetPlan -Started $started -CliMap $map
+            $launched  = 0
+            foreach ($entry in $fleetPlan) {
+                if (-not $entry.workPath) { continue }
+                # The picker already resolved through the fallback, but re-resolve at spawn
+                # time so an unavailable CLI never actually launches (defense in depth).
+                $actualCli = Resolve-LaunchCli -Chosen $entry.cli -Availability $availability
+                $spawn = Start-WorktreeSession -IssueNum $entry.issue -Repo $entry.repo -Branch $entry.branch `
+                                               -WorkPath $entry.workPath -ClaudeAuthVar $ClaudeAuthVar -Cli $actualCli
+                $launched++
+                $via = if ($spawn.usesWt) { "wt" } else { "pwsh" }
+                if ($spawn.process -and -not $spawn.usesWt) {
+                    Write-SessionRegistryEntry -IssueNum $entry.issue -SessionPid $spawn.process.Id -Via $via -Cli $actualCli
+                } else {
+                    Write-SessionRegistryEntry -IssueNum $entry.issue -Via $via -Cli $actualCli
+                }
+            }
+            Write-Host ""
+            Write-Host ("Fleet lanzada: {0} sesion(es). CLI resuelto por issue (fallback claude)." -f $launched) -ForegroundColor Yellow
+        }
+    } elseif ($Launch) {
         Write-Host ""
         # Auto-prefer the subscription OAuth token when the caller did not pick an
         # auth var explicitly (see Resolve-ClaudeAuthVar).

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -833,7 +833,8 @@ function Get-CliAdapters {
             Kind         = 'repl'
             IsDefault    = $true
             InstallCmd   = ''
-            Probe        = { param($ctx) $null }
+            # claude is the host CLI running this very script -> always available.
+            Probe        = { param($ctx) 'ok' }
             # Build the per-worktree claude launch script. $ctx carries at least
             # BriefingFile + AuthVar. This is the SAME construction Build-WorktreeLaunch
             # used inline before the adapter refactor - kept byte-identical on purpose
@@ -859,8 +860,17 @@ function Get-CliAdapters {
             Kind         = 'repl'
             IsDefault    = $false
             InstallCmd   = 'npm i -g @google/gemini-cli'
-            Probe        = { param($ctx) $null }
-            BuildLaunch  = { param($ctx) $null }
+            # One-token probe prompt with the SAME autonomous flags as the real launch, so
+            # an auth/quota failure classifies correctly (see Get-CliProbeStatus).
+            Probe        = { param($ctx) Invoke-CliProbe @('gemini', '-p', 'reply OK', '--approval-mode', 'yolo', '--skip-trust') }
+            BuildLaunch  = {
+                param($ctx)
+                # Same single-quote doubling as the claude adapter (see its BuildLaunch
+                # comment) so a briefing path containing ' (e.g. an O'Brien user folder)
+                # can't break out of the generated script's single-quoted literal.
+                $b = $ctx.BriefingFile -replace "'", "''"
+                'gemini -p (Get-Content -Raw -LiteralPath ''{0}'') --approval-mode yolo --skip-trust' -f $b
+            }
         }
         [PSCustomObject]@{
             Name         = 'jules'
@@ -868,8 +878,17 @@ function Get-CliAdapters {
             Kind         = 'async'
             IsDefault    = $false
             InstallCmd   = 'npm i -g @google/jules'
-            Probe        = { param($ctx) $null }
-            BuildLaunch  = { param($ctx) $null }
+            # jules is an ASYNC cloud agent: 'jules new' dispatches a session that operates
+            # on the REMOTE repo, not this local worktree/branch. Phase-1 limitation: this
+            # dispatch is best-effort - there is no local worktree/PR integration yet (the
+            # cloud session runs independently of the branch this script checked out). Full
+            # worktree/PR round-trip integration is deferred to a later phase.
+            Probe        = { param($ctx) Invoke-CliProbe @('jules', 'remote', 'list') }
+            BuildLaunch  = {
+                param($ctx)
+                $b = $ctx.BriefingFile -replace "'", "''"
+                'jules new (Get-Content -Raw -LiteralPath ''{0}'')' -f $b
+            }
         }
         [PSCustomObject]@{
             Name         = 'codex'
@@ -877,8 +896,12 @@ function Get-CliAdapters {
             Kind         = 'repl'
             IsDefault    = $false
             InstallCmd   = 'npm i -g @openai/codex'
-            Probe        = { param($ctx) $null }
-            BuildLaunch  = { param($ctx) $null }
+            Probe        = { param($ctx) Invoke-CliProbe @('codex', 'exec', 'reply OK', '--dangerously-bypass-approvals-and-sandbox') }
+            BuildLaunch  = {
+                param($ctx)
+                $b = $ctx.BriefingFile -replace "'", "''"
+                'codex exec (Get-Content -Raw -LiteralPath ''{0}'') --dangerously-bypass-approvals-and-sandbox' -f $b
+            }
         }
         [PSCustomObject]@{
             Name         = 'copilot'
@@ -886,8 +909,12 @@ function Get-CliAdapters {
             Kind         = 'repl'
             IsDefault    = $false
             InstallCmd   = 'npm i -g @github/copilot'
-            Probe        = { param($ctx) $null }
-            BuildLaunch  = { param($ctx) $null }
+            Probe        = { param($ctx) Invoke-CliProbe @('copilot', '-p', 'reply OK', '--allow-all') }
+            BuildLaunch  = {
+                param($ctx)
+                $b = $ctx.BriefingFile -replace "'", "''"
+                'copilot -p (Get-Content -Raw -LiteralPath ''{0}'') --allow-all' -f $b
+            }
         }
     )
 }

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -859,6 +859,16 @@ function Get-CliAdapters {
     )
 }
 
+# Classify a probe outcome into one status word. Pure -> unit-testable.
+# Order matters: quota/rate-limit and auth are more specific than the generic error.
+function Get-CliProbeStatus([int]$ExitCode, [string]$Stderr) {
+    if ($ExitCode -eq 0) { return 'ok' }
+    $s = "$Stderr".ToLower()
+    if ($s -match 'rate.?limit|quota|429|resource.?exhausted|too many requests') { return 'no-quota' }
+    if ($s -match '401|403|unauthor|authenticat|not logged in|login required')   { return 'auth' }
+    return 'error'
+}
+
 # ==============================================================================
 # Main entry. Dot-source guard: when the test harness sets ABIOS_BOARDWORK_DOTSOURCE,
 # the script returns here with only the functions defined - no token check, no gh

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -628,7 +628,17 @@ query($o:String!, $r:String!, $n:Int!) {
 # ==============================================================================
 
 # The one-line first message a spawned Claude session receives. Pure -> testable.
-function Get-SessionBriefing([int]$issueNum, [string]$repo, [string]$branch, [string]$workPath) {
+# -Cli is threaded (default 'claude') so Phase-2 adapters can specialize the leading
+# autonomy sentence per CLI without another signature change; Phase 1 keeps the
+# body text identical for every repl CLI.
+function Get-SessionBriefing {
+    param(
+        [int]$issueNum,
+        [string]$repo,
+        [string]$branch,
+        [string]$workPath,
+        [string]$Cli = 'claude'
+    )
     return ("You are running AUTONOMOUSLY - permissions are pre-approved, so work this " +
             "task end-to-end WITHOUT stopping to ask for confirmation. " +
             "Pick up GitHub issue #$issueNum in $repo. It is already In Progress and claimed, " +

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -820,10 +820,42 @@ function Get-CliAdapters {
             Probe        = { param($ctx) $null }
             BuildLaunch  = { param($ctx) $null }
         }
-        [PSCustomObject]@{ Name='gemini';  Command='gemini';  Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @google/gemini-cli'; Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
-        [PSCustomObject]@{ Name='jules';   Command='jules';   Kind='async'; IsDefault=$false; InstallCmd='npm i -g @google/jules';      Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
-        [PSCustomObject]@{ Name='codex';   Command='codex';   Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @openai/codex';       Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
-        [PSCustomObject]@{ Name='copilot'; Command='copilot'; Kind='repl';  IsDefault=$false; InstallCmd='npm i -g @github/copilot';      Probe={ param($ctx) $null }; BuildLaunch={ param($ctx) $null } }
+        [PSCustomObject]@{
+            Name         = 'gemini'
+            Command      = 'gemini'
+            Kind         = 'repl'
+            IsDefault    = $false
+            InstallCmd   = 'npm i -g @google/gemini-cli'
+            Probe        = { param($ctx) $null }
+            BuildLaunch  = { param($ctx) $null }
+        }
+        [PSCustomObject]@{
+            Name         = 'jules'
+            Command      = 'jules'
+            Kind         = 'async'
+            IsDefault    = $false
+            InstallCmd   = 'npm i -g @google/jules'
+            Probe        = { param($ctx) $null }
+            BuildLaunch  = { param($ctx) $null }
+        }
+        [PSCustomObject]@{
+            Name         = 'codex'
+            Command      = 'codex'
+            Kind         = 'repl'
+            IsDefault    = $false
+            InstallCmd   = 'npm i -g @openai/codex'
+            Probe        = { param($ctx) $null }
+            BuildLaunch  = { param($ctx) $null }
+        }
+        [PSCustomObject]@{
+            Name         = 'copilot'
+            Command      = 'copilot'
+            Kind         = 'repl'
+            IsDefault    = $false
+            InstallCmd   = 'npm i -g @github/copilot'
+            Probe        = { param($ctx) $null }
+            BuildLaunch  = { param($ctx) $null }
+        }
     )
 }
 

--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -657,7 +657,7 @@ function Get-SessionBriefing([int]$issueNum, [string]$repo, [string]$branch, [st
 # launch-<issue>.ps1 and launching `pwsh -NoExit -File <script>` puts ZERO ';' on
 # wt's command line, so wt opens exactly one tab. The briefing is likewise passed by
 # file so no long/quoted text ever hits the command line.
-function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefingFile, [string]$windowName = "abios-parallel", [string]$claudeAuthVar = "ANTHROPIC_API_KEY") {
+function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefingFile, [string]$windowName = "abios-parallel", [string]$claudeAuthVar = "ANTHROPIC_API_KEY", [string]$Cli = 'claude') {
     $tabTitle  = "issue-$issueNum"
     # Defense-in-depth: this name is interpolated into the spawned launch script,
     # so it MUST be a bare env-var identifier - never let ';'/quotes/spaces through.
@@ -686,17 +686,20 @@ function Build-WorktreeLaunch([int]$issueNum, [string]$workPath, [string]$briefi
     # CLAUDE_CODE_OAUTH_TOKEN, so an inherited API key would otherwise silently
     # override a subscription token (or 401 if stale). We also drop the inherited
     # CLAUDE_CODE_* session markers so the child starts as a clean top-level session.
-    # Double any single quote so a briefing path containing ' (valid on Windows, e.g. an
-    # O'Brien user folder) can't break out of the single-quoted literal it is embedded in
-    # inside the generated launch script (the Get-Content -LiteralPath '...' arg below).
-    $safeBrief  = $briefingFile -replace "'", "''"
-    # Each step on its OWN line (a .ps1 file), so no ';' is ever needed - which is the
-    # whole point: ';' on wt's command line would split the tab (see the header note).
-    $clearAuth  = 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue'
-    $setAuth    = '$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User'')' -f $claudeAuthVar
-    $clean      = 'Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue'
-    $run        = 'claude -p (Get-Content -Raw -LiteralPath ''{0}'') --permission-mode bypassPermissions --no-session-persistence --verbose' -f $safeBrief
-    $launchScript = ($clearAuth, $setAuth, $clean, $run) -join "`r`n"
+    # Delegate the launch-script construction to the chosen CLI's adapter. The adapter
+    # receives a context object and RETURNS the launch-script string; the claude adapter
+    # reproduces the exact lines this function used to build inline (byte-identical).
+    $ctx = @{
+        IssueNum     = $issueNum
+        WorkPath     = $workPath
+        BriefingFile = $briefingFile
+        TabTitle     = $tabTitle
+        WindowName   = $windowName
+        AuthVar      = $claudeAuthVar
+    }
+    $adapter = Get-CliAdapters | Where-Object { $_.Name -eq $Cli } | Select-Object -First 1
+    if (-not $adapter) { throw "Unknown CLI adapter '$Cli'." }
+    $launchScript = & $adapter.BuildLaunch $ctx
     # The launch script lives next to the briefing (same dir the caller chose).
     $launchScriptFile = Join-Path (Split-Path -Parent $briefingFile) "launch-$issueNum.ps1"
     $safeScriptPath   = $launchScriptFile   # a plain path arg (its own arg element -> Start-Process quotes it)
@@ -818,7 +821,24 @@ function Get-CliAdapters {
             IsDefault    = $true
             InstallCmd   = ''
             Probe        = { param($ctx) $null }
-            BuildLaunch  = { param($ctx) $null }
+            # Build the per-worktree claude launch script. $ctx carries at least
+            # BriefingFile + AuthVar. This is the SAME construction Build-WorktreeLaunch
+            # used inline before the adapter refactor - kept byte-identical on purpose
+            # (see the O'Brien single-quote escaping + the -join "`r`n" below).
+            BuildLaunch  = {
+                param($ctx)
+                # Double any single quote so a briefing path containing ' (valid on Windows, e.g. an
+                # O'Brien user folder) can't break out of the single-quoted literal it is embedded in
+                # inside the generated launch script (the Get-Content -LiteralPath '...' arg below).
+                $safeBrief  = $ctx.BriefingFile -replace "'", "''"
+                # Each step on its OWN line (a .ps1 file), so no ';' is ever needed - which is the
+                # whole point: ';' on wt's command line would split the tab (see the header note).
+                $clearAuth  = 'Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue'
+                $setAuth    = '$env:{0}=[Environment]::GetEnvironmentVariable(''{0}'',''User'')' -f $ctx.AuthVar
+                $clean      = 'Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue'
+                $run        = 'claude -p (Get-Content -Raw -LiteralPath ''{0}'') --permission-mode bypassPermissions --no-session-persistence --verbose' -f $safeBrief
+                ($clearAuth, $setAuth, $clean, $run) -join "`r`n"
+            }
         }
         [PSCustomObject]@{
             Name         = 'gemini'

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -333,7 +333,7 @@ Describe 'Invoke-IssueStart safety refusals + dry-run' {
     }
 }
 
-Describe "Get-CliAdapters" {
+Describe 'Get-CliAdapters' {
     It "returns claude as the default adapter with all required fields" {
         $adapters = Get-CliAdapters
         $claude = $adapters | Where-Object { $_.Name -eq 'claude' }

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -482,3 +482,20 @@ Describe 'Show-CliAvailability' {
         $out | Should -Match 'no-quota'
     }
 }
+
+Describe 'Build-FleetPlan' {
+    It 'pairs each started issue with its resolved CLI' {
+        $started = @(
+            [PSCustomObject]@{ issue=12; repo='o/r'; branch='issue-12-x'; workPath='C:\wt\12' }
+            [PSCustomObject]@{ issue=14; repo='o/r'; branch='issue-14-y'; workPath='C:\wt\14' }
+        )
+        $map = @{ 12='gemini'; 14='claude' }
+        $plan = Build-FleetPlan -Started $started -CliMap $map
+        ($plan | Where-Object issue -eq 12).cli | Should -Be 'gemini'
+        ($plan | Where-Object issue -eq 14).cli | Should -Be 'claude'
+    }
+    It 'defaults to claude when an issue is absent from the map' {
+        $started = @([PSCustomObject]@{ issue=7; repo='o/r'; branch='b'; workPath='C:\wt\7' })
+        (Build-FleetPlan -Started $started -CliMap @{})[0].cli | Should -Be 'claude'
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -499,3 +499,32 @@ Describe 'Build-FleetPlan' {
         (Build-FleetPlan -Started $started -CliMap @{})[0].cli | Should -Be 'claude'
     }
 }
+
+Describe 'non-claude adapters' {
+    It 'gemini BuildLaunch uses -p and --approval-mode yolo --skip-trust' {
+        $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
+        $s = & ((Get-CliAdapters | Where-Object Name -eq 'gemini').BuildLaunch) $ctx
+        $s | Should -Match 'gemini -p'
+        $s | Should -Match '--approval-mode yolo'
+        $s | Should -Match '--skip-trust'
+    }
+    It 'codex BuildLaunch uses exec + --dangerously-bypass-approvals-and-sandbox' {
+        $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
+        (& ((Get-CliAdapters | Where-Object Name -eq 'codex').BuildLaunch) $ctx) | Should -Match 'codex exec .* --dangerously-bypass-approvals-and-sandbox'
+    }
+    It 'copilot BuildLaunch uses -p + --allow-all' {
+        $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
+        (& ((Get-CliAdapters | Where-Object Name -eq 'copilot').BuildLaunch) $ctx) | Should -Match 'copilot -p .* --allow-all'
+    }
+    It 'jules BuildLaunch dispatches jules new' {
+        $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
+        (& ((Get-CliAdapters | Where-Object Name -eq 'jules').BuildLaunch) $ctx) | Should -Match 'jules new'
+    }
+    It 'claude probe returns ok (host CLI always available)' {
+        (& (Get-CliAdapters | Where-Object Name -eq 'claude').Probe $null) | Should -Be 'ok'
+    }
+    It 'briefing path with a single quote is escaped in a non-claude adapter' {
+        $ctx = @{ BriefingFile = "C:\Users\O'Brien\b.txt" }
+        (& ((Get-CliAdapters | Where-Object Name -eq 'gemini').BuildLaunch) $ctx) | Should -Match "O''Brien"
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -354,3 +354,19 @@ Describe 'Get-CliAdapters' {
         @(Get-CliAdapters | Where-Object { $_.IsDefault }).Count | Should -Be 1
     }
 }
+
+Describe 'Get-CliProbeStatus' {
+    It 'returns ok on exit 0' {
+        Get-CliProbeStatus -ExitCode 0 -Stderr "" | Should -Be 'ok'
+    }
+    It 'returns no-quota on a rate-limit/quota message' {
+        Get-CliProbeStatus -ExitCode 1 -Stderr "Error: 429 rate limit exceeded" | Should -Be 'no-quota'
+        Get-CliProbeStatus -ExitCode 1 -Stderr "quota exceeded for this project" | Should -Be 'no-quota'
+    }
+    It 'returns auth on a 401/authentication message' {
+        Get-CliProbeStatus -ExitCode 1 -Stderr "401 Unauthorized: please login" | Should -Be 'auth'
+    }
+    It 'returns error on any other non-zero exit' {
+        Get-CliProbeStatus -ExitCode 1 -Stderr "some unexpected failure" | Should -Be 'error'
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -126,6 +126,19 @@ Describe 'Get-SessionBriefing' {
     }
 }
 
+Describe 'Get-SessionBriefing adapter-aware' {
+    It 'keeps the claude briefing unchanged' {
+        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'claude') | Should -Match 'AUTONOMOUSLY'
+        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'claude') | Should -Match 'issue #5'
+    }
+    It 'still references the same PR + review-gate steps for any repl CLI' {
+        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'gemini') | Should -Match 'New-BoardPR.ps1'
+    }
+    It 'defaults to claude behavior when -Cli is omitted' {
+        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt') | Should -Match 'AUTONOMOUSLY'
+    }
+}
+
 Describe 'Resolve-ClaudeAuthVar' {
     It 'honors an explicit -ClaudeAuthVar even when the OAuth token exists' {
         Resolve-ClaudeAuthVar $true 'ANTHROPIC_API_KEY' $true | Should -Be 'ANTHROPIC_API_KEY'

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -459,3 +459,26 @@ Describe 'Resolve-LaunchCli' {
         Resolve-LaunchCli -Chosen 'codex' -Availability @{ claude='ok' } | Should -Be 'claude'
     }
 }
+
+Describe 'Resolve-IssueCliMap' {
+    It 'keeps a valid available choice' {
+        $map = Resolve-IssueCliMap -Issues @(12,14) -Choices @{ 12='gemini'; 14='claude' } -Availability @{ gemini='ok'; claude='ok' }
+        $map[12] | Should -Be 'gemini'
+        $map[14] | Should -Be 'claude'
+    }
+    It 'coerces an unavailable choice to claude' {
+        $map = Resolve-IssueCliMap -Issues @(12) -Choices @{ 12='codex' } -Availability @{ claude='ok' }
+        $map[12] | Should -Be 'claude'
+    }
+    It 'defaults an unspecified issue to claude' {
+        $map = Resolve-IssueCliMap -Issues @(99) -Choices @{} -Availability @{ claude='ok' }
+        $map[99] | Should -Be 'claude'
+    }
+}
+Describe 'Show-CliAvailability' {
+    It 'renders one line per CLI with its status' {
+        $out = Show-CliAvailability -Availability @{ claude='ok'; gemini='no-quota' } | Out-String
+        $out | Should -Match 'claude'
+        $out | Should -Match 'no-quota'
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -222,6 +222,56 @@ Describe 'Build-WorktreeLaunch' {
     }
 }
 
+Describe 'Build-WorktreeLaunch adapter parity' {
+    # GOLDEN fixture captured from the pre-refactor Build-WorktreeLaunch for a claude
+    # launch of issue 42 (brief C:\b\briefing-42.txt). The adapter-driven refactor MUST
+    # keep the claude launchScript + args byte-identical to these constants.
+    BeforeAll {
+        $script:GoldenLaunchScript = @(
+            "Remove-Item Env:ANTHROPIC_API_KEY,Env:ANTHROPIC_AUTH_TOKEN,Env:CLAUDE_CODE_OAUTH_TOKEN -ErrorAction SilentlyContinue"
+            "`$env:ANTHROPIC_API_KEY=[Environment]::GetEnvironmentVariable('ANTHROPIC_API_KEY','User')"
+            "Remove-Item Env:CLAUDECODE,Env:CLAUDE_CODE_SESSION_ID,Env:CLAUDE_CODE_CHILD_SESSION,Env:CLAUDE_CODE_ENTRYPOINT -ErrorAction SilentlyContinue"
+            "claude -p (Get-Content -Raw -LiteralPath 'C:\b\briefing-42.txt') --permission-mode bypassPermissions --no-session-persistence --verbose"
+        ) -join "`r`n"
+        $script:GoldenWtArgs = @('-w', 'abios-parallel', 'new-tab', '--title', 'issue-42',
+                                 '--startingDirectory', 'C:\wt\issue-42', 'pwsh', '-NoExit', '-File', 'C:\b\launch-42.ps1')
+    }
+
+    It 'exposes a -Cli parameter (adapter selector) defaulting to claude' {
+        $cmd = Get-Command Build-WorktreeLaunch
+        $cmd.Parameters.ContainsKey('Cli') | Should -BeTrue
+        # the added selector must be appended, keeping the 5 original positionals in order
+        $cmd.Parameters['Cli'].ParameterType | Should -Be ([string])
+    }
+    It 'produces a launchScript byte-identical to the golden when -Cli claude is explicit' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 42 'C:\wt\issue-42' 'C:\b\briefing-42.txt' 'abios-parallel' 'ANTHROPIC_API_KEY' 'claude'
+        $p.launchScript | Should -BeExactly $script:GoldenLaunchScript
+    }
+    It 'produces a launchScript byte-identical to the golden when -Cli is omitted (default claude)' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 42 'C:\wt\issue-42' 'C:\b\briefing-42.txt' 'abios-parallel' 'ANTHROPIC_API_KEY'
+        $p.launchScript | Should -BeExactly $script:GoldenLaunchScript
+    }
+    It 'produces args byte-identical to the golden wt args (explicit claude)' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 42 'C:\wt\issue-42' 'C:\b\briefing-42.txt' 'abios-parallel' 'ANTHROPIC_API_KEY' 'claude'
+        $p.args.Count            | Should -Be $script:GoldenWtArgs.Count
+        ($p.args -join "`n")     | Should -BeExactly ($script:GoldenWtArgs -join "`n")
+    }
+    It 'produces args byte-identical to the golden wt args (default claude)' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }
+        $p = Build-WorktreeLaunch 42 'C:\wt\issue-42' 'C:\b\briefing-42.txt' 'abios-parallel' 'ANTHROPIC_API_KEY'
+        $p.args.Count            | Should -Be $script:GoldenWtArgs.Count
+        ($p.args -join "`n")     | Should -BeExactly ($script:GoldenWtArgs -join "`n")
+    }
+    It 'default (no -Cli) still yields a claude -p launch script' {
+        Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { $null }
+        $p = Build-WorktreeLaunch 12 'C:\wt' 'C:\brief.txt'
+        $p.launchScript | Should -Match 'claude -p '
+    }
+}
+
 Describe 'Get-BranchDriftWarning (foreign-checkout guard)' {
     BeforeAll {
         # Build a session-registry entry shaped like Write-SessionRegistryEntry writes.

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -370,3 +370,17 @@ Describe 'Get-CliProbeStatus' {
         Get-CliProbeStatus -ExitCode 1 -Stderr "some unexpected failure" | Should -Be 'error'
     }
 }
+
+Describe 'Test-CliAvailability' {
+    It 'reports not-installed when the command is absent' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'codex' }
+        $r = Test-CliAvailability -Adapter ([PSCustomObject]@{ Name='codex'; Command='codex'; Probe={ param($ctx) 'ok' } })
+        $r.Status | Should -Be 'not-installed'
+    }
+    It 'runs the probe when installed and returns its status' {
+        Mock Get-Command { [PSCustomObject]@{ Source='C:\x\gemini.exe' } } -ParameterFilter { $Name -eq 'gemini' }
+        $r = Test-CliAvailability -Adapter ([PSCustomObject]@{ Name='gemini'; Command='gemini'; Probe={ param($ctx) 'no-quota' } })
+        $r.Status | Should -Be 'no-quota'
+        $r.Cli    | Should -Be 'gemini'
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -332,3 +332,25 @@ Describe 'Invoke-IssueStart safety refusals + dry-run' {
         $r.branch  | Should -Match '^issue-1-'
     }
 }
+
+Describe "Get-CliAdapters" {
+    It "returns claude as the default adapter with all required fields" {
+        $adapters = Get-CliAdapters
+        $claude = $adapters | Where-Object { $_.Name -eq 'claude' }
+        $claude              | Should -Not -BeNullOrEmpty
+        $claude.Command      | Should -Be 'claude'
+        $claude.Kind         | Should -Be 'repl'
+        $claude.IsDefault    | Should -BeTrue
+        $claude.BuildLaunch  | Should -BeOfType ([scriptblock])
+        $claude.Probe        | Should -BeOfType ([scriptblock])
+    }
+    It "includes all five CLIs by name" {
+        (Get-CliAdapters).Name | Should -Contain 'gemini'
+        (Get-CliAdapters).Name | Should -Contain 'jules'
+        (Get-CliAdapters).Name | Should -Contain 'codex'
+        (Get-CliAdapters).Name | Should -Contain 'copilot'
+    }
+    It "marks exactly one adapter as default" {
+        @(Get-CliAdapters | Where-Object { $_.IsDefault }).Count | Should -Be 1
+    }
+}

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -447,3 +447,15 @@ Describe 'Test-CliAvailability' {
         $r.Cli    | Should -Be 'gemini'
     }
 }
+
+Describe 'Resolve-LaunchCli' {
+    It 'returns the chosen CLI when it is available' {
+        Resolve-LaunchCli -Chosen 'gemini' -Availability @{ gemini='ok'; claude='ok' } | Should -Be 'gemini'
+    }
+    It 'falls back to claude when the chosen CLI is unavailable' {
+        Resolve-LaunchCli -Chosen 'gemini' -Availability @{ gemini='no-quota'; claude='ok' } | Should -Be 'claude'
+    }
+    It 'falls back to claude when the chosen CLI is missing from the map' {
+        Resolve-LaunchCli -Chosen 'codex' -Availability @{ claude='ok' } | Should -Be 'claude'
+    }
+}


### PR DESCRIPTION
Closes #168

Closes #169
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179
Closes #180

## board fleet - Phase 1 (multi-CLI launch)

Turns `/board work -Parallel -Launch` from a Claude-only launcher into a heterogeneous multi-CLI coordinator, reusing the existing worktree + session-registry + Windows-Terminal machinery. New `-Fleet` switch; `-Launch` stays claude-only and byte-identical.

### What is in
- CLI adapter registry (claude default + gemini/jules/codex/copilot): install / probe / headless-launch per CLI.
- Availability probe classifier (ok/no-quota/auth/not-installed/error) + `Test-CliAvailability`.
- `Build-WorktreeLaunch` / `Get-SessionBriefing` refactored to adapter-driven; claude launch output proven byte-identical (golden fixture).
- Interactive per-issue picker with auto-fallback to claude; install-on-approval for missing CLIs.
- `-Fleet` wiring + `cli` field in the session registry.
- 82/82 Pester tests.

### Spike-verified headless invocations (REGLA 1 - discovered live, not invented)
- gemini: `-p <b> --approval-mode yolo --skip-trust`
- codex: `exec <b> --dangerously-bypass-approvals-and-sandbox`
- copilot: `-p <b> --allow-all`
- jules: `new <b>` (async cloud; operates on the remote repo - best-effort Phase 1)

### Note
Non-claude CLIs currently probe as unavailable until their auth is configured (gemini's individual free tier is discontinued; codex/copilot/jules need login), so today the fleet falls back to claude - by design. Coordinator layer (governor + monitor + tree-deep task reaper) is Phase 2.