### PR TITLE
feat(fleet): file-ownership guard (Phase 3 P3-3)

### DIFF
--- a/plugins/agentic-board/scripts/Fleet-Ownership.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Ownership.ps1
@@ -1,0 +1,278 @@
+<#
+.SYNOPSIS
+    Fleet file-ownership guard (Phase 3, P3-3) - "one owner per file" for the parallel
+    /board work fleet.
+
+.DESCRIPTION
+    Parallel worktrees can edit the same files and collide at merge time. This guard lets
+    each fleet session DECLARE the paths it will own for its issue, into a shared registry
+    next to the MAIN clone's .git (.agentic-bi-ops/fleet/ownership.json, shared across
+    worktrees), and warns when a new claim would OVERLAP paths another live session already
+    owns. Overlap is boundary-aware: owning a directory ('scripts') conflicts with a file
+    inside it ('scripts/Foo.ps1') but not with a look-alike sibling ('scriptsfoo/Bar.ps1').
+
+    Dead sessions release their paths automatically: every read prunes claims whose
+    sessionPid is no longer a live process (a pid of 0/unknown is kept). Like sessions.json,
+    identity is the long-lived PARENT of this script (the host session), not the transient
+    script PID.
+
+    Same conventions as Fleet-Findings.ps1: pure-ASCII source, pure helpers behind a
+    dot-source guard ($env:ABIOS_FLEETOWNERSHIP_DOTSOURCE) for unit tests, no gh/token.
+
+.PARAMETER Claim
+    Declare ownership of -Paths for -Issue (warns on overlap, then records the claim).
+
+.PARAMETER Check
+    Dry check: report overlaps for -Paths without recording. Exit 1 if any overlap, else 0
+    (so a session can gate on it before starting).
+
+.PARAMETER List
+    Show the live ownership registry (dead-PID claims pruned).
+
+.PARAMETER Release
+    Remove -Issue's claim (call when the issue's PR merges).
+
+.PARAMETER Issue
+    The issue whose session owns the paths.
+
+.PARAMETER Branch
+    The work branch (informational, shown in conflict reports).
+
+.PARAMETER Paths
+    Files/dirs to own (comma-joined or a native array; the pwsh -File "a,b" case is split).
+
+.PARAMETER Json
+    With -List: emit raw JSON.
+
+.EXAMPLE
+    .\Fleet-Ownership.ps1 -Check  -Issue 241 -Paths "plugins/agentic-board/scripts/Board-Work.ps1"
+    .\Fleet-Ownership.ps1 -Claim  -Issue 241 -Branch issue-241-x -Paths "scripts/A.ps1,scripts/B.ps1"
+    .\Fleet-Ownership.ps1 -List
+    .\Fleet-Ownership.ps1 -Release -Issue 241
+#>
+[CmdletBinding()]
+param(
+    [switch]$Claim,
+    [switch]$Check,
+    [switch]$List,
+    [switch]$Release,
+    [int]$Issue = 0,
+    [string]$Branch = "",
+    [string[]]$Paths = @(),
+    [switch]$Json
+)
+$ErrorActionPreference = "Stop"
+
+# ------------------------------------------------------------------ pure helpers
+# Normalize a path for comparison: forward slashes, no leading ./, no trailing /,
+# lowercased (Windows paths are case-insensitive). Pure -> unit-testable.
+function ConvertTo-NormPath {
+    param([string]$Path)
+    if (-not $Path) { return '' }
+    $p = ($Path -replace '\\', '/') -replace '^\./', ''
+    return $p.TrimEnd('/').ToLower()
+}
+
+# Do two paths overlap? Identical, or one is a directory-prefix of the other at a path
+# boundary ('src' overlaps 'src/x' but NOT 'srcfoo/x'). Pure -> unit-testable.
+function Test-PathOverlap {
+    param([string]$A, [string]$B)
+    $a = ConvertTo-NormPath $A
+    $b = ConvertTo-NormPath $B
+    if ($a -eq $b -and $a -ne '') { return $true }
+    if ($a -and $b) {
+        if ($b.StartsWith("$a/") -or $a.StartsWith("$b/")) { return $true }
+    }
+    return $false
+}
+
+# Build an ownership claim with normalized, de-duplicated, comma-split paths. Pure.
+function New-Ownership {
+    param(
+        [int]$Issue,
+        [string]$Branch = "",
+        [string[]]$Paths = @(),
+        [int]$SessionPid = 0,
+        [string]$HostName = "",
+        [string]$Now = ""
+    )
+    $norm = @()
+    foreach ($t in $Paths) {
+        if ($null -eq $t) { continue }
+        foreach ($part in ($t -split ',')) {
+            $part = $part.Trim()
+            if ($part -eq '') { continue }
+            $n = ConvertTo-NormPath $part
+            if ($n -ne '' -and $norm -notcontains $n) { $norm += $n }
+        }
+    }
+    [pscustomobject]@{
+        issue      = $Issue
+        branch     = $Branch
+        paths      = @($norm)
+        sessionPid = $SessionPid
+        host       = $HostName
+        ts         = $Now
+    }
+}
+
+# Conflicts for $NewClaim against $Existing: every OTHER issue whose owned paths overlap
+# the new claim's paths, each with the list of overlapping (existing) paths. Pure.
+function Find-OwnershipConflicts {
+    param([object[]]$Existing, [object]$NewClaim)
+    $out = @()
+    foreach ($e in @($Existing | Where-Object { $null -ne $_ })) {
+        if ([int]$e.issue -eq [int]$NewClaim.issue) { continue }
+        $overlap = @()
+        foreach ($np in @($NewClaim.paths)) {
+            foreach ($ep in @($e.paths)) {
+                if ((Test-PathOverlap $np $ep) -and ($overlap -notcontains $ep)) { $overlap += $ep }
+            }
+        }
+        if ($overlap.Count -gt 0) {
+            $out += [pscustomobject]@{ issue = [int]$e.issue; branch = $e.branch; paths = @($overlap) }
+        }
+    }
+    return $out
+}
+
+# Drop claims whose sessionPid is a dead process. A pid <= 0 (unknown) is KEPT - we can't
+# prove it dead. $IsAlive is injected (a pid -> bool predicate) so this stays pure/testable.
+function Remove-DeadClaims {
+    param([object[]]$Claims, [scriptblock]$IsAlive)
+    return @($Claims | Where-Object {
+        $null -ne $_ -and ( [int]$_.sessionPid -le 0 -or (& $IsAlive ([int]$_.sessionPid)) )
+    })
+}
+
+# ------------------------------------------------------------- disk (side-effecting)
+# ownership.json next to the MAIN clone's .git, shared across every worktree.
+function Get-FleetOwnershipPath {
+    $common = git rev-parse --git-common-dir 2>$null
+    if (-not $common) { return $null }
+    try { $root = Split-Path (Resolve-Path $common).Path -Parent } catch { return $null }
+    $dir = Join-Path (Join-Path $root ".agentic-bi-ops") "fleet"
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    return (Join-Path $dir "ownership.json")
+}
+
+# Read all claims (empty on missing/corrupt - a guard must never throw). -Path injectable.
+function Read-Ownership {
+    param([string]$Path)
+    if (-not $Path) { $Path = Get-FleetOwnershipPath }
+    if (-not $Path -or -not (Test-Path $Path)) { return @() }
+    try { $data = @(Get-Content $Path -Raw | ConvertFrom-Json) } catch { return @() }
+    return @($data | Where-Object { $null -ne $_ } | ForEach-Object {
+        $_.paths = @($_.paths | Where-Object { $null -ne $_ })
+        $_
+    })
+}
+
+# Upsert a claim by issue (a re-claim REPLACES that issue's paths - ownership is current,
+# not cumulative), written as a JSON array.
+function Write-Ownership {
+    param([string]$Path, [object]$Claim)
+    if (-not $Path) { $Path = Get-FleetOwnershipPath }
+    if (-not $Path) { return }
+    $dir = Split-Path $Path -Parent
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    $others = @(Read-Ownership -Path $Path | Where-Object { [int]$_.issue -ne [int]$Claim.issue })
+    Set-Content -Path $Path -Value (ConvertTo-OwnershipJson @($others + $Claim)) -Encoding UTF8
+}
+
+# Serialize a claim array to a JSON string, always an array even when empty (an empty
+# pipeline into ConvertTo-Json emits nothing, which would leave Set-Content a no-op and
+# fail to clear the file - so force "[]").
+function ConvertTo-OwnershipJson {
+    param([object[]]$Claims)
+    if (@($Claims).Count -eq 0) { return '[]' }
+    return ($Claims | ConvertTo-Json -Depth 6 -AsArray)
+}
+
+# Release an issue's claim.
+function Remove-OwnershipClaim {
+    param([string]$Path, [int]$Issue)
+    if (-not $Path) { $Path = Get-FleetOwnershipPath }
+    if (-not $Path -or -not (Test-Path $Path)) { return }
+    $kept = @(Read-Ownership -Path $Path | Where-Object { [int]$_.issue -ne $Issue })
+    Set-Content -Path $Path -Value (ConvertTo-OwnershipJson $kept) -Encoding UTF8
+}
+
+# Human-readable render of the live claims.
+function Show-Ownership {
+    param([object[]]$Claims)
+    if (-not $Claims -or @($Claims).Count -eq 0) {
+        Write-Host "  (sin claims de propiedad)" -ForegroundColor DarkGray
+        return
+    }
+    foreach ($c in @($Claims | Sort-Object { [int]$_.issue })) {
+        Write-Host ("  #{0} {1} (pid {2})" -f $c.issue, $c.branch, $c.sessionPid) -ForegroundColor Yellow
+        foreach ($p in @($c.paths)) { Write-Host ("      - {0}" -f $p) -ForegroundColor DarkGray }
+    }
+}
+
+# --- dot-source guard: stop here so unit tests get the pure helpers with no I/O -----
+if ($env:ABIOS_FLEETOWNERSHIP_DOTSOURCE) { return }
+
+# ------------------------------------------------------------------------ main entry
+$path    = Get-FleetOwnershipPath
+$machine = "$env:COMPUTERNAME"
+$alive   = { param($processId) [bool](Get-Process -Id $processId -ErrorAction SilentlyContinue) }
+
+# Prune dead-PID claims on every entry (a crashed session releases its paths).
+$existing = @(Read-Ownership -Path $path)
+$live     = @(Remove-DeadClaims $existing $alive)
+if ($path -and $live.Count -ne $existing.Count) {
+    Set-Content -Path $path -Value (ConvertTo-OwnershipJson $live) -Encoding UTF8
+}
+
+if ($List) {
+    if ($Json) { $live | ConvertTo-Json -Depth 6 -AsArray; return }
+    Write-Host "=== Propiedad de archivos del fleet ===" -ForegroundColor Cyan
+    Show-Ownership $live
+    Write-Host ("Total: {0} claim(s) viva(s)." -f @($live).Count) -ForegroundColor Cyan
+    return
+}
+
+if ($Issue -le 0) { throw "Especifica -Issue <n> (o usa -List)." }
+
+if ($Release) {
+    Remove-OwnershipClaim -Path $path -Issue $Issue
+    Write-Host ("  OK  Claim de #{0} liberado." -f $Issue) -ForegroundColor Green
+    return
+}
+
+# -Claim / -Check both build a prospective claim keyed to the long-lived session PID.
+# NOTE: not named $claim - PowerShell vars are case-insensitive, so $claim would alias
+# the [switch]$Claim parameter and fail to hold a PSCustomObject (type-constrained).
+$trackPid = 0
+try { $trackPid = (Get-CimInstance Win32_Process -Filter "ProcessId=$PID" -ErrorAction Stop).ParentProcessId } catch { }
+$prospect  = New-Ownership -Issue $Issue -Branch $Branch -Paths $Paths -SessionPid $trackPid -HostName $machine -Now (Get-Date -Format 'yyyy-MM-dd HH:mm')
+$conflicts = @(Find-OwnershipConflicts $live $prospect)
+
+if ($conflicts.Count -gt 0) {
+    Write-Host ("  WARN #{0} solaparia archivos con otra(s) sesion(es):" -f $Issue) -ForegroundColor Yellow
+    foreach ($c in $conflicts) {
+        Write-Host ("      #{0} ({1}) ya reclamo: {2}" -f $c.issue, $c.branch, (@($c.paths) -join ', ')) -ForegroundColor Red
+    }
+} else {
+    Write-Host ("  OK  #{0}: sin solapamiento con otras sesiones." -f $Issue) -ForegroundColor Green
+}
+
+if ($Check) {
+    if ($conflicts.Count -gt 0) { exit 1 } else { exit 0 }
+}
+
+if ($Claim) {
+    if (-not $Paths -or @($Paths).Count -eq 0) { throw "-Claim requiere -Paths <archivos>." }
+    Write-Ownership -Path $path -Claim $prospect
+    Write-Host ("  OK  #{0} reclamo {1} archivo(s) en la registry." -f $Issue, @($prospect.paths).Count) -ForegroundColor Green
+    if ($path) { Write-Host ("      {0}" -f $path) -ForegroundColor DarkGray }
+    return
+}
+
+Write-Host "Uso:" -ForegroundColor DarkGray
+Write-Host "  Fleet-Ownership.ps1 -Claim  -Issue <n> -Paths <a,b> [-Branch <x>]" -ForegroundColor DarkGray
+Write-Host "  Fleet-Ownership.ps1 -Check  -Issue <n> -Paths <a,b>   (exit 1 si hay conflicto)" -ForegroundColor DarkGray
+Write-Host "  Fleet-Ownership.ps1 -List [-Json]" -ForegroundColor DarkGray
+Write-Host "  Fleet-Ownership.ps1 -Release -Issue <n>" -ForegroundColor DarkGray

--- a/plugins/agentic-board/tests/Fleet-Ownership.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Ownership.Tests.ps1
@@ -1,0 +1,134 @@
+#Requires -Modules Pester
+<#  Pester tests for Fleet-Ownership.ps1 - the fleet file-ownership guard (P3-3,
+    "one owner per file"). Side-effecting (disk + git + process liveness), so it
+    exposes a dot-source guard ($env:ABIOS_FLEETOWNERSHIP_DOTSOURCE) to unit-test the
+    pure helpers (path normalization, overlap, conflict detection, dead-claim prune)
+    with zero I/O, plus a disk round-trip via -Path injection. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Fleet-Ownership.ps1' | Resolve-Path
+    $env:ABIOS_FLEETOWNERSHIP_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FLEETOWNERSHIP_DOTSOURCE = ''
+}
+
+Describe 'ConvertTo-NormPath' {
+    It 'converts backslashes to forward slashes' {
+        ConvertTo-NormPath 'a\b\c.ps1' | Should -Be 'a/b/c.ps1'
+    }
+    It 'trims a leading ./ and a trailing slash' {
+        ConvertTo-NormPath './a/b/' | Should -Be 'a/b'
+    }
+    It 'lowercases for case-insensitive comparison' {
+        ConvertTo-NormPath 'Scripts/Foo.PS1' | Should -Be 'scripts/foo.ps1'
+    }
+}
+
+Describe 'Test-PathOverlap' {
+    It 'identical paths overlap' {
+        Test-PathOverlap 'a/b.ps1' 'a/b.ps1' | Should -BeTrue
+    }
+    It 'different files under the same dir do NOT overlap' {
+        Test-PathOverlap 'a/x.ps1' 'a/y.ps1' | Should -BeFalse
+    }
+    It 'a directory overlaps a file inside it (either order)' {
+        Test-PathOverlap 'src' 'src/x.ps1' | Should -BeTrue
+        Test-PathOverlap 'src/x.ps1' 'src' | Should -BeTrue
+    }
+    It 'is boundary-safe: a dir does not overlap a sibling with the same prefix' {
+        Test-PathOverlap 'src' 'srcfoo/x.ps1' | Should -BeFalse
+    }
+    It 'is case-insensitive and slash-agnostic' {
+        Test-PathOverlap 'A\B.ps1' 'a/b.ps1' | Should -BeTrue
+    }
+}
+
+Describe 'New-Ownership' {
+    It 'builds a claim with normalized paths and the given fields' {
+        $c = New-Ownership -Issue 241 -Branch 'issue-241-x' -Paths 'Scripts\A.ps1','b/c' -SessionPid 123 -HostName 'PC1' -Now 't'
+        $c.issue      | Should -Be 241
+        $c.branch     | Should -Be 'issue-241-x'
+        $c.paths      | Should -Be @('scripts/a.ps1','b/c')
+        $c.sessionPid | Should -Be 123
+        $c.host       | Should -Be 'PC1'
+        $c.ts         | Should -Be 't'
+    }
+    It 'splits comma-joined paths (the pwsh -File case)' {
+        (New-Ownership -Issue 1 -Paths 'a,b' -Now 't').paths | Should -Be @('a','b')
+    }
+}
+
+Describe 'Find-OwnershipConflicts' {
+    It 'reports no conflict against an empty registry' {
+        @(Find-OwnershipConflicts @() (New-Ownership -Issue 1 -Paths 'a' -Now 't')).Count | Should -Be 0
+    }
+    It 'does NOT conflict with the same issue re-claiming its own paths' {
+        $ex = @(New-Ownership -Issue 1 -Paths 'a/b.ps1' -Now 't')
+        @(Find-OwnershipConflicts $ex (New-Ownership -Issue 1 -Paths 'a/b.ps1' -Now 't2')).Count | Should -Be 0
+    }
+    It 'reports a conflict when another issue owns an overlapping path' {
+        $ex = @(New-Ownership -Issue 1 -Branch 'i1' -Paths 'src/shared.ps1' -Now 't')
+        $r  = @(Find-OwnershipConflicts $ex (New-Ownership -Issue 2 -Paths 'src/shared.ps1' -Now 't'))
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 1
+        $r[0].paths | Should -Be @('src/shared.ps1')
+    }
+    It 'does not conflict on disjoint paths' {
+        $ex = @(New-Ownership -Issue 1 -Paths 'a/x.ps1' -Now 't')
+        @(Find-OwnershipConflicts $ex (New-Ownership -Issue 2 -Paths 'a/y.ps1' -Now 't')).Count | Should -Be 0
+    }
+    It 'detects directory-vs-file overlap across issues' {
+        $ex = @(New-Ownership -Issue 1 -Paths 'src' -Now 't')
+        @(Find-OwnershipConflicts $ex (New-Ownership -Issue 2 -Paths 'src/deep/x.ps1' -Now 't')).Count | Should -Be 1
+    }
+}
+
+Describe 'Remove-DeadClaims (injected liveness predicate)' {
+    It 'keeps live-PID claims and drops dead ones' {
+        $claims = @(
+            (New-Ownership -Issue 1 -Paths 'a' -SessionPid 100 -Now 't'),
+            (New-Ownership -Issue 2 -Paths 'b' -SessionPid 200 -Now 't')
+        )
+        $isAlive = { param($processId) $processId -eq 100 }   # only 100 is "alive"
+        $r = @(Remove-DeadClaims $claims $isAlive)
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 1
+    }
+    It 'keeps claims with no pid (pid 0) rather than dropping them' {
+        $claims = @(New-Ownership -Issue 1 -Paths 'a' -SessionPid 0 -Now 't')
+        @(Remove-DeadClaims $claims { param($processId) $false }).Count | Should -Be 1
+    }
+}
+
+Describe 'Read/Write/Release round-trip (disk, via -Path injection)' {
+    BeforeAll {
+        $script:Tmp  = Join-Path ([System.IO.Path]::GetTempPath()) ("fleet-own-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Force $script:Tmp | Out-Null
+        $script:File = Join-Path $script:Tmp 'ownership.json'
+    }
+    AfterAll { Remove-Item -Recurse -Force $script:Tmp -ErrorAction SilentlyContinue }
+
+    It 'reads an empty array when the file is missing' {
+        @(Read-Ownership -Path $script:File).Count | Should -Be 0
+    }
+    It 'writes then reads back a claim' {
+        Write-Ownership -Path $script:File -Claim (New-Ownership -Issue 7 -Paths 'a/b.ps1' -Now 't')
+        $r = @(Read-Ownership -Path $script:File)
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 7
+    }
+    It 'upserts by issue (a re-claim replaces the paths, no duplicate row)' {
+        Write-Ownership -Path $script:File -Claim (New-Ownership -Issue 7 -Paths 'a/b.ps1','c/d.ps1' -Now 't2')
+        $r = @(Read-Ownership -Path $script:File | Where-Object { $_.issue -eq 7 })
+        $r.Count | Should -Be 1
+        @($r[0].paths) | Should -Be @('a/b.ps1','c/d.ps1')
+    }
+    It 'releases a claim by issue' {
+        Remove-OwnershipClaim -Path $script:File -Issue 7
+        @(Read-Ownership -Path $script:File | Where-Object { $_.issue -eq 7 }).Count | Should -Be 0
+    }
+    It 'returns an empty array on a corrupt file instead of throwing' {
+        Set-Content -Path $script:File -Value '{ not json'
+        @(Read-Ownership -Path $script:File).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
Closes #241 · Part of #238 (Fleet Phase 3 — work coordination).

## What

`Fleet-Ownership.ps1` — **"one owner per file"** for the parallel `/board work` fleet. Parallel worktrees can edit the same files and collide at merge time. This guard lets each session **declare the paths it owns** for its issue and **warns when a claim overlaps** paths another live session already owns.

## Design

- **Shared registry** `.agentic-bi-ops/fleet/ownership.json`, next to the main clone's `.git` (same pattern as `sessions.json` / the #239 blackboard) — shared across worktrees, gitignored.
- **Boundary-aware overlap**: owning `scripts` conflicts with `scripts/Foo.ps1` but **not** with a look-alike sibling `scriptsfoo/Bar.ps1`. Paths normalized (slashes, case, `./`, trailing `/`).
- **Auto-release of dead sessions**: every read prunes claims whose `sessionPid` is no longer a live process (pid 0/unknown kept). Identity is the long-lived parent session PID, like `sessions.json`.
- **Upsert by issue**: a re-claim replaces that issue's owned set (ownership is current, not cumulative).

## API / CLI

Pure helpers behind a dot-source guard (`ABIOS_FLEETOWNERSHIP_DOTSOURCE`): `ConvertTo-NormPath`, `Test-PathOverlap`, `New-Ownership`, `Find-OwnershipConflicts`, `Remove-DeadClaims`. Disk layer takes an injectable `-Path`.

```
Fleet-Ownership.ps1 -Check   -Issue 241 -Paths "a.ps1,b.ps1"   # exit 1 if conflict
Fleet-Ownership.ps1 -Claim   -Issue 241 -Paths "a.ps1" -Branch issue-241-x
Fleet-Ownership.ps1 -List
Fleet-Ownership.ps1 -Release -Issue 241
```

## Verification

- **TDD**: 22 Pester tests (normalization, boundary-safe overlap, cross-issue conflicts, dead-PID prune, disk round-trip incl. release + corrupt file) — watched fail, then green.
- **Full plugin suite: 264/264 green** (no regressions).
- **Live smoke test** of the CLI end-to-end (claim → conflicting check exits 1 → disjoint check exits 0 → list → release). It surfaced a real bug — a `$claim`/`$Claim` **case-insensitive variable-vs-switch collision** (PowerShell vars are case-insensitive, so the local aliased the `[switch]$Claim` param and failed the type constraint) — now fixed by renaming the local to `$prospect`.

## Scope note

Wiring the fleet briefing to auto-`-Claim`/`-Check` before touching files belongs with the planner (#240). This PR is the guard + CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
