### PR TITLE
docs(board-sync): document minimal PAT scopes (public_repo + project)

### DIFF
--- a/scripts/board-sync.sh
+++ b/scripts/board-sync.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # board-sync.sh — Auto-fill all gaps in a GitHub Projects v2 board.
 # Runs on: issue events, PR events, weekly schedule, manual dispatch.
-# Requires: GH_TOKEN with 'project' + 'repo' scopes (PROJECTS_TOKEN secret).
+# Requires: GH_TOKEN = classic PAT (PROJECTS_TOKEN secret) with minimal scopes:
+#   - 'project'      → read/write the user-owned Project v2 (issues assign + Status field)
+#   - 'public_repo'  → write to this PUBLIC repo's issues (do NOT use full 'repo')
+# Fine-grained PATs can't manage user-owned Projects v2, so a classic PAT is required.
+# 'public_repo' (not 'repo') keeps private repos out of the blast radius if the secret leaks.
+# If this ever syncs a PRIVATE repo, swap 'public_repo' for full 'repo' — but never store
+# such a token as a secret in a public repo.
 set -euo pipefail
 
 OWNER="${REPO_OWNER:-CSalcedoDataBI}"


### PR DESCRIPTION
## What
Updates the header comment in `scripts/board-sync.sh` to document the **minimal** classic PAT scopes required for the `PROJECTS_TOKEN` secret.

## Why
The old comment said `'project' + 'repo'` scopes, which documents an over-broad token. In practice:

- **`project`** — required to read/write the user-owned Project v2 (fine-grained PATs can't manage user-owned Projects v2, so a classic PAT is mandatory).
- **`public_repo`** (not full `repo`) — enough to assign issues on this **public** repo, and it keeps private repos **out of the blast radius** if the public-repo secret ever leaks.

Note added: if this workflow is ever pointed at a *private* repo it would need full `repo`, but such a token must never live as a secret in a public repo.

No behavior change — comment/documentation only.