### PR TITLE
plan: board fleet - Phase 1.1 (probe hardening)

### DIFF
--- a/plugins/agentic-bi-ops/scripts/Board-Work.ps1
+++ b/plugins/agentic-bi-ops/scripts/Board-Work.ps1
@@ -883,7 +883,9 @@ function Get-CliAdapters {
             # dispatch is best-effort - there is no local worktree/PR integration yet (the
             # cloud session runs independently of the branch this script checked out). Full
             # worktree/PR round-trip integration is deferred to a later phase.
-            Probe        = { param($ctx) Invoke-CliProbe @('jules', 'remote', 'list') }
+            # 'jules remote list' returns "Must specify what to list" with exit 0 (a
+            # false ok) - '--session' scopes it to a well-formed listing instead.
+            Probe        = { param($ctx) Invoke-CliProbe @('jules', 'remote', 'list', '--session') }
             BuildLaunch  = {
                 param($ctx)
                 $b = $ctx.BriefingFile -replace "'", "''"
@@ -896,11 +898,16 @@ function Get-CliAdapters {
             Kind         = 'repl'
             IsDefault    = $false
             InstallCmd   = 'npm i -g @openai/codex'
-            Probe        = { param($ctx) Invoke-CliProbe @('codex', 'exec', 'reply OK', '--dangerously-bypass-approvals-and-sandbox') }
+            # 'codex login status' is a lightweight auth check (no stdin read, ~2.6s)
+            # vs. the old 'codex exec' probe which took ~19.5s and reads stdin.
+            Probe        = { param($ctx) Invoke-CliProbe @('codex', 'login', 'status') }
             BuildLaunch  = {
                 param($ctx)
+                # 'codex exec' reads stdin even with a prompt arg - in a wt tab (TTY
+                # stdin) that hangs waiting for input. Piping $null gives it immediate
+                # EOF so it proceeds using only the prompt argument.
                 $b = $ctx.BriefingFile -replace "'", "''"
-                'codex exec (Get-Content -Raw -LiteralPath ''{0}'') --dangerously-bypass-approvals-and-sandbox' -f $b
+                '$null | codex exec (Get-Content -Raw -LiteralPath ''{0}'') --dangerously-bypass-approvals-and-sandbox' -f $b
             }
         }
         [PSCustomObject]@{
@@ -920,12 +927,14 @@ function Get-CliAdapters {
 }
 
 # Classify a probe outcome into one status word. Pure -> unit-testable.
-# Order matters: quota/rate-limit and auth are more specific than the generic error.
+# Order matters: quota/rate-limit and auth are checked FIRST, even on exit 0 -
+# some CLIs (observed live) print an error message but wrongly exit 0, so a
+# generic exit-0 "ok" short-circuit would hide a real quota/auth failure.
 function Get-CliProbeStatus([int]$ExitCode, [string]$Stderr) {
-    if ($ExitCode -eq 0) { return 'ok' }
     $s = "$Stderr".ToLower()
     if ($s -match 'rate.?limit|quota|429|resource.?exhausted|too many requests') { return 'no-quota' }
     if ($s -match '401|403|unauthor|authenticat|not logged in|login required')   { return 'auth' }
+    if ($ExitCode -eq 0) { return 'ok' }
     return 'error'
 }
 
@@ -933,11 +942,18 @@ function Get-CliProbeStatus([int]$ExitCode, [string]$Stderr) {
 # adapter's probe command, capture exit code + stderr, classify. Each adapter's
 # Probe scriptblock calls this with its own argument list (filled per CLI in the
 # spike tasks). Kept separate so Test-CliAvailability can be tested with a mock Probe.
-function Invoke-CliProbe([string[]]$CommandLine) {
+# Runs the command in a background job with a timeout so a slow/hung CLI (e.g.
+# codex exec waiting on stdin) can never block the fleet launch indefinitely.
+function Invoke-CliProbe([string[]]$CommandLine, [int]$TimeoutSec = 30) {
     $exe  = $CommandLine[0]
-    $rest = $CommandLine[1..($CommandLine.Count-1)]
-    $err  = & $exe @rest 2>&1 | Out-String
-    return Get-CliProbeStatus $LASTEXITCODE $err
+    $rest = @($CommandLine[1..($CommandLine.Count-1)])
+    $j = Start-Job { param($e,$a) $o = & $e @a 2>&1 | Out-String; [pscustomobject]@{ Exit = $LASTEXITCODE; Out = $o } } -ArgumentList $exe, $rest
+    if (Wait-Job $j -Timeout $TimeoutSec) {
+        $r = Receive-Job $j; Remove-Job $j -Force
+        return Get-CliProbeStatus $r.Exit $r.Out
+    }
+    Stop-Job $j; Remove-Job $j -Force
+    return 'error'
 }
 
 # Availability = installed on PATH AND (for repl CLIs) a live probe. Returns

--- a/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-bi-ops/tests/Board-Work.Tests.ps1
@@ -432,6 +432,21 @@ Describe 'Get-CliProbeStatus' {
     It 'returns error on any other non-zero exit' {
         Get-CliProbeStatus -ExitCode 1 -Stderr "some unexpected failure" | Should -Be 'error'
     }
+    It 'catches quota error even on exit 0' {
+        Get-CliProbeStatus -ExitCode 0 -Stderr "quota exceeded" | Should -Be 'no-quota'
+    }
+    It 'catches auth error even on exit 0' {
+        Get-CliProbeStatus -ExitCode 0 -Stderr "not logged in" | Should -Be 'auth'
+    }
+}
+
+Describe 'Invoke-CliProbe timeout' {
+    It 'returns error when the command exceeds the timeout' {
+        Invoke-CliProbe @('pwsh', '-NoProfile', '-Command', 'Start-Sleep 5') -TimeoutSec 1 | Should -Be 'error'
+    }
+    It 'classifies a fast command' {
+        Invoke-CliProbe @('pwsh', '-NoProfile', '-Command', 'exit 0') | Should -Be 'ok'
+    }
 }
 
 Describe 'Test-CliAvailability' {
@@ -508,9 +523,17 @@ Describe 'non-claude adapters' {
         $s | Should -Match '--approval-mode yolo'
         $s | Should -Match '--skip-trust'
     }
-    It 'codex BuildLaunch uses exec + --dangerously-bypass-approvals-and-sandbox' {
+    It 'codex BuildLaunch uses exec + --dangerously-bypass-approvals-and-sandbox with an stdin EOF guard' {
         $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
-        (& ((Get-CliAdapters | Where-Object Name -eq 'codex').BuildLaunch) $ctx) | Should -Match 'codex exec .* --dangerously-bypass-approvals-and-sandbox'
+        $s = & ((Get-CliAdapters | Where-Object Name -eq 'codex').BuildLaunch) $ctx
+        $s | Should -Match '\$null \|.*codex exec .*--dangerously-bypass-approvals-and-sandbox'
+        $s | Should -Match 'Get-Content'
+    }
+    It 'codex Probe uses login status (not exec, which hangs on stdin)' {
+        ((Get-CliAdapters | Where-Object Name -eq 'codex').Probe).ToString() | Should -Match 'login.*status'
+    }
+    It 'jules Probe scopes to remote list --session' {
+        ((Get-CliAdapters | Where-Object Name -eq 'jules').Probe).ToString() | Should -Match 'remote.*list.*session'
     }
     It 'copilot BuildLaunch uses -p + --allow-all' {
         $ctx = @{ BriefingFile = 'C:\b\brief.txt' }


### PR DESCRIPTION
Closes #182

Closes #183
Closes #184
Closes #185
Closes #186

## board fleet - Phase 1.1 (probe hardening)

Fixes 3 bugs found by live-testing the shipped -Fleet against real CLIs:
- `Invoke-CliProbe` now runs each probe in a background job with a 30s timeout - a hung CLI can no longer block the availability phase forever.
- codex probe switched to `codex login status` (lightweight, ~3s; the old `codex exec "reply OK"` took 19.5s and read stdin); codex launch now pipes empty stdin (`$null | codex exec ...`) to avoid a TTY-wait hang.
- jules probe fixed to `jules remote list --session` (the old `jules remote list` returned exit 0 with "Must specify what to list" -> false 'ok').
- `Get-CliProbeStatus` now catches quota/auth errors even when a CLI wrongly exits 0.

### Live validation (after fix)
claude=ok, codex=ok, jules=ok, gemini=auth, copilot=auth - 3 usable CLIs, 2 correctly unavailable, no hangs, all bounded by the timeout.

88/88 Pester; claude launch output still byte-identical.