### PR TITLE
feat(fleet): advisory board-lead planner (Phase 3 P3-2)

### DIFF
--- a/plugins/agentic-board/scripts/Fleet-Plan.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Plan.ps1
@@ -1,0 +1,281 @@
+<#
+.SYNOPSIS
+    Advisory board-lead planner (Phase 3, P3-2) - the "who does what" for the /board work
+    fleet.
+
+.DESCRIPTION
+    Today the human types the issue numbers for `/board work -Parallel`. This planner reads
+    the PENDING issues of a board, resolves their blocked-by dependencies into ordered
+    WAVES, and routes each issue to the best available CLI by capability (labels / type /
+    size). It EMITS the assignment map (prints it + writes .agentic-bi-ops/fleet/plan.json
+    + prints the suggested -Parallel command per wave) - it never launches anything. Driving
+    the fleet stays the human's call (or a future -Launch flag).
+
+    Routing (first available wins, else claude, else first CLI):
+      security/architecture label, size L/XL, or Spike -> claude
+      Refactor                                         -> codex  -> claude
+      Docs                                             -> gemini -> copilot -> claude
+      Chore / size S/XS                                -> copilot -> gemini -> claude
+      otherwise                                        -> claude
+
+    Pure planner core (routing + waves) sits behind a dot-source guard
+    ($env:ABIOS_FLEETPLAN_DOTSOURCE) for unit tests; only the board read + emit touch gh.
+
+.PARAMETER ProjectNum
+    GitHub Projects v2 board number. Required to actually read the board.
+
+.PARAMETER Owner
+    Board owner. Default CSalcedoDataBI.
+
+.PARAMETER Clis
+    Available CLIs (comma-joined or array), e.g. "claude,codex". Default: claude only.
+
+.PARAMETER Json
+    Emit the raw plan JSON instead of the formatted view.
+
+.EXAMPLE
+    .\Fleet-Plan.ps1 -ProjectNum 13 -Clis claude,codex,gemini
+    .\Fleet-Plan.ps1 -ProjectNum 13 -Json
+#>
+[CmdletBinding()]
+param(
+    [int]$ProjectNum = 0,
+    [string]$Owner = "CSalcedoDataBI",
+    [string]$Repo = "",
+    [string[]]$Clis = @(),
+    [switch]$Json,
+    [string]$TokenVar = "GITHUB_TOKEN_PERSONAL"
+)
+$ErrorActionPreference = "Stop"
+
+# ------------------------------------------------------------------ pure planner core
+function Split-CsvArg {
+    param([string[]]$Tokens)
+    $out = @()
+    foreach ($t in $Tokens) {
+        if ($null -eq $t) { continue }
+        foreach ($p in ($t -split ',')) {
+            $p = $p.Trim()
+            if ($p -ne '' -and $out -notcontains $p) { $out += $p }
+        }
+    }
+    return $out
+}
+
+# Route an issue to the best AVAILABLE CLI by capability. Pure -> unit-testable.
+function Select-CliForIssue {
+    param([object]$Issue, [string[]]$Clis)
+    $avail = @(Split-CsvArg $Clis)
+    if ($avail.Count -eq 0) { $avail = @('claude') }
+    $labels = @($Issue.labels | ForEach-Object { "$_".ToLower() })
+    $type   = "$($Issue.type)".ToLower()
+    $size   = "$($Issue.size)".ToUpper()
+
+    if (($labels -contains 'security') -or ($labels -contains 'architecture') -or $type -eq 'spike' -or ($size -in @('L','XL'))) {
+        $pref = @('claude')
+    } elseif ($type -eq 'refactor' -or ($labels -contains 'refactor')) {
+        $pref = @('codex','claude')
+    } elseif ($type -eq 'docs' -or ($labels -contains 'docs') -or ($labels -contains 'documentation')) {
+        $pref = @('gemini','copilot','claude')
+    } elseif ($type -eq 'chore' -or ($size -in @('S','XS'))) {
+        $pref = @('copilot','gemini','claude')
+    } else {
+        $pref = @('claude')
+    }
+    foreach ($p in $pref)      { if ($avail -contains $p) { return $p } }
+    if ($avail -contains 'claude') { return 'claude' }
+    return $avail[0]
+}
+
+# Layer issues into dependency waves: wave 1 = issues whose in-set blockers are all placed,
+# and so on. Blockers OUTSIDE the pending set are treated as satisfied (already closed). A
+# cycle can't be ordered, so the remainder is dumped into a final wave (never hangs). Pure.
+function Get-AssignmentWaves {
+    param([object[]]$Issues)
+    $pending = @($Issues | Where-Object { $null -ne $_ })
+    $inSet   = @($pending | ForEach-Object { [int]$_.number })
+    $placed  = @{}
+    $waves   = @()
+    $remaining = @($pending)
+    while ($remaining.Count -gt 0) {
+        $ready = @($remaining | Where-Object {
+            $blockers = @($_.blockedBy | Where-Object { $inSet -contains [int]$_ })
+            @($blockers | Where-Object { -not $placed[[int]$_] }).Count -eq 0
+        })
+        if ($ready.Count -eq 0) {
+            # unresolvable (cycle) -> place the rest together so nothing is lost
+            $waves += , @($remaining)
+            break
+        }
+        $waves += , @($ready)
+        foreach ($r in $ready) { $placed[[int]$r.number] = $true }
+        $remaining = @($remaining | Where-Object { -not $placed[[int]$_.number] })
+    }
+    # Unary comma: without it a single-wave result (an array holding one array) is
+    # unwrapped on output and the caller sees the issues, not the waves.
+    return , $waves
+}
+
+# Combine waves x routing into a flat assignment plan: one {issue,title,cli,wave} per issue.
+function New-AssignmentPlan {
+    param([object[]]$Issues, [string[]]$Clis)
+    $avail = @(Split-CsvArg $Clis)
+    if ($avail.Count -eq 0) { $avail = @('claude') }
+    $waves = Get-AssignmentWaves $Issues
+    $plan  = @()
+    for ($w = 0; $w -lt $waves.Count; $w++) {
+        foreach ($iss in @($waves[$w])) {
+            $plan += [pscustomobject]@{
+                issue = [int]$iss.number
+                title = $iss.title
+                cli   = (Select-CliForIssue $iss $avail)
+                wave  = $w + 1
+            }
+        }
+    }
+    return $plan
+}
+
+# ------------------------------------------------------------- board read + emit (I/O)
+# Accumulate all board items across pages (same fix as #246).
+function Get-AllPages {
+    param([scriptblock]$FetchPage)
+    $all = @(); $cursor = $null
+    do {
+        $page = & $FetchPage $cursor
+        if (-not $page) { break }
+        $all += @($page.nodes)
+        $cursor = $page.endCursor
+        $more   = [bool]$page.hasNext
+    } while ($more)
+    return $all
+}
+
+# Read the board's PENDING issues (Status Backlog or empty, OPEN) with labels/size/type,
+# and best-effort blocked-by numbers from the issue dependencies API.
+function Get-PendingBoardIssues {
+    param([string]$Owner, [int]$ProjectNum)
+    $nodes = Get-AllPages {
+        param($cursor)
+        $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+        $q = @"
+query(`$o:String!, `$n:Int!) {
+  user(login:`$o) {
+    projectV2(number:`$n) {
+      items(first:100 $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          fieldValues(first:20) {
+            nodes { ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2SingleSelectField { name } } name } }
+          }
+          content {
+            __typename
+            ... on Issue {
+              number title state
+              labels(first:15) { nodes { name } }
+              repository { nameWithOwner }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"@
+        $items = (gh api graphql -f query=$q -F "o=$Owner" -F "n=$ProjectNum" | ConvertFrom-Json).data.user.projectV2.items
+        return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
+    }
+
+    $out = @()
+    foreach ($it in $nodes) {
+        if ($it.content.__typename -ne 'Issue' -or $it.content.state -ne 'OPEN') { continue }
+        $fields = @{}
+        foreach ($fv in @($it.fieldValues.nodes)) { if ($fv.field.name) { $fields[$fv.field.name] = $fv.name } }
+        $status = $fields['Status']
+        if ($status -and $status -ne 'Backlog') { continue }   # only pending
+        $repo = $it.content.repository.nameWithOwner
+        $blockedBy = @()
+        try {
+            $deps = gh api "repos/$repo/issues/$($it.content.number)/dependencies/blocked_by" 2>$null | ConvertFrom-Json
+            $blockedBy = @($deps | Where-Object { $_.state -eq 'open' } | ForEach-Object { [int]$_.number })
+        } catch { }
+        $out += [pscustomobject]@{
+            number    = [int]$it.content.number
+            title     = $it.content.title
+            labels    = @($it.content.labels.nodes.name)
+            size      = $fields['Size']
+            type      = $fields['Type']
+            priority  = $fields['Priority']
+            repo      = $repo
+            blockedBy = $blockedBy
+        }
+    }
+    return $out
+}
+
+function Get-FleetPlanPath {
+    $common = git rev-parse --git-common-dir 2>$null
+    if (-not $common) { return $null }
+    try { $root = Split-Path (Resolve-Path $common).Path -Parent } catch { return $null }
+    $dir = Join-Path (Join-Path $root ".agentic-bi-ops") "fleet"
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    return (Join-Path $dir "plan.json")
+}
+
+function Write-PlanLedger {
+    param([string]$Path, [object[]]$Plan)
+    if (-not $Path) { $Path = Get-FleetPlanPath }
+    if (-not $Path) { return }
+    $json = if (@($Plan).Count -eq 0) { '[]' } else { $Plan | ConvertTo-Json -Depth 6 -AsArray }
+    Set-Content -Path $Path -Value $json -Encoding UTF8
+}
+
+function Show-Plan {
+    param([object[]]$Plan)
+    if (-not $Plan -or @($Plan).Count -eq 0) {
+        Write-Host "  (no hay issues pendientes que planificar)" -ForegroundColor DarkGray
+        return
+    }
+    $waves = @($Plan | ForEach-Object { $_.wave } | Sort-Object -Unique)
+    foreach ($w in $waves) {
+        $inWave = @($Plan | Where-Object { $_.wave -eq $w })
+        Write-Host ("  Wave {0}:" -f $w) -ForegroundColor Cyan
+        foreach ($p in $inWave) {
+            Write-Host ("     #{0,-4} -> {1,-8} {2}" -f $p.issue, $p.cli, $p.title) -ForegroundColor Yellow
+        }
+    }
+}
+
+# --- dot-source guard: stop here so unit tests get the pure core with no I/O -----
+if ($env:ABIOS_FLEETPLAN_DOTSOURCE) { return }
+
+# ------------------------------------------------------------------------ main entry
+if (-not $env:GH_TOKEN) { $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, "User") }
+if (-not $env:GH_TOKEN) { throw "$TokenVar no esta en el entorno de usuario (y GH_TOKEN vacio)." }
+if ($ProjectNum -le 0) { throw "Especifica -ProjectNum <n> del board." }
+
+$issues = @(Get-PendingBoardIssues $Owner $ProjectNum)
+$plan   = @(New-AssignmentPlan $issues $Clis)
+
+if ($Json) { if ($plan.Count -eq 0) { '[]' } else { $plan | ConvertTo-Json -Depth 6 -AsArray }; return }
+
+Write-Host "=== Plan de asignacion del fleet (board #$ProjectNum) ===" -ForegroundColor Cyan
+$fleetClis = @(Split-CsvArg $Clis); if ($fleetClis.Count -eq 0) { $fleetClis = @('claude') }
+Write-Host ("CLIs disponibles: {0}" -f ($fleetClis -join ', ')) -ForegroundColor DarkGray
+Write-Host ""
+Show-Plan $plan
+
+$ledger = Get-FleetPlanPath
+Write-PlanLedger -Path $ledger -Plan $plan
+if ($ledger) { Write-Host "" ; Write-Host ("Plan guardado en: {0}" -f $ledger) -ForegroundColor DarkGray }
+
+# Advisory: the -Parallel command per wave (dependent waves run after the prior merges).
+if ($plan.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Sugerencia (advisory - no se lanza nada):" -ForegroundColor Cyan
+    foreach ($w in (@($plan | ForEach-Object { $_.wave } | Sort-Object -Unique))) {
+        $nums = @($plan | Where-Object { $_.wave -eq $w } | ForEach-Object { $_.issue })
+        Write-Host ("  Wave {0}:  Board-Work.ps1 -ProjectNum {1} -Parallel {2} -Fleet" -f $w, $ProjectNum, ($nums -join ',')) -ForegroundColor Gray
+    }
+    Write-Host "  (corre cada wave cuando la anterior haya mergeado sus PRs)" -ForegroundColor DarkGray
+}

--- a/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
@@ -1,0 +1,89 @@
+#Requires -Modules Pester
+<#  Pester tests for Fleet-Plan.ps1 - the advisory board-lead planner (P3-2). It reads
+    pending board issues and emits an assignment map (issue -> CLI -> dependency wave)
+    WITHOUT launching anything. Side-effecting at the edges (gh), so a dot-source guard
+    ($env:ABIOS_FLEETPLAN_DOTSOURCE) exposes the pure planner core for unit tests. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Fleet-Plan.ps1' | Resolve-Path
+    $env:ABIOS_FLEETPLAN_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FLEETPLAN_DOTSOURCE = ''
+
+    function New-Iss {
+        param([int]$Number, [string]$Title = 't', [string[]]$Labels = @(), [string]$Size = 'M', [string]$Type = 'Feature', [int[]]$BlockedBy = @())
+        [pscustomobject]@{ number = $Number; title = $Title; labels = $Labels; size = $Size; type = $Type; blockedBy = $BlockedBy }
+    }
+    $all = @('claude','codex','gemini','copilot')
+}
+
+Describe 'Select-CliForIssue (capability routing with availability fallback)' {
+    It 'routes security/architecture/large work to claude' {
+        Select-CliForIssue (New-Iss 1 -Labels 'security') $all | Should -Be 'claude'
+        Select-CliForIssue (New-Iss 2 -Size 'L')          $all | Should -Be 'claude'
+    }
+    It 'routes refactors to codex when available' {
+        Select-CliForIssue (New-Iss 3 -Type 'Refactor') $all | Should -Be 'codex'
+    }
+    It 'falls back to claude when the preferred CLI is not available' {
+        Select-CliForIssue (New-Iss 4 -Type 'Refactor') @('claude','gemini') | Should -Be 'claude'
+    }
+    It 'routes docs to gemini' {
+        Select-CliForIssue (New-Iss 5 -Type 'Docs') @('gemini','claude') | Should -Be 'gemini'
+    }
+    It 'routes small chores to copilot' {
+        Select-CliForIssue (New-Iss 6 -Type 'Chore' -Size 'S') @('copilot','claude') | Should -Be 'copilot'
+    }
+    It 'defaults a plain feature to claude' {
+        Select-CliForIssue (New-Iss 7) $all | Should -Be 'claude'
+    }
+    It 'uses the first available CLI when nothing preferred (not even claude) is present' {
+        Select-CliForIssue (New-Iss 8 -Type 'Docs') @('copilot') | Should -Be 'copilot'
+    }
+}
+
+Describe 'Get-AssignmentWaves (dependency-aware layering)' {
+    It 'puts fully-independent issues in a single wave' {
+        $w = Get-AssignmentWaves @( (New-Iss 1), (New-Iss 2), (New-Iss 3) )
+        $w.Count | Should -Be 1
+        @($w[0]).Count | Should -Be 3
+    }
+    It 'sequences a blocker before its dependent' {
+        $w = Get-AssignmentWaves @( (New-Iss 1), (New-Iss 2 -BlockedBy 1) )
+        $w.Count | Should -Be 2
+        $w[0][0].number | Should -Be 1
+        $w[1][0].number | Should -Be 2
+    }
+    It 'builds one wave per link in a chain A->B->C' {
+        $w = Get-AssignmentWaves @( (New-Iss 1), (New-Iss 2 -BlockedBy 1), (New-Iss 3 -BlockedBy 2) )
+        $w.Count | Should -Be 3
+    }
+    It 'treats a blocker OUTSIDE the pending set as already satisfied' {
+        $w = Get-AssignmentWaves @( (New-Iss 5 -BlockedBy 99) )   # 99 not in the set
+        $w.Count | Should -Be 1
+        $w[0][0].number | Should -Be 5
+    }
+    It 'does not hang on a dependency cycle (places the rest in a final wave)' {
+        $w = Get-AssignmentWaves @( (New-Iss 1 -BlockedBy 2), (New-Iss 2 -BlockedBy 1) )
+        @($w | ForEach-Object { $_ }).Count | Should -BeGreaterThan 0
+        # both issues still appear somewhere
+        (@($w | ForEach-Object { $_ }) | ForEach-Object { $_.number } | Sort-Object) | Should -Be @(1,2)
+    }
+}
+
+Describe 'New-AssignmentPlan (waves x routing)' {
+    It 'assigns every issue a wave and a CLI' {
+        $plan = New-AssignmentPlan @( (New-Iss 1 -Type 'Refactor'), (New-Iss 2 -BlockedBy 1 -Labels 'security') ) @('claude','codex')
+        ($plan | Where-Object { $_.issue -eq 1 }).wave | Should -Be 1
+        ($plan | Where-Object { $_.issue -eq 1 }).cli  | Should -Be 'codex'
+        ($plan | Where-Object { $_.issue -eq 2 }).wave | Should -Be 2
+        ($plan | Where-Object { $_.issue -eq 2 }).cli  | Should -Be 'claude'
+    }
+    It 'defaults to a claude-only fleet when no CLIs are given' {
+        $plan = New-AssignmentPlan @( (New-Iss 1) ) @()
+        $plan[0].cli | Should -Be 'claude'
+    }
+    It 'produces one plan entry per issue' {
+        (New-AssignmentPlan @( (New-Iss 1), (New-Iss 2), (New-Iss 3) ) @('claude')).Count | Should -Be 3
+    }
+}


### PR DESCRIPTION
Closes #240 · Part of #238 (Fleet Phase 3 — work coordination).

## What

`Fleet-Plan.ps1` — the **"who does what"** for the `/board work` fleet, and the fix for the original complaint (*no jefe reparte el trabajo*). Today the human types the issue numbers for `-Parallel`. This planner reads a board's **pending** issues, orders them into dependency **waves**, routes each to the best available CLI by capability, and **emits** the assignment map. **Advisory only** — it never launches anything (per the chosen design); driving the fleet stays the human's call.

## Design

- **Capability routing** (`Select-CliForIssue`, first-available wins → claude fallback):
  - security/architecture, size L/XL, Spike → **claude**
  - Refactor → **codex** → claude
  - Docs → **gemini** → copilot → claude
  - Chore / size S/XS → **copilot** → gemini → claude
  - otherwise → **claude**
- **Dependency waves** (`Get-AssignmentWaves`): topological layering by `blocked-by`; blockers outside the pending set count as satisfied (closed); cycle-safe (never hangs — the remainder lands in a final wave).
- **Emit**: prints the plan grouped by wave, writes `.agentic-bi-ops/fleet/plan.json`, and prints the suggested `-Parallel … -Fleet` command per wave (run each wave after the prior merges).

## API

Pure planner core behind a dot-source guard (`ABIOS_FLEETPLAN_DOTSOURCE`): `Select-CliForIssue`, `Get-AssignmentWaves`, `New-AssignmentPlan`. Board read paginated (the #246 pattern); `blocked-by` via the issue dependencies API.

```
Fleet-Plan.ps1 -ProjectNum 13 -Clis claude,codex,gemini,copilot
Fleet-Plan.ps1 -ProjectNum 13 -Json
```

## Verification

- **TDD**: 15 Pester tests (routing incl. availability fallback, waves incl. chain / external-blocker / cycle, combined plan) — watched fail, then green. Two failures surfaced during the run were **PowerShell idioms**, fixed: a nested-array unwrap on return (`return ,$waves`) and a Pester-v5 discovery-vs-run variable-scope issue in the test.
- **Full plugin suite: 279/279 green** (no regressions).
- **Live smoke test** against board #13: read 23 pending issues → assigned CLIs → single wave (their blockers #239/#241 are already Done) → emitted the `-Parallel` suggestion + `plan.json`.

## Scope note

Wave-size caps (don't launch 23 sessions at once) are the **capacity governor's** job — Phase 2 (#190–198). Wiring the planner's output to auto-write the blackboard / claim ownership is the hand-off (#242). This PR is the planner + emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
