### PR TITLE
feat(fleet): supervisor - stall detection + termination (Phase 3 P3-5)

### DIFF
--- a/plugins/agentic-board/scripts/Fleet-Supervisor.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Supervisor.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+    Fleet supervisor: stall detection + fleet termination policy (Phase 3, P3-5).
+
+.DESCRIPTION
+    Watches the live /board work fleet (from .agentic-bi-ops/sessions.json) and produces a
+    verdict:
+      - which sessions have STALLED (running past -ThresholdMin with no PR opened yet),
+      - whether the whole run is COMPLETE (every session's PR merged),
+      - whether it should STOP - the guard against a runaway fleet: complete, or too many
+        stalled sessions (-MaxStalled).
+    Stalled sessions are surfaced with a suggestion to re-plan (Fleet-Plan.ps1) or take them
+    over; it never kills anything itself (that is Phase 2's reaper).
+
+    Pure verdict core (Test-SessionStalled / Get-StalledSessions / Test-FleetComplete /
+    Get-FleetVerdict) sits behind a dot-source guard ($env:ABIOS_FLEETSUPERVISOR_DOTSOURCE)
+    for unit tests; only the CLI reads sessions.json + gh.
+
+.PARAMETER Check
+    Read the live fleet and print the verdict.
+
+.PARAMETER ThresholdMin
+    Minutes with no PR before a session counts as stalled. Default 30.
+
+.PARAMETER MaxStalled
+    Stalled-session count that trips a STOP. Default 2.
+
+.EXAMPLE
+    .\Fleet-Supervisor.ps1 -Check
+    .\Fleet-Supervisor.ps1 -Check -ThresholdMin 45 -MaxStalled 3 -Json
+#>
+[CmdletBinding()]
+param(
+    [switch]$Check,
+    [int]$ProjectNum = 0,
+    [int]$ThresholdMin = 30,
+    [int]$MaxStalled = 2,
+    [string]$Owner = "CSalcedoDataBI",
+    [switch]$Json,
+    [string]$TokenVar = "GITHUB_TOKEN_PERSONAL"
+)
+$ErrorActionPreference = "Stop"
+
+# ------------------------------------------------------------------ pure verdict core
+# A session is stalled when it has run past the threshold with NO PR yet (an open PR is
+# progress, so it is never stalled). Pure -> unit-testable.
+function Test-SessionStalled {
+    param([object]$Session, [int]$ThresholdMin)
+    return ([string]::IsNullOrEmpty("$($Session.pr)")) -and ([int]$Session.ageMin -gt $ThresholdMin)
+}
+
+function Get-StalledSessions {
+    param([object[]]$Sessions, [int]$ThresholdMin)
+    return @($Sessions | Where-Object { $null -ne $_ -and (Test-SessionStalled $_ $ThresholdMin) })
+}
+
+# The fleet is complete when every session's PR is merged (an empty fleet is trivially so).
+function Test-FleetComplete {
+    param([object[]]$Sessions)
+    $s = @($Sessions | Where-Object { $null -ne $_ })
+    if ($s.Count -eq 0) { return $true }
+    return (@($s | Where-Object { -not $_.merged }).Count -eq 0)
+}
+
+# The termination verdict: stop when the fleet is complete OR too many sessions have stalled.
+function Get-FleetVerdict {
+    param([object[]]$Sessions, [int]$ThresholdMin, [int]$MaxStalled)
+    $complete = Test-FleetComplete $Sessions
+    $stalled  = @(Get-StalledSessions $Sessions $ThresholdMin)
+    $shouldStop = $complete -or ($stalled.Count -ge $MaxStalled)
+    $reason = if ($complete) { 'fleet complete - every session merged' }
+              elseif ($stalled.Count -ge $MaxStalled) { "stalled - $($stalled.Count) session(s) past ${ThresholdMin}min with no PR" }
+              else { 'in progress' }
+    return [pscustomobject]@{
+        complete   = $complete
+        stalled    = $stalled
+        shouldStop = $shouldStop
+        reason     = $reason
+    }
+}
+
+# ------------------------------------------------------------- I/O (sessions.json + gh)
+function Get-SessionsFile {
+    $common = git rev-parse --git-common-dir 2>$null
+    if (-not $common) { return $null }
+    try { $root = Split-Path (Resolve-Path $common).Path -Parent } catch { return $null }
+    return (Join-Path (Join-Path $root ".agentic-bi-ops") "sessions.json")
+}
+
+function Read-FleetSessions {
+    $p = Get-SessionsFile
+    if (-not $p -or -not (Test-Path $p)) { return @() }
+    try { return @(Get-Content $p -Raw | ConvertFrom-Json) } catch { return @() }
+}
+
+# Enrich raw registry entries with ageMin (from `started`) + pr/merged (from gh).
+function Resolve-LiveSessions {
+    $out = @()
+    foreach ($e in (Read-FleetSessions)) {
+        $ageMin = 0
+        try { $ageMin = [int]((Get-Date) - [datetime]::ParseExact($e.started, 'yyyy-MM-dd HH:mm', $null)).TotalMinutes } catch { }
+        $pr = ''; $merged = $false
+        if ($e.repo -and $e.branch) {
+            try {
+                $found = @(gh pr list --repo $e.repo --head $e.branch --state all --json number,state --limit 1 2>$null | ConvertFrom-Json)
+                if ($found.Count -gt 0) { $pr = "#$($found[0].number)"; $merged = ($found[0].state -eq 'MERGED') }
+            } catch { }
+        }
+        $out += [pscustomobject]@{ issue = $e.issue; branch = $e.branch; ageMin = $ageMin; pr = $pr; merged = $merged }
+    }
+    return $out
+}
+
+# --- dot-source guard: stop here so unit tests get the pure core with no I/O -----
+if ($env:ABIOS_FLEETSUPERVISOR_DOTSOURCE) { return }
+
+# ------------------------------------------------------------------------ main entry
+if (-not $env:GH_TOKEN) { $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, "User") }
+
+$sessions = @(Resolve-LiveSessions)
+$verdict  = Get-FleetVerdict $sessions $ThresholdMin $MaxStalled
+
+if ($Json) { $verdict | ConvertTo-Json -Depth 6; return }
+
+Write-Host "=== Supervisor del fleet ===" -ForegroundColor Cyan
+if ($sessions.Count -eq 0) {
+    Write-Host "  (no hay sesiones vivas registradas)" -ForegroundColor DarkGray
+    return
+}
+foreach ($s in ($sessions | Sort-Object issue)) {
+    $tag = if ($s.merged) { 'merged' } elseif ($s.pr) { 'in review' } elseif ($s.ageMin -gt $ThresholdMin) { 'STALLED' } else { 'working' }
+    $color = switch ($tag) { 'merged' { 'Green' } 'in review' { 'DarkCyan' } 'STALLED' { 'Red' } default { 'Yellow' } }
+    Write-Host ("  #{0,-4} {1,-9} {2,4}min  {3}" -f $s.issue, $tag, $s.ageMin, $s.pr) -ForegroundColor $color
+}
+Write-Host ""
+Write-Host ("Veredicto: {0}" -f $verdict.reason) -ForegroundColor Cyan
+if (@($verdict.stalled).Count -gt 0) {
+    Write-Host ("  Estancados: {0}" -f ((@($verdict.stalled).issue) -join ', ')) -ForegroundColor Red
+    Write-Host "  Sugerencia: re-planifica (Fleet-Plan.ps1) o retoma con Board-Work.ps1 -Start <n> -TakeOver." -ForegroundColor DarkYellow
+}
+if ($verdict.shouldStop) {
+    Write-Host "  >> STOP: el fleet deberia detenerse." -ForegroundColor Magenta
+} else {
+    Write-Host "  >> CONTINUE: hay trabajo en curso." -ForegroundColor DarkGray
+}

--- a/plugins/agentic-board/tests/Fleet-Supervisor.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Supervisor.Tests.ps1
@@ -1,0 +1,71 @@
+#Requires -Modules Pester
+<#  Pester tests for Fleet-Supervisor.ps1 - stall detection + fleet termination (P3-5).
+    Watches the live fleet and decides: which sessions have stalled (running too long with
+    no PR), whether the whole run is complete, and whether it should STOP (guard against
+    runaway loops). Pure verdict core behind a dot-source guard
+    ($env:ABIOS_FLEETSUPERVISOR_DOTSOURCE); only the CLI reads sessions.json / gh. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Fleet-Supervisor.ps1' | Resolve-Path
+    $env:ABIOS_FLEETSUPERVISOR_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FLEETSUPERVISOR_DOTSOURCE = ''
+
+    function New-Sess {
+        param([int]$Issue, [int]$AgeMin = 0, [string]$Pr = '', [bool]$Merged = $false)
+        [pscustomobject]@{ issue = $Issue; ageMin = $AgeMin; pr = $Pr; merged = $Merged }
+    }
+}
+
+Describe 'Test-SessionStalled' {
+    It 'is not stalled while young' {
+        Test-SessionStalled (New-Sess 1 -AgeMin 5) 30 | Should -BeFalse
+    }
+    It 'is stalled when old and still has no PR' {
+        Test-SessionStalled (New-Sess 1 -AgeMin 60) 30 | Should -BeTrue
+    }
+    It 'is NOT stalled when old but a PR is already open (that is progress)' {
+        Test-SessionStalled (New-Sess 1 -AgeMin 60 -Pr 'http://pr/1') 30 | Should -BeFalse
+    }
+}
+
+Describe 'Get-StalledSessions' {
+    It 'returns only the stalled sessions' {
+        $s = @( (New-Sess 1 -AgeMin 5), (New-Sess 2 -AgeMin 90), (New-Sess 3 -AgeMin 90 -Pr 'p') )
+        $r = @(Get-StalledSessions $s 30)
+        $r.Count | Should -Be 1
+        $r[0].issue | Should -Be 2
+    }
+}
+
+Describe 'Test-FleetComplete' {
+    It 'is complete when every session is merged' {
+        Test-FleetComplete @( (New-Sess 1 -Merged $true), (New-Sess 2 -Merged $true) ) | Should -BeTrue
+    }
+    It 'is not complete while any session is unmerged' {
+        Test-FleetComplete @( (New-Sess 1 -Merged $true), (New-Sess 2) ) | Should -BeFalse
+    }
+    It 'treats an empty fleet as complete' {
+        Test-FleetComplete @() | Should -BeTrue
+    }
+}
+
+Describe 'Get-FleetVerdict (termination policy)' {
+    It 'says STOP + complete when all sessions merged' {
+        $v = Get-FleetVerdict @( (New-Sess 1 -Merged $true) ) 30 2
+        $v.complete   | Should -BeTrue
+        $v.shouldStop | Should -BeTrue
+        $v.reason     | Should -Match 'complet'
+    }
+    It 'says STOP when stalled count reaches the max' {
+        $v = Get-FleetVerdict @( (New-Sess 1 -AgeMin 90), (New-Sess 2 -AgeMin 90) ) 30 2
+        $v.shouldStop | Should -BeTrue
+        $v.reason     | Should -Match 'stall'
+        @($v.stalled).Count | Should -Be 2
+    }
+    It 'keeps going when work is in progress and nothing is stalled' {
+        $v = Get-FleetVerdict @( (New-Sess 1 -AgeMin 5 -Pr 'p'), (New-Sess 2 -AgeMin 5) ) 30 2
+        $v.complete   | Should -BeFalse
+        $v.shouldStop | Should -BeFalse
+    }
+}


### PR DESCRIPTION
Closes #243 · **Completes #238 (Fleet Phase 3 — work coordination / collaboration).**

## What

`Fleet-Supervisor.ps1` — the fleet's watchdog. It reads the live fleet (`sessions.json`) and produces a **verdict**:
- **stalled** sessions — running past `-ThresholdMin` (default 30) with **no PR opened** yet (an open PR is progress),
- **complete** — every session's PR merged,
- **should-stop** — the guard against a runaway fleet: complete, **or** `≥ -MaxStalled` (default 2) sessions stalled.

Stalled sessions are surfaced with a **re-plan / take-over** suggestion (`Fleet-Plan.ps1` or `Board-Work.ps1 -Start <n> -TakeOver`). It never kills anything — process-tree killing is Phase 2's reaper (#196/#197).

## API

Pure verdict core behind a dot-source guard (`ABIOS_FLEETSUPERVISOR_DOTSOURCE`): `Test-SessionStalled`, `Get-StalledSessions`, `Test-FleetComplete`, `Get-FleetVerdict`. The CLI `-Check` reads `sessions.json` and gh for each session's PR/merged state.

```
Fleet-Supervisor.ps1 -Check
Fleet-Supervisor.ps1 -Check -ThresholdMin 45 -MaxStalled 3 -Json
```

## Verification

- **TDD**: 10 tests (stall detection incl. "has-PR is not stalled", completeness incl. empty fleet, and the full stop-verdict: complete → stop, ≥max stalled → stop, in-progress → continue) — watched fail, then green.
- **Full plugin suite: 300/300 green** (no regressions).
- **Live smoke test**: `-Check` reads the real `sessions.json` and renders a per-session status table + verdict.

## Phase 3 is now complete

| Piece | PR |
|---|---|
| #239 blackboard (shared findings) | #245 |
| #241 file-ownership guard | #249 |
| #240 advisory planner | #250 |
| #242 dependency hand-off + **briefing wiring** | #251 |
| **#243 supervisor (this)** | this |

Plus the blocker #246 (board pagination). The `/board work` fleet now **collaborates**: shares findings, avoids file collisions, hands dependent work forward with a planner assigning who-does-what, and a supervisor that knows when to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
