### PR TITLE
ux: two-tier command surface - hide internal skills from the / palette (commands = only entry points)

### DIFF
--- a/plugins/agentic-board/skills/abios-feedback/SKILL.md
+++ b/plugins/agentic-board/skills/abios-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: abios-feedback
 description: Use when, while working in ANY project (especially a PRIVATE one), you notice a bug or improvement for the agentic-board tool itself. Captures it as a SANITIZED issue on the tool's OWN public repo/board — never touching the current project and never leaking private data. Triggers — "mejora para la herramienta", "esto es una mejora para agentic-board", "abios bug", "esto deberíamos arreglarlo en el plugin", a guard block, a recurring gh/board failure.
+user-invocable: false
 ---
 
 # abios-feedback — improvements flow back, private data never leaks

--- a/plugins/agentic-board/skills/gh-account/SKILL.md
+++ b/plugins/agentic-board/skills/gh-account/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gh-account
 description: Use FIRST before any GitHub Projects/issues operation in the agentic-board suite. Resolves which account (default CSalcedoDataBI, override PAL-Devs) and reads its PAT from the Windows user registry, injecting GH_TOKEN per-invocation without touching `gh auth switch`. Triggers — any board/issue op, "cambia a CSalcedoDataBI", 403 on a PAL board, INSUFFICIENT_SCOPES/read:project.
+user-invocable: false
 ---
 
 # gh-account — Cross-Account GitHub Token Resolver

--- a/plugins/agentic-board/skills/knowledge-harvest/SKILL.md
+++ b/plugins/agentic-board/skills/knowledge-harvest/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: knowledge-harvest
 description: Use to sweep the CURRENT repo for knowledge references that are not yet catalogued — docs/*.md research files and http links in README/docs — and turn the chosen ones into registry entries by domain. The batch-capture companion to knowledge-registry, parallel to project-scan. Triggers — "cosecha las referencias", "escanea el repo por docs/links", "qué conocimiento no está registrado", "harvest knowledge", "/knowledge harvest".
+user-invocable: false
 ---
 
 # knowledge-harvest

--- a/plugins/agentic-board/skills/knowledge-registry/SKILL.md
+++ b/plugins/agentic-board/skills/knowledge-registry/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: knowledge-registry
 description: Use to capture and read a project's knowledge references by domain — add a research MD, repo, doc folder, URL, NotebookLM notebook or video to knowledge/registry.json, regenerate the KNOWLEDGE.md table, or publish it to the repo's GitHub Wiki. Distinct from MEMORY.md (agent facts) and HANDOFF.md (task resume). Triggers — "guarda esta referencia", "agrega a knowledge", "registra este link/doc/repo", "muéstrame la tabla de conocimiento", "publica el knowledge al wiki", "/knowledge add", "/knowledge list", "/knowledge gen", "/knowledge wiki".
+user-invocable: false
 ---
 
 # knowledge-registry

--- a/plugins/agentic-board/skills/project-scan/SKILL.md
+++ b/plugins/agentic-board/skills/project-scan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-scan
 description: Use to scan the CURRENT project for latent, hard-to-track work — code TODO/FIXME, unchecked checklists and "pending/next steps" in docs, and plan/spec docs not yet tracked — then convert the chosen items into issues + a work plan on THIS project's board. Triggers — "escanea el proyecto", "convierte los pendientes en issues", "harvest backlog", "qué hay sin trackear", "arma el plan de trabajo", /scan.
+user-invocable: false
 ---
 
 # project-scan — turn latent work into tracked issues/plan

--- a/plugins/agentic-board/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-board/skills/projects-admin/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: projects-admin
 description: Use to administer or automate a GitHub Projects (v2) board or its issues — create/configure a project, set Status/Priority/Target fields, add/move/bulk-edit items, link a board to a repo, install CI auto-add, run /board fill to detect and fix gaps, or /board work to see pending issues across boards and start one. Always resolves identity via gh-account (default CSalcedoDataBI). Triggers — "administra el board", "mueve a Done", "crea el project", "add to board", "bulk close", "automatiza el board", "llena el board", "qué hay pendiente", "qué issue trabajo", "empecemos un issue", /board.
+user-invocable: false
 ---
 
 # projects-admin — GitHub Projects (v2) Board & Issue Admin

--- a/plugins/agentic-board/skills/skills-audit/SKILL.md
+++ b/plugins/agentic-board/skills/skills-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skills-audit
 description: Use to evaluate Agent Skills and detect when one is failing — a static health audit (empty/first-person/over-budget descriptions, missing triggers, near-duplicates, misplaced) plus an on-demand runtime trigger-eval (run a realistic prompt with the skill enabled vs disabled, 3x, score false positives/negatives). Classifies failures (under-triggered, over-triggered, wrong output, ignored, obsolete) and, behind a human gate, files a SANITIZED issue to the repo that OWNS the skill — the tool's own board for its skills, the project's board for the project's own skills, local-only for third-party — never leaking the private project you are working in. Triggers — "audita mis skills", "esta skill no dispara/falla", "evalúa el triggering", "skill health check", "por qué no se activó la skill", /skills audit.
+user-invocable: false
 ---
 
 # skills-audit — detect skill failures, file them where they belong

--- a/plugins/agentic-board/skills/skills-bootstrap/SKILL.md
+++ b/plugins/agentic-board/skills/skills-bootstrap/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skills-bootstrap
 description: Use to install curated best-practice skills for authoring and evaluating skills (skill-creator, writing-skills, skill-improver, second-opinion) WITHOUT duplicating what is already installed. Detects the gap against the live inventory, recommends only what is missing, and clean-clones each from its source repo into ~/.claude/skills preserving the LICENSE/attribution. Use when setting up a machine for skill development, or when you want the recommended skill-quality toolkit. NOT for organizing or auditing existing skills — use skills-organize or skills-audit for that. Triggers — "instala las skills de buenas prácticas", "bootstrap skills", "qué skills de calidad me faltan", "setup skill toolkit", /skills bootstrap.
+user-invocable: false
 ---
 
 # skills-bootstrap — the recommended skill toolkit, no duplicates

--- a/plugins/agentic-board/skills/skills-organize/SKILL.md
+++ b/plugins/agentic-board/skills/skills-organize/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skills-organize
 description: Use to inventory and organize Agent Skills in a repo or monorepo — a read-only catalog + health report (description lint, near-duplicate detection, misplaced/orphaned skills) and a propose-then-confirm reorganize that moves scattered SKILL.md files into the canonical .claude/skills/<project>/<skill>/ layout with git mv (dry-run first, fully reversible) and writes a skills-index.json. Use when skills are scattered across a messy monorepo, when you want a catalog of what is installed, or before auditing skill quality. Triggers — "organiza mis skills", "cataloga las skills", "skills regadas/desordenadas", "skills health", "reorganiza el monorepo", "no mezclar skills", /skills organize.
+user-invocable: false
 ---
 
 # skills-organize — catalog, health, and repo layout for Agent Skills

--- a/plugins/agentic-board/skills/tmdl-review/SKILL.md
+++ b/plugins/agentic-board/skills/tmdl-review/SKILL.md
@@ -8,6 +8,7 @@ description: >
   Triggers — "revisa el diff TMDL", "breaking changes del modelo", "compara el
   modelo semántico", "¿este cambio rompe el modelo?", "review the TMDL diff",
   "detect breaking schema changes".
+user-invocable: false
 ---
 
 # tmdl-review — detect breaking semantic-model changes


### PR DESCRIPTION
Closes #204