### PR TITLE
ci: docs-freshness gate - regenerate + git diff --exit-code (blocks a stale README)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
-# Runs the Pester test suite on every pull request. A failure here fails the
-# `test` check, which blocks the merge (Board-ReviewGate waits on it, and the
-# check can also be marked "Required" in the branch ruleset — see #201).
+# Two blocking checks on every pull request:
+#   * `test` — the Pester suite (a failure blocks the merge; Board-ReviewGate
+#     waits on it, and it can be marked "Required" in the branch ruleset, see #201).
+#   * `docs` — the docs-freshness gate (#203): regenerate the derived README
+#     regions from source and fail if they drift from what was committed.
 
 on:
   pull_request:
@@ -48,3 +50,25 @@ jobs:
           name: pester-results
           path: testResults.xml
           if-no-files-found: warn
+
+  docs:
+    name: Docs freshness
+    runs-on: ubuntu-latest   # all-LF checkout, no autocrlf: a clean byte-for-byte diff
+    steps:
+      - uses: actions/checkout@v4
+
+      # Regenerate the marked README regions (command catalog from frontmatter +
+      # version from plugin.json) from their sources, rewriting in place.
+      - name: Regenerate derived README regions
+        shell: pwsh
+        run: plugins/agentic-board/scripts/Update-Docs.ps1
+
+      # If regeneration changed anything, the committed README was stale: a command
+      # description or the version moved without the README being regenerated.
+      - name: Fail if the README drifted from its sources
+        run: |
+          if ! git diff --exit-code -- README.md; then
+            echo "::error::README is stale — a command description or the version changed without regenerating."
+            echo "Fix it locally: run 'plugins/agentic-board/scripts/Update-Docs.ps1' and commit README.md."
+            exit 1
+          fi

--- a/plugins/agentic-board/scripts/Update-Docs.ps1
+++ b/plugins/agentic-board/scripts/Update-Docs.ps1
@@ -96,6 +96,15 @@ function Format-CatalogTable {
     $lines -join "`n"
 }
 
+# The newline a file predominantly uses. A Windows working copy with autocrlf
+# checks README out as CRLF; emitting an LF-only generated region into it would
+# read back as "stale" on every -Check and rewrite the region needlessly. So the
+# generator matches the file's own newline. Pure -> testable.
+function Get-DominantNewline {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Text)
+    if ($Text -match "`r`n") { "`r`n" } else { "`n" }
+}
+
 # Read the version out of a plugin.json's raw text (same regex the release
 # tooling uses). Pure -> testable.
 function Get-PluginVersion {
@@ -157,18 +166,24 @@ $readme    = [System.IO.File]::ReadAllText($ReadmePath)
 $pluginRaw = [System.IO.File]::ReadAllText($pluginJson)
 
 $catalog = Get-CommandCatalog -CommandsDir $commandsDir
-$table   = Format-CatalogTable -Rows $catalog
 $version = Get-PluginVersion -Raw $pluginRaw
 
-# Splice both marked regions. The command block sits on its own lines (blank line
+# Match the README's own newline so the generated region does not read back as
+# "stale" purely from CRLF-vs-LF (Format-CatalogTable emits LF).
+$nl              = Get-DominantNewline -Text $readme
+$table           = (Format-CatalogTable -Rows $catalog) -replace "`r?`n", $nl
+$commandsContent = "$nl$table$nl"
+$versionContent  = "v$version"
+
+# Splice both marked regions. The command block sits on its own lines (newline
 # padding); the version marker is inline, so its content is just the string.
-$updated = Set-MarkedRegion -Text $readme    -Name 'commands' -Content "`n$table`n"
-$updated = Set-MarkedRegion -Text $updated   -Name 'version'  -Content "v$version"
+$updated = Set-MarkedRegion -Text $readme  -Name 'commands' -Content $commandsContent
+$updated = Set-MarkedRegion -Text $updated -Name 'version'  -Content $versionContent
 
 # Which regions differ? Report per-region so the gate message is actionable.
 $stale = @()
-if ((Set-MarkedRegion -Text $readme -Name 'commands' -Content "`n$table`n") -ne $readme) { $stale += 'command catalog' }
-if ((Set-MarkedRegion -Text $readme -Name 'version'  -Content "v$version")  -ne $readme) { $stale += 'version' }
+if ((Set-MarkedRegion -Text $readme -Name 'commands' -Content $commandsContent) -ne $readme) { $stale += 'command catalog' }
+if ((Set-MarkedRegion -Text $readme -Name 'version'  -Content $versionContent)  -ne $readme) { $stale += 'version' }
 
 if ($Check) {
     Write-Host "=== Docs check  ($([System.IO.Path]::GetFileName($ReadmePath))) ===" -ForegroundColor Cyan

--- a/plugins/agentic-board/tests/Update-Docs.Tests.ps1
+++ b/plugins/agentic-board/tests/Update-Docs.Tests.ps1
@@ -97,6 +97,18 @@ Describe 'Format-CatalogTable' {
     }
 }
 
+Describe 'Get-DominantNewline' {
+    It 'returns CRLF when the text contains a CRLF' {
+        Get-DominantNewline -Text "a`r`nb" | Should -Be "`r`n"
+    }
+    It 'returns LF for LF-only text' {
+        Get-DominantNewline -Text "a`nb" | Should -Be "`n"
+    }
+    It 'returns LF for text with no newline at all' {
+        Get-DominantNewline -Text 'single line' | Should -Be "`n"
+    }
+}
+
 Describe 'Get-PluginVersion' {
     It 'extracts the version from minified plugin.json text' {
         Get-PluginVersion -Raw '{"name":"x","version":"0.18.0"}' | Should -Be '0.18.0'


### PR DESCRIPTION
Closes #203