### PR TITLE
fix(board): paginate project-item lookups (issue #246)

### DIFF
--- a/plugins/agentic-board/scripts/Board-Changelog.ps1
+++ b/plugins/agentic-board/scripts/Board-Changelog.ps1
@@ -116,13 +116,18 @@ if (-not $Version) {
     if (-not $Version) { $Version = "0.0.0" }
 }
 
-# ── Read board items (issue content + Type single-select) ─────────────────────
-$data = gh api graphql -f query='
-query($owner:String!, $num:Int!) {
-  user(login:$owner) {
-    projectV2(number:$num) {
+# ── Read board items, paginated (issue #246: items(first:100) alone skipped issues
+#    on boards >100 items, so the changelog silently missed recent entries) ───────
+$nodes = @(); $cursor = $null
+do {
+    $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+    $q = @"
+query(`$owner:String!, `$num:Int!) {
+  user(login:`$owner) {
+    projectV2(number:`$num) {
       id
-      items(first:100) {
+      items(first:100 $after) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           fieldValues(first:20) {
             nodes {
@@ -143,12 +148,17 @@ query($owner:String!, $num:Int!) {
       }
     }
   }
-}' -F "owner=$Owner" -F "num=$ProjectNum" | ConvertFrom-Json
-
-if (-not $data.data.user.projectV2.id) {
-    throw "No pude resolver el board #$ProjectNum de $Owner (revisa cuenta / scope 'project')."
 }
-$nodes = $data.data.user.projectV2.items.nodes
+"@
+    $data = gh api graphql -f query=$q -F "owner=$Owner" -F "num=$ProjectNum" | ConvertFrom-Json
+    $pv = $data.data.user.projectV2
+    if (-not $pv.id) {
+        throw "No pude resolver el board #$ProjectNum de $Owner (revisa cuenta / scope 'project')."
+    }
+    $nodes += @($pv.items.nodes)
+    $cursor = $pv.items.pageInfo.endCursor
+    $more   = $pv.items.pageInfo.hasNextPage
+} while ($more)
 
 # ── Select + bucket ───────────────────────────────────────────────────────────
 $sections = [ordered]@{ Added = @(); Changed = @(); Fixed = @() }

--- a/plugins/agentic-board/scripts/Board-Fill.ps1
+++ b/plugins/agentic-board/scripts/Board-Fill.ps1
@@ -129,12 +129,32 @@ query($owner:String!, $num:Int!) {
 function Get-Field($name) { $allFields | Where-Object { $_.name -eq $name } }
 function Get-Opt($field, $optName) { ($field.options | Where-Object { $_.name -eq $optName }).id }
 
+# Accumulate all nodes across GraphQL project-item pages (issue #246: without this the
+# scan stopped at items(first:100) and silently skipped issues on boards >100 items).
+# Pure w.r.t. its injected fetcher -> unit-testable with a fake page source.
+function Get-AllPages {
+    param([scriptblock]$FetchPage)
+    $all = @(); $cursor = $null
+    do {
+        $page = & $FetchPage $cursor
+        if (-not $page) { break }
+        $all += @($page.nodes)
+        $cursor = $page.endCursor
+        $more   = [bool]$page.hasNext
+    } while ($more)
+    return $all
+}
+
 function Get-BoardItems($projId) {
-    $data = gh api graphql -f query='
-query($proj:ID!) {
-  node(id:$proj) {
+    return Get-AllPages {
+        param($cursor)
+        $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+        $q = @"
+query(`$proj:ID!) {
+  node(id:`$proj) {
     ... on ProjectV2 {
-      items(first:100) {
+      items(first:100 $after) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           fieldValues(first:20) {
@@ -166,8 +186,11 @@ query($proj:ID!) {
       }
     }
   }
-}' -F "proj=$projId" | ConvertFrom-Json
-    return $data.data.node.items.nodes
+}
+"@
+        $items = (gh api graphql -f query=$q -F "proj=$projId" | ConvertFrom-Json).data.node.items
+        return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
+    }
 }
 
 # Dot-source guard: tests set this to load the functions above without running

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -336,14 +336,38 @@ query($owner:String!, $num:Int!) {
     return [PSCustomObject]@{ projectId = $projectId; statusNode = $statusNode; inProgId = $inProgId }
 }
 
-# Find the board item for an issue number, with one retry (eventual consistency).
+# Accumulate all nodes across GraphQL project-item pages. $FetchPage is called with a
+# cursor ($null on the first call) and must return @{ nodes; hasNext; endCursor } for
+# that page. Pure w.r.t. its injected fetcher -> unit-testable with a fake page source.
+# Fixes #246: board lookups used items(first:100) with no pagination, so issues past
+# the first 100 board items were invisible (a 148-item board hid the newest issues, and
+# -Start/-ToReview/-Parallel/-Fleet all failed on them via Get-BoardItem).
+function Get-AllPages {
+    param([scriptblock]$FetchPage)
+    $all = @(); $cursor = $null
+    do {
+        $page = & $FetchPage $cursor
+        if (-not $page) { break }
+        $all += @($page.nodes)
+        $cursor = $page.endCursor
+        $more   = [bool]$page.hasNext
+    } while ($more)
+    return $all
+}
+
+# Find the board item for an issue number, paginating the WHOLE board (issue #246) with
+# one retry for GitHub eventual consistency. $projectId is closed over by the fetcher.
 function Get-BoardItem([string]$projectId, [int]$issueNum) {
     foreach ($attempt in 1..2) {
-        $itemsData = gh api graphql -f query='
-query($proj:ID!) {
-  node(id:$proj) {
+        $nodes = Get-AllPages {
+            param($cursor)
+            $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+            $q = @"
+query(`$proj:ID!) {
+  node(id:`$proj) {
     ... on ProjectV2 {
-      items(first:100) {
+      items(first:100 $after) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           fieldValues(first:20) {
@@ -366,9 +390,12 @@ query($proj:ID!) {
       }
     }
   }
-}' -F "proj=$projectId" | ConvertFrom-Json
-
-        $item = $itemsData.data.node.items.nodes |
+}
+"@
+            $items = (gh api graphql -f query=$q -F "proj=$projectId" | ConvertFrom-Json).data.node.items
+            return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
+        }
+        $item = $nodes |
                 Where-Object { $_.content.__typename -eq "Issue" -and $_.content.number -eq $issueNum } |
                 Select-Object -First 1
         if ($item) { return $item }
@@ -1210,22 +1237,9 @@ query($owner:String!, $num:Int!) {
         throw "El board #$ProjectNum no tiene la opcion 'In Review' en Status. Agregala (/board field) antes de usar -ToReview."
     }
 
-    # Find the item (one retry for GitHub eventual consistency, like -Start).
-    $item = $null
-    foreach ($attempt in 1..2) {
-        $itemsData = gh api graphql -f query='
-query($proj:ID!) {
-  node(id:$proj) {
-    ... on ProjectV2 {
-      items(first:100) { nodes { id content { __typename ... on Issue { number title } } } } }
-  }
-}' -F "proj=$projectId" | ConvertFrom-Json
-        $item = $itemsData.data.node.items.nodes |
-                Where-Object { $_.content.__typename -eq "Issue" -and $_.content.number -eq $ToReview } |
-                Select-Object -First 1
-        if ($item) { break }
-        if ($attempt -eq 1) { Start-Sleep -Seconds 3 }
-    }
+    # Find the item by reusing Get-BoardItem, which paginates the whole board (#246)
+    # and retries for eventual consistency - no separate capped query here.
+    $item = Get-BoardItem $projectId $ToReview
     if (-not $item) { throw "Issue #$ToReview no esta en el board #$ProjectNum." }
 
     if ($DryRun) {

--- a/plugins/agentic-board/tests/Board-Fill.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Fill.Tests.ps1
@@ -28,6 +28,23 @@ Describe 'Get-OwnerRoot (owner-type -> GraphQL root, issue #86)' {
     }
 }
 
+Describe 'Get-AllPages (board pagination - issue #246)' {
+    It 'concatenates nodes across pages and stops when hasNext is false' {
+        $script:calls = 0
+        $fetch = {
+            param($cursor)
+            $script:calls++
+            if ($script:calls -eq 1) { @{ nodes = @(1,2); hasNext = $true;  endCursor = 'c1' } }
+            else                     { @{ nodes = @(3);   hasNext = $false; endCursor = $null } }
+        }
+        (Get-AllPages $fetch) | Should -Be @(1,2,3)
+        $script:calls | Should -Be 2
+    }
+    It 'returns an empty array for a single empty page' {
+        @(Get-AllPages { param($c) @{ nodes = @(); hasNext = $false; endCursor = $null } }).Count | Should -Be 0
+    }
+}
+
 Describe 'Get-OwnerUrlSegment (projects URL segment)' {
     It 'uses /orgs/ for an organization' {
         Get-OwnerUrlSegment -OwnerType 'Organization' | Should -Be 'orgs'

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -551,3 +551,44 @@ Describe 'non-claude adapters' {
         (& ((Get-CliAdapters | Where-Object Name -eq 'gemini').BuildLaunch) $ctx) | Should -Match "O''Brien"
     }
 }
+
+Describe 'Get-AllPages (board pagination - issue #246)' {
+    It 'concatenates nodes across pages and stops when hasNext is false' {
+        $script:calls = 0
+        $fetch = {
+            param($cursor)
+            $script:calls++
+            if ($script:calls -eq 1) { @{ nodes = @(1,2); hasNext = $true;  endCursor = 'c1' } }
+            else                     { @{ nodes = @(3);   hasNext = $false; endCursor = $null } }
+        }
+        (Get-AllPages $fetch) | Should -Be @(1,2,3)
+        $script:calls | Should -Be 2
+    }
+    It 'threads each page endCursor into the next fetch (first cursor is empty)' {
+        $script:seen = @()
+        $fetch = {
+            param($cursor)
+            $script:seen += "$cursor"
+            if (-not $cursor) { @{ nodes = @('a'); hasNext = $true;  endCursor = 'NEXT' } }
+            else              { @{ nodes = @('b'); hasNext = $false; endCursor = $null } }
+        }
+        Get-AllPages $fetch | Out-Null
+        $script:seen[0] | Should -Be ''
+        $script:seen[1] | Should -Be 'NEXT'
+    }
+    It 'returns an empty array for a single empty page' {
+        @(Get-AllPages { param($c) @{ nodes = @(); hasNext = $false; endCursor = $null } }).Count | Should -Be 0
+    }
+    It 'finds an issue that only appears on the SECOND page (the #246 regression)' {
+        $fetch = {
+            param($cursor)
+            if (-not $cursor) {
+                @{ nodes = @([pscustomobject]@{ content = [pscustomobject]@{ __typename='Issue'; number=1 } }); hasNext = $true; endCursor = 'p2' }
+            } else {
+                @{ nodes = @([pscustomobject]@{ content = [pscustomobject]@{ __typename='Issue'; number=239 } }); hasNext = $false; endCursor = $null }
+            }
+        }
+        $all = @(Get-AllPages $fetch)
+        ($all | Where-Object { $_.content.number -eq 239 }).Count | Should -Be 1
+    }
+}


### PR DESCRIPTION
Closes #246.

## Bug

Board item lookups used `items(first:100)` with **no pagination**, so on a board with more than 100 items the newest issues were invisible. Board #13 already has **148 items**, so:
- `Board-Work -Start/-ToReview/-Parallel/-Fleet` threw `"Issue #N no esta en el board"` for any recent issue (resolved via `Get-BoardItem`) — **this blocked the whole Phase 3 fleet path.**
- `Board-Fill` and `Board-Changelog` silently skipped items past the first 100.

Found while moving #239 to In Review during Phase 3 work.

## Fix

- **`Get-AllPages`** — a pure, testable accumulator that walks GraphQL pages via an injected page fetcher (`@{ nodes; hasNext; endCursor }`). Added to `Board-Work.ps1` and `Board-Fill.ps1`.
- `Get-BoardItem` (Board-Work) and `Get-BoardItems` (Board-Fill) now paginate through it.
- **`-ToReview` reuses `Get-BoardItem`** instead of its own capped query (one lookup path, DRY).
- `Board-Changelog` paginates its inline board scan.

## Verification

- **TDD**: `Get-AllPages` tests (multi-page concat, cursor threading, and a "finds an issue only on page 2" regression test) in the Board-Work **and** Board-Fill suites — watched fail, then green.
- **Full suite: 219/219 green** (no regressions).
- **Live smoke test**: `Board-Work -ProjectNum 13 -ToReview 240 -DryRun` now resolves #240 (item >100), which previously threw "no esta en el board".

## Note

`Get-AllPages` is duplicated across the two standalone scripts (no shared module in this plugin — same pattern as other per-script helpers). Board-Changelog uses an inline paginated loop (the script has no dot-source test harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)