### PR TITLE
feat(fleet): shared findings blackboard (Phase 3 P3-1)

### DIFF
--- a/plugins/agentic-board/scripts/Fleet-Findings.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Findings.ps1
@@ -1,0 +1,284 @@
+<#
+.SYNOPSIS
+    Fleet shared-findings blackboard (Phase 3, P3-1) - a shared brain for the /board
+    work parallel fleet.
+
+.DESCRIPTION
+    The parallel fleet (/board work -Parallel/-Launch) runs each issue in its own git
+    worktree. Today those sessions only AVOID collisions (claim + sessions.json); they
+    do not SHARE what they learn. This is the blackboard: a shared findings file each
+    worktree writes on progress/completion, so the next session reads prior findings
+    (files touched, decisions, gotchas) before starting and never re-derives them.
+
+    Like sessions.json, the store lives next to the MAIN clone's .git
+    (git rev-parse --git-common-dir) inside .agentic-bi-ops/fleet/findings.json, so
+    every worktree of the repo sees the same one. It is gitignored (state, not code).
+
+    Entries are UPSERTED by issue: a second write for the same issue unions its arrays
+    (filesTouched / decisions / gotchas / labels, de-duplicated) and refreshes the
+    scalar fields (status / pr / ts), never duplicating the row.
+
+    Same conventions as the rest of the plugin: pure-ASCII source, pure helpers behind
+    a dot-source guard ($env:ABIOS_FLEETFINDINGS_DOTSOURCE) for unit tests, no token
+    needed (findings never touch gh).
+
+.PARAMETER Add
+    Record (upsert) a finding for -Issue. Combine with -Files/-Decisions/-Gotchas/
+    -Labels/-Pr/-Status.
+
+.PARAMETER List
+    Read the blackboard. Narrow with -Issue / -Label / -Text; -Json for raw output.
+
+.PARAMETER Issue
+    With -Add: the issue the finding belongs to (required). With -List: filter to it.
+
+.PARAMETER Files
+    Files touched (comma-joined or a native array; the pwsh -File "a,b" case is split).
+
+.PARAMETER Decisions
+    Design/implementation decisions worth sharing (free text; one per token).
+
+.PARAMETER Gotchas
+    Pitfalls a sibling session should know before touching the same area.
+
+.PARAMETER Labels
+    Tags for retrieval by type (comma-joined or array).
+
+.PARAMETER Pr
+    The PR URL/number opened for the issue.
+
+.PARAMETER Status
+    in-progress (default) or done.
+
+.PARAMETER Label
+    With -List: keep only findings carrying this label (case-insensitive).
+
+.PARAMETER Text
+    With -List: keep only findings whose decisions/gotchas/files contain this text.
+
+.PARAMETER Json
+    With -List: emit raw JSON instead of the formatted view.
+
+.EXAMPLE
+    .\Fleet-Findings.ps1 -Add -Issue 239 -Files "scripts/Fleet-Findings.ps1" -Decisions "state lives next to main .git" -Status done -Pr "https://github.com/o/r/pull/1"
+    .\Fleet-Findings.ps1 -List
+    .\Fleet-Findings.ps1 -List -Issue 239
+    .\Fleet-Findings.ps1 -List -Text pagination -Json
+#>
+[CmdletBinding()]
+param(
+    [switch]$Add,
+    [switch]$List,
+    [int]$Issue = 0,
+    [string]$Repo = "",
+    [string]$Branch = "",
+    [string[]]$Files = @(),
+    [string[]]$Decisions = @(),
+    [string[]]$Gotchas = @(),
+    [string[]]$Labels = @(),
+    [string]$Pr = "",
+    [ValidateSet('in-progress','done')][string]$Status = 'in-progress',
+    [string]$Label = "",
+    [string]$Text = "",
+    [switch]$Json
+)
+$ErrorActionPreference = "Stop"
+
+# ------------------------------------------------------------------ pure helpers
+# Split comma-joined tokens into a de-duplicated, trimmed array. Mirrors
+# Get-ParallelQueue in Board-Work.ps1: `pwsh -File ... -Files "a,b"` arrives as the
+# single string "a,b", so every token is split on ',' as well as honoring a native
+# multi-element array. Pure -> unit-testable.
+function Split-CsvArg {
+    param([string[]]$Tokens)
+    $out = @()
+    foreach ($t in $Tokens) {
+        if ($null -eq $t) { continue }
+        foreach ($p in ($t -split ',')) {
+            $p = $p.Trim()
+            if ($p -eq '') { continue }
+            if ($out -notcontains $p) { $out += $p }
+        }
+    }
+    return $out
+}
+
+# Build one finding record. -Now is injected (not read from the clock) so the shape
+# is deterministic for tests; the CLI passes the current timestamp. Files/Labels are
+# comma-split; Decisions/Gotchas are free text (kept verbatim, empties dropped). Pure.
+function New-FleetFinding {
+    param(
+        [int]$Issue,
+        [string]$Repo = "",
+        [string]$Branch = "",
+        [string[]]$Files = @(),
+        [string[]]$Decisions = @(),
+        [string[]]$Gotchas = @(),
+        [string[]]$Labels = @(),
+        [string]$Pr = "",
+        [ValidateSet('in-progress','done')][string]$Status = 'in-progress',
+        [string]$HostName = "",
+        [string]$Now = ""
+    )
+    $keep = { param($a) @($a | Where-Object { $null -ne $_ -and "$_".Trim() -ne '' }) }
+    [pscustomobject]@{
+        issue        = $Issue
+        repo         = $Repo
+        branch       = $Branch
+        filesTouched = @(Split-CsvArg $Files)
+        decisions    = @(& $keep $Decisions)
+        gotchas      = @(& $keep $Gotchas)
+        labels       = @(Split-CsvArg $Labels)
+        pr           = $Pr
+        status       = $Status
+        host         = $HostName
+        ts           = $Now
+    }
+}
+
+# Union two arrays: existing first, then new, de-duplicated, empties dropped. Pure.
+function Join-FindingArray {
+    param($A, $B)
+    $out = @()
+    foreach ($x in (@($A) + @($B))) {
+        if ($null -ne $x -and "$x".Trim() -ne '' -and $out -notcontains $x) { $out += $x }
+    }
+    return $out
+}
+
+# Upsert $New into $Existing keyed by issue: a matching row unions its array fields
+# and refreshes non-empty scalars, keeping its position; otherwise $New is appended.
+# Returns a NEW array (does not mutate the input). Pure -> unit-testable.
+function Merge-FleetFinding {
+    param([object[]]$Existing, [object]$New)
+    $list = @($Existing | Where-Object { $null -ne $_ })
+    $idx = -1
+    for ($i = 0; $i -lt $list.Count; $i++) {
+        if ([int]$list[$i].issue -eq [int]$New.issue) { $idx = $i; break }
+    }
+    if ($idx -lt 0) { return @($list + $New) }
+    $cur = $list[$idx]
+    $merged = [pscustomobject]@{
+        issue        = [int]$cur.issue
+        repo         = if ($New.repo)   { $New.repo }   else { $cur.repo }
+        branch       = if ($New.branch) { $New.branch } else { $cur.branch }
+        filesTouched = @(Join-FindingArray $cur.filesTouched $New.filesTouched)
+        decisions    = @(Join-FindingArray $cur.decisions    $New.decisions)
+        gotchas      = @(Join-FindingArray $cur.gotchas      $New.gotchas)
+        labels       = @(Join-FindingArray $cur.labels       $New.labels)
+        pr           = if ($New.pr)     { $New.pr }     else { $cur.pr }
+        status       = if ($New.status) { $New.status } else { $cur.status }
+        host         = if ($New.host)   { $New.host }   else { $cur.host }
+        ts           = if ($New.ts)     { $New.ts }     else { $cur.ts }
+    }
+    $copy = @($list)
+    $copy[$idx] = $merged
+    return @($copy)
+}
+
+# Filter findings by issue / label (case-insensitive) / free text over the
+# decisions+gotchas+files of each entry. Filters AND together; none -> all. Pure.
+function Select-FleetFindings {
+    param([object[]]$All, [int]$Issue = 0, [string]$Label = "", [string]$Text = "")
+    $res = @($All | Where-Object { $null -ne $_ })
+    if ($Issue -gt 0) { $res = @($res | Where-Object { [int]$_.issue -eq $Issue }) }
+    if ($Label)       { $res = @($res | Where-Object { @($_.labels) -contains $Label }) }
+    if ($Text) {
+        $t = $Text.ToLower()
+        $res = @($res | Where-Object {
+            $hay = ((@($_.decisions) + @($_.gotchas) + @($_.filesTouched)) -join "`n").ToLower()
+            $hay.Contains($t)
+        })
+    }
+    return $res
+}
+
+# ------------------------------------------------------------- disk (side-effecting)
+# The blackboard path: .agentic-bi-ops/fleet/findings.json next to the MAIN clone's
+# .git, shared across every worktree of the repo. Returns $null outside a git repo.
+function Get-FleetFindingsPath {
+    $common = git rev-parse --git-common-dir 2>$null
+    if (-not $common) { return $null }
+    try { $root = Split-Path (Resolve-Path $common).Path -Parent } catch { return $null }
+    $dir = Join-Path (Join-Path $root ".agentic-bi-ops") "fleet"
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    return (Join-Path $dir "findings.json")
+}
+
+# Read all findings (empty array if missing/corrupt - a blackboard must never throw).
+# JSON deserializes single-element arrays as scalars, so array fields are re-wrapped.
+# -Path is injectable for tests; defaults to the resolved store.
+function Read-FleetFindings {
+    param([string]$Path)
+    if (-not $Path) { $Path = Get-FleetFindingsPath }
+    if (-not $Path -or -not (Test-Path $Path)) { return @() }
+    try { $data = @(Get-Content $Path -Raw | ConvertFrom-Json) } catch { return @() }
+    return @($data | Where-Object { $null -ne $_ } | ForEach-Object {
+        $_.filesTouched = @($_.filesTouched | Where-Object { $null -ne $_ })
+        $_.decisions    = @($_.decisions    | Where-Object { $null -ne $_ })
+        $_.gotchas      = @($_.gotchas      | Where-Object { $null -ne $_ })
+        $_.labels       = @($_.labels       | Where-Object { $null -ne $_ })
+        $_
+    })
+}
+
+# Upsert one finding into the store (read -> Merge -> write), always as a JSON array.
+function Write-FleetFinding {
+    param([string]$Path, [object]$Finding)
+    if (-not $Path) { $Path = Get-FleetFindingsPath }
+    if (-not $Path) { return }
+    $dir = Split-Path $Path -Parent
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    $merged = @(Merge-FleetFinding (Read-FleetFindings -Path $Path) $Finding)
+    $merged | ConvertTo-Json -Depth 6 -AsArray | Set-Content -Path $Path -Encoding UTF8
+}
+
+# Human-readable render of a set of findings.
+function Show-FleetFindings {
+    param([object[]]$Findings)
+    if (-not $Findings -or @($Findings).Count -eq 0) {
+        Write-Host "  (pizarra vacia)" -ForegroundColor DarkGray
+        return
+    }
+    foreach ($f in @($Findings | Sort-Object { [int]$_.issue })) {
+        Write-Host ("  #{0} [{1}] {2}" -f $f.issue, $f.status, $f.branch) -ForegroundColor Yellow
+        if (@($f.filesTouched).Count -gt 0) {
+            Write-Host ("      files: {0}" -f (@($f.filesTouched) -join ', ')) -ForegroundColor DarkGray
+        }
+        foreach ($d in @($f.decisions)) { Write-Host ("      + {0}" -f $d) -ForegroundColor Gray }
+        foreach ($g in @($f.gotchas))   { Write-Host ("      ! {0}" -f $g) -ForegroundColor DarkYellow }
+        if ($f.pr) { Write-Host ("      PR: {0}" -f $f.pr) -ForegroundColor DarkCyan }
+    }
+}
+
+# --- dot-source guard: stop here so unit tests get the pure helpers with no I/O -----
+if ($env:ABIOS_FLEETFINDINGS_DOTSOURCE) { return }
+
+# ------------------------------------------------------------------------ main entry
+if ($Add) {
+    if ($Issue -le 0) { throw "-Add requiere -Issue <n>." }
+    $now     = Get-Date -Format 'yyyy-MM-dd HH:mm'
+    $machine = "$env:COMPUTERNAME"
+    $finding = New-FleetFinding -Issue $Issue -Repo $Repo -Branch $Branch -Files $Files `
+                   -Decisions $Decisions -Gotchas $Gotchas -Labels $Labels -Pr $Pr `
+                   -Status $Status -HostName $machine -Now $now
+    Write-FleetFinding -Finding $finding
+    Write-Host ("  OK  Finding registrado en la pizarra para #{0} ({1})" -f $Issue, $Status) -ForegroundColor Green
+    $p = Get-FleetFindingsPath
+    if ($p) { Write-Host ("      {0}" -f $p) -ForegroundColor DarkGray }
+    return
+}
+
+if ($List) {
+    $all = Read-FleetFindings
+    $sel = @(Select-FleetFindings $all -Issue $Issue -Label $Label -Text $Text)
+    if ($Json) { $sel | ConvertTo-Json -Depth 6 -AsArray; return }
+    Write-Host "=== Pizarra de findings del fleet ===" -ForegroundColor Cyan
+    Show-FleetFindings $sel
+    Write-Host ("Total: {0} finding(s)." -f $sel.Count) -ForegroundColor Cyan
+    return
+}
+
+Write-Host "Uso:" -ForegroundColor DarkGray
+Write-Host "  Fleet-Findings.ps1 -Add -Issue <n> [-Files ..] [-Decisions ..] [-Gotchas ..] [-Labels ..] [-Pr ..] [-Status done]" -ForegroundColor DarkGray
+Write-Host "  Fleet-Findings.ps1 -List [-Issue <n>] [-Label <x>] [-Text <y>] [-Json]" -ForegroundColor DarkGray

--- a/plugins/agentic-board/tests/Fleet-Findings.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Findings.Tests.ps1
@@ -1,0 +1,158 @@
+#Requires -Modules Pester
+<#  Pester tests for Fleet-Findings.ps1 - the fleet shared-findings blackboard (P3-1).
+
+    Fleet-Findings.ps1 is a side-effecting command (disk + git + Write-Host), so it
+    exposes a dot-source guard: with $env:ABIOS_FLEETFINDINGS_DOTSOURCE set it returns
+    after defining every function WITHOUT reading args or touching disk/git. That lets
+    us unit-test the pure helpers (Split-CsvArg / New-FleetFinding / Merge-FleetFinding
+    / Select-FleetFindings) with zero side effects, and the disk round-trip against a
+    temp file via the -Path injection on Read-FleetFindings / Write-FleetFinding. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Fleet-Findings.ps1' | Resolve-Path
+    $env:ABIOS_FLEETFINDINGS_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FLEETFINDINGS_DOTSOURCE = ''
+}
+
+Describe 'Split-CsvArg (pwsh -File comma-joined arrays)' {
+    It 'splits a single comma-joined string' {
+        (Split-CsvArg 'a.ps1,b.ps1') | Should -Be @('a.ps1','b.ps1')
+    }
+    It 'trims whitespace around tokens' {
+        (Split-CsvArg 'a, b ,c') | Should -Be @('a','b','c')
+    }
+    It 'de-duplicates while preserving order' {
+        (Split-CsvArg 'a,b,a,c') | Should -Be @('a','b','c')
+    }
+    It 'drops empty tokens' {
+        (Split-CsvArg 'a,,b,') | Should -Be @('a','b')
+    }
+    It 'returns an empty array for empty input' {
+        @(Split-CsvArg @()).Count | Should -Be 0
+    }
+    It 'splits inside a native multi-element array too' {
+        (Split-CsvArg @('a','b,c')) | Should -Be @('a','b','c')
+    }
+}
+
+Describe 'New-FleetFinding' {
+    It 'builds a record with all given fields and a fixed timestamp' {
+        $f = New-FleetFinding -Issue 239 -Repo 'o/r' -Branch 'issue-239-x' -Files 'a.ps1' `
+                 -Decisions 'used JSON' -Gotchas 'watch pagination' -Labels 'fleet' `
+                 -Pr 'http://pr/1' -Status 'done' -HostName 'PC1' -Now '2026-07-10 12:00'
+        $f.issue        | Should -Be 239
+        $f.repo         | Should -Be 'o/r'
+        $f.branch       | Should -Be 'issue-239-x'
+        $f.filesTouched | Should -Be @('a.ps1')
+        $f.decisions    | Should -Be @('used JSON')
+        $f.gotchas      | Should -Be @('watch pagination')
+        $f.labels       | Should -Be @('fleet')
+        $f.pr           | Should -Be 'http://pr/1'
+        $f.status       | Should -Be 'done'
+        $f.host         | Should -Be 'PC1'
+        $f.ts           | Should -Be '2026-07-10 12:00'
+    }
+    It 'defaults status to in-progress' {
+        (New-FleetFinding -Issue 1 -Now 't').status | Should -Be 'in-progress'
+    }
+    It 'normalizes comma-joined files and labels into arrays' {
+        $f = New-FleetFinding -Issue 1 -Files 'a,b' -Labels 'x,y' -Now 't'
+        $f.filesTouched | Should -Be @('a','b')
+        $f.labels       | Should -Be @('x','y')
+    }
+}
+
+Describe 'Merge-FleetFinding (upsert by issue)' {
+    It 'appends a finding for a new issue' {
+        $a = @(New-FleetFinding -Issue 1 -Now 't')
+        $r = @(Merge-FleetFinding $a (New-FleetFinding -Issue 2 -Now 't'))
+        $r.Count | Should -Be 2
+        $r[1].issue | Should -Be 2
+    }
+    It 'unions and de-duplicates array fields for an existing issue' {
+        $a = @(New-FleetFinding -Issue 1 -Files 'a' -Decisions 'd1' -Now 't')
+        $r = @(Merge-FleetFinding $a (New-FleetFinding -Issue 1 -Files @('a','b') -Decisions 'd2' -Now 't2'))
+        $r.Count | Should -Be 1
+        $r[0].filesTouched | Should -Be @('a','b')
+        $r[0].decisions    | Should -Be @('d1','d2')
+    }
+    It 'updates scalar fields (status, pr, ts) when the new value is provided' {
+        $a = @(New-FleetFinding -Issue 1 -Status 'in-progress' -Now 't1')
+        $r = @(Merge-FleetFinding $a (New-FleetFinding -Issue 1 -Status 'done' -Pr 'http://pr/1' -Now 't2'))
+        $r[0].status | Should -Be 'done'
+        $r[0].pr     | Should -Be 'http://pr/1'
+        $r[0].ts     | Should -Be 't2'
+    }
+    It 'keeps the existing scalar when the new value is empty' {
+        $a = @(New-FleetFinding -Issue 1 -Repo 'o/r' -Now 't1')
+        $r = @(Merge-FleetFinding $a (New-FleetFinding -Issue 1 -Now 't2'))
+        $r[0].repo | Should -Be 'o/r'
+    }
+    It 'preserves the position of the upserted entry' {
+        $a = @( (New-FleetFinding -Issue 1 -Now 't'), (New-FleetFinding -Issue 2 -Now 't') )
+        $r = @(Merge-FleetFinding $a (New-FleetFinding -Issue 1 -Decisions 'new' -Now 't2'))
+        $r[0].issue | Should -Be 1
+        $r[1].issue | Should -Be 2
+        $r[0].decisions | Should -Be @('new')
+    }
+}
+
+Describe 'Select-FleetFindings (retrieval)' {
+    BeforeAll {
+        $script:All = @(
+            (New-FleetFinding -Issue 1 -Files 'auth.ps1' -Decisions 'used MSAL' -Labels 'auth' -Now 't'),
+            (New-FleetFinding -Issue 2 -Files 'board.ps1' -Gotchas 'pagination caps at 100' -Labels 'fleet' -Now 't')
+        )
+    }
+    It 'returns everything when no filter is given' {
+        @(Select-FleetFindings $All).Count | Should -Be 2
+    }
+    It 'filters by issue number' {
+        $r = @(Select-FleetFindings $All -Issue 2)
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 2
+    }
+    It 'filters by label, case-insensitive' {
+        $r = @(Select-FleetFindings $All -Label 'AUTH')
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 1
+    }
+    It 'filters by free text across decisions, gotchas and files (case-insensitive)' {
+        (@(Select-FleetFindings $All -Text 'pagination')[0]).issue | Should -Be 2
+        (@(Select-FleetFindings $All -Text 'msal')[0]).issue       | Should -Be 1
+        (@(Select-FleetFindings $All -Text 'board.ps1')[0]).issue  | Should -Be 2
+    }
+    It 'ANDs multiple filters' {
+        @(Select-FleetFindings $All -Issue 1 -Label 'fleet').Count | Should -Be 0
+    }
+}
+
+Describe 'Read/Write round-trip (disk, via -Path injection)' {
+    BeforeAll {
+        $script:Tmp  = Join-Path ([System.IO.Path]::GetTempPath()) ("fleet-find-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Force $script:Tmp | Out-Null
+        $script:File = Join-Path $script:Tmp 'findings.json'
+    }
+    AfterAll { Remove-Item -Recurse -Force $script:Tmp -ErrorAction SilentlyContinue }
+
+    It 'reads an empty array when the file does not exist' {
+        @(Read-FleetFindings -Path $script:File).Count | Should -Be 0
+    }
+    It 'writes then reads back a finding' {
+        Write-FleetFinding -Path $script:File -Finding (New-FleetFinding -Issue 7 -Decisions 'x' -Now 't')
+        $r = @(Read-FleetFindings -Path $script:File)
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 7
+    }
+    It 'upserts on a second write for the same issue (no duplicate, arrays union)' {
+        Write-FleetFinding -Path $script:File -Finding (New-FleetFinding -Issue 7 -Decisions 'y' -Now 't2')
+        $r = @(Read-FleetFindings -Path $script:File | Where-Object { $_.issue -eq 7 })
+        $r.Count | Should -Be 1
+        @($r[0].decisions) | Should -Be @('x','y')
+    }
+    It 'returns an empty array on a corrupt file instead of throwing' {
+        Set-Content -Path $script:File -Value '{ this is not valid json'
+        @(Read-FleetFindings -Path $script:File).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
Closes #239 · Part of #238 (Fleet Phase 3 — work coordination).

## What

`Fleet-Findings.ps1` — the fleet's **shared brain**. Today parallel `/board work` sessions only *avoid collisions* (claim + `sessions.json`); they don't *share what they learn*. This adds the blackboard: each worktree records findings (files touched, decisions, gotchas) and the next session reads them before starting, so nothing gets re-derived.

## Design

- **Location:** `.agentic-bi-ops/fleet/findings.json`, next to the **main clone's** `.git` (`git rev-parse --git-common-dir`) — the exact pattern `sessions.json` uses, so every worktree of the repo sees one shared store. Gitignored (state, not code).
- **Upsert by issue:** a second write for the same issue **unions** its arrays (files/decisions/gotchas/labels, de-duplicated) and refreshes scalars (status/pr/ts) — never a duplicate row.
- **Never throws:** missing or corrupt file → empty array. A blackboard must not break the fleet.

## API

Pure helpers behind a dot-source guard (`ABIOS_FLEETFINDINGS_DOTSOURCE`), so they unit-test with zero I/O:
`Split-CsvArg`, `New-FleetFinding`, `Merge-FleetFinding`, `Select-FleetFindings`. Disk layer (`Read`/`Write-FleetFinding`) takes an injectable `-Path`.

CLI:
```
Fleet-Findings.ps1 -Add -Issue 239 -Files a.ps1 -Decisions "..." -Gotchas "..." -Status done -Pr <url>
Fleet-Findings.ps1 -List [-Issue n] [-Label x] [-Text y] [-Json]
```

## Tests

- **23 Pester tests** (Split/New/Merge/Select + disk round-trip incl. corrupt-file + upsert).
- Watched them fail first (TDD), then green.
- **Full plugin suite: 236/236 green** (no regressions).
- Smoke-tested the real CLI end-to-end (add → upsert → list/filter/json); fixed a double-nested `-Json` bug found there.

## Scope note (for review)

This PR is the **store + API + CLI** only. Wiring the fleet **briefing** to auto-write a finding on completion and auto-read the board before starting is the natural next connection — it belongs with the planner (#240) / hand-off (#242), which orchestrate the sessions. Kept separate to keep this foundational piece small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)