### PR TITLE
work: session teardown asks the filesystem too — a leftover folder leaks the branch and the registry entry forever

### DIFF
--- a/plugins/agentic-board/scripts/Board-Doctor.ps1
+++ b/plugins/agentic-board/scripts/Board-Doctor.ps1
@@ -120,74 +120,12 @@ finally {
 }
 
 # ------------------------------------------------------------------ pure helpers
-
-# Parse `git worktree list --porcelain` into objects. The porcelain format is a blank-line
-# separated record per worktree: `worktree <path>`, then optional `HEAD <oid>`,
-# `branch refs/heads/<name>` | `detached`, `bare`, `locked [<reason>]`, `prunable <reason>`.
-# We take `prunable` straight from git rather than guessing: git already knows a registered
-# worktree whose directory is gone. PURE over the text -> unit-testable.
-function Get-WorktreeRecords {
-    param([Parameter(Mandatory)][AllowEmptyString()][string]$Porcelain)
-    $records = @()
-    $cur = $null
-    foreach ($rawLine in ($Porcelain -split "`r?`n")) {
-        $line = $rawLine.TrimEnd()
-        if (-not $line) { if ($cur) { $records += $cur; $cur = $null }; continue }
-        if ($line -match '^worktree (.+)$') {
-            if ($cur) { $records += $cur }
-            $cur = [pscustomobject]@{
-                Path = $Matches[1]; Head = ''; Branch = ''; Detached = $false
-                Bare = $false; Locked = $false; Prunable = ''
-            }
-            continue
-        }
-        if (-not $cur) { continue }
-        switch -Regex ($line) {
-            '^HEAD (.+)$'             { $cur.Head     = $Matches[1] }
-            '^branch refs/heads/(.+)$'{ $cur.Branch   = $Matches[1] }
-            '^detached$'              { $cur.Detached = $true }
-            '^bare$'                  { $cur.Bare     = $true }
-            '^locked'                 { $cur.Locked   = $true }
-            '^prunable (.+)$'         { $cur.Prunable = $Matches[1] }
-            '^prunable$'              { $cur.Prunable = 'prunable' }
-        }
-    }
-    if ($cur) { $records += $cur }
-    return @($records)
-}
-
-# Does git STILL register a worktree that HOLDS THIS BRANCH? The question after
-# `git worktree remove --force`, and the authority is git's registry - never the disk (#287).
-# A removal routinely de-registers the worktree while the directory survives, empty, held by an
-# open handle from the session that created it; asking Test-Path there answers "still present"
-# about something git already let go, which kept a merged branch alive and forced a second -Fix
-# pass. An entry git still lists is a real failure; a leftover folder is litter.
 #
-# ASK BY BRANCH, NOT BY PATH, and note that this is the whole point rather than a shortcut. The
-# branch is what we are about to `git branch -D`, and a registered worktree holding it is exactly
-# what makes that fail - so it is the fact worth checking. Matching paths instead means comparing
-# two strings from different producers, which FAILS OPEN when they disagree: git emits the long
-# `C:/Users/Cristobal/...` while a path routed through %TEMP% can carry the 8.3 short name
-# `C:/Users/CRISTO~1/...`. That mismatch reads as "not registered" and licenses the delete. Caught
-# exactly that way while testing this fix, on a locked worktree git was still listing.
-# -Path is kept as a SECONDARY signal for the detached/branchless case; either hit is a block.
-# PURE over the text -> unit-testable.
-function Test-WorktreeStillRegistered {
-    param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$Porcelain,
-        [string]$Path   = '',
-        [string]$Branch = ''
-    )
-    $norm = { param($p) ($p -replace '\\', '/').TrimEnd('/') }
-    $want = if ($Path) { & $norm $Path } else { $null }
-    foreach ($w in (Get-WorktreeRecords -Porcelain $Porcelain)) {
-        # -eq on strings is case-insensitive, which is right for both a Windows path and the
-        # branch name as git echoes it back.
-        if ($Branch -and $w.Branch -eq $Branch)      { return $true }
-        if ($want   -and (& $norm $w.Path) -eq $want) { return $true }
-    }
-    return $false
-}
+# Get-WorktreeRecords and Test-WorktreeStillRegistered used to live HERE, and moved to
+# Board-Work.ps1 (#289) - the dot-source above brings them in, exactly like Get-SessionCompletion.
+# They moved because the session teardown needs the same "did the removal take?" verdict, and the
+# dependency only runs doctor -> work: Board-Work cannot dot-source us back without a cycle, and
+# a second copy is the drift this file refuses everywhere else.
 
 # Which PR speaks for THIS branch tip? Several PRs can share a reused branch name
 # (-TakeOver reuses `issue-<n>-<slug>`), so "the newest one" is not trustworthy: an old

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1802,6 +1802,77 @@ function Remove-SessionRegistryEntry {
     $kept | ConvertTo-Json -Depth 4 -AsArray | Set-Content $p
 }
 
+# Parse `git worktree list --porcelain` into objects. The porcelain format is a blank-line
+# separated record per worktree: `worktree <path>`, then optional `HEAD <oid>`,
+# `branch refs/heads/<name>` | `detached`, `bare`, `locked [<reason>]`, `prunable <reason>`.
+# We take `prunable` straight from git rather than guessing: git already knows a registered
+# worktree whose directory is gone. PURE over the text -> unit-testable.
+#
+# Lives here rather than in Board-Doctor.ps1 (its original home, moved in #289) because BOTH the
+# doctor and the teardown below need it, and the dot-source only runs doctor -> work.
+function Get-WorktreeRecords {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Porcelain)
+    $records = @()
+    $cur = $null
+    foreach ($rawLine in ($Porcelain -split "`r?`n")) {
+        $line = $rawLine.TrimEnd()
+        if (-not $line) { if ($cur) { $records += $cur; $cur = $null }; continue }
+        if ($line -match '^worktree (.+)$') {
+            if ($cur) { $records += $cur }
+            $cur = [pscustomobject]@{
+                Path = $Matches[1]; Head = ''; Branch = ''; Detached = $false
+                Bare = $false; Locked = $false; Prunable = ''
+            }
+            continue
+        }
+        if (-not $cur) { continue }
+        switch -Regex ($line) {
+            '^HEAD (.+)$'             { $cur.Head     = $Matches[1] }
+            '^branch refs/heads/(.+)$'{ $cur.Branch   = $Matches[1] }
+            '^detached$'              { $cur.Detached = $true }
+            '^bare$'                  { $cur.Bare     = $true }
+            '^locked'                 { $cur.Locked   = $true }
+            '^prunable (.+)$'         { $cur.Prunable = $Matches[1] }
+            '^prunable$'              { $cur.Prunable = 'prunable' }
+        }
+    }
+    if ($cur) { $records += $cur }
+    return @($records)
+}
+
+# Does git STILL register a worktree that HOLDS THIS BRANCH? The question after
+# `git worktree remove --force`, and the authority is git's registry - never the disk (#287/#289).
+# A removal routinely de-registers the worktree while the directory survives, empty, held by an
+# open handle from the shell that was cwd'd inside it; asking Test-Path there answers "still
+# present" about something git already let go. An entry git still lists is a real failure; a
+# leftover folder is litter.
+#
+# ASK BY BRANCH, NOT BY PATH, and note that this is the whole point rather than a shortcut. The
+# branch is what the caller is about to `git branch -D`, and a registered worktree holding it is
+# exactly what makes that fail - so it is the fact worth checking. Matching paths instead means
+# comparing two strings from different producers, which FAILS OPEN when they disagree: git emits
+# the long `C:/Users/Cristobal/...` while a path routed through %TEMP% can carry the 8.3 short name
+# `C:/Users/CRISTO~1/...`. That mismatch reads as "not registered" and licenses the delete. Caught
+# exactly that way while testing #287, on a locked worktree git was still listing.
+# -Path is kept as a SECONDARY signal for the detached/branchless case; either hit is a block.
+# PURE over the text -> unit-testable.
+function Test-WorktreeStillRegistered {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Porcelain,
+        [string]$Path   = '',
+        [string]$Branch = ''
+    )
+    $norm = { param($p) ($p -replace '\\', '/').TrimEnd('/') }
+    $want = if ($Path) { & $norm $Path } else { $null }
+    foreach ($w in (Get-WorktreeRecords -Porcelain $Porcelain)) {
+        # -eq on strings is case-insensitive, which is right for both a Windows path and the
+        # branch name as git echoes it back.
+        if ($Branch -and $w.Branch -eq $Branch)       { return $true }
+        if ($want   -and (& $norm $w.Path) -eq $want) { return $true }
+    }
+    return $false
+}
+
 # Tear down a finished session: kill the tab shell FIRST (the `pwsh -NoExit` left cwd'd
 # inside the worktree keeps a handle -> `git worktree remove` fails with Permission denied),
 # then remove the worktree, delete the local branch, and prune the registry entry. Returns
@@ -1847,19 +1918,39 @@ function Invoke-SessionCleanup {
         }
     }
     # Removing the worktree is the step that can genuinely fail (a held handle - see the
-    # tab-shell gotcha). Success = the path is gone afterwards. Only when it is do we delete
-    # the branch and prune the registry; otherwise keep BOTH so the leftover is still tracked
-    # and a later run can retry (Codex review, PR #269 - never drop tracking on a failed teardown).
+    # tab-shell gotcha). Success = GIT no longer registers it. Only then do we delete the branch
+    # and prune the registry; otherwise keep BOTH so the leftover is still tracked and a later
+    # run can retry (Codex review, PR #269 - never drop tracking on a failed teardown).
+    #
+    # ASK GIT, NOT THE DISK (#289), and here that is not a nicety - Test-Path made the retry
+    # UNABLE TO CONVERGE. With a handle open, `remove --force` de-registers the worktree and still
+    # fails to delete the directory, so pass 1 left the folder behind; Test-Path then said "still
+    # present" and kept the branch + the registry entry. Every later pass re-ran the removal on a
+    # path git had already forgotten ("fatal: not a working tree"), the folder never went away, and
+    # the entry leaked FOREVER. The doctor recovered on a second pass only because its inventory
+    # comes from `git worktree list`; workPath here comes from the registry, so nothing self-heals.
+    # This is the designed case for a `wt` session, whose shell is deliberately never killed above.
     $worktreeGone = $true
     if ($Session.workPath) {
         $actions += "git worktree remove --force $($Session.workPath)"
         if (-not $DryRun) {
             git worktree remove --force $Session.workPath 2>&1 | Out-Null
-            $worktreeGone = -not (Test-Path $Session.workPath)
+            $after = (git worktree list --porcelain 2>$null) -join "`n"
+            if ($LASTEXITCODE -ne 0) {
+                # FAIL CLOSED: "I could not ask git" is not "it is gone" (the #277 rule).
+                $actions += "FAIL no pude releer 'git worktree list' tras el remove - conservo la rama y el registro de #$($Session.issue) para reintentar"
+                return $actions
+            }
+            $worktreeGone = -not (Test-WorktreeStillRegistered -Porcelain $after -Path $Session.workPath -Branch $Session.branch)
+            # Litter, not a blocker: git let it go, so the teardown continues. Name the path -
+            # nothing else will ever clean it up, since git no longer knows about it.
+            if ($worktreeGone -and (Test-Path $Session.workPath)) {
+                $actions += "NOTA git solto el worktree pero la carpeta sigue en disco (handle abierto?): $($Session.workPath) - borrala a mano; sigo con la rama y el registro"
+            }
         }
     }
     if (-not $worktreeGone) {
-        $actions += "FAIL el worktree sigue presente (handle abierto?) - conservo la rama y el registro de #$($Session.issue) para reintentar"
+        $actions += "FAIL git sigue registrando el worktree de #$($Session.issue) (handle abierto?) - conservo la rama y el registro para reintentar"
         return $actions
     }
     # Deleting the branch is only safe once the work is somewhere else (#273). -PrMerged is

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1215,6 +1215,27 @@ Describe 'Get-SessionCompletion (watch completion predicate, #135)' {
     }
 }
 
+Describe 'Worktree registry helpers live here now (#289)' {
+    # Moved from Board-Doctor.ps1: the doctor dot-sources THIS file, so both callers share one
+    # verdict. The doctor's own suite still exercises them through that dot-source; these pin the
+    # contract at the new home. Full parsing/matching coverage stays in Board-Doctor.Tests.ps1.
+    It 'defines both helpers so the teardown below can reach them without a dot-source cycle' {
+        Get-Command Get-WorktreeRecords          -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        Get-Command Test-WorktreeStillRegistered -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+    It 'blocks on the branch even when the path strings do not compare equal' {
+        # The fail-open guarded since #287: git prints the long path, %TEMP% carries the 8.3 short
+        # name, so the same directory yields two different strings.
+        $p = "worktree C:/Users/Cristobal/AppData/Local/Temp/wt/w`nHEAD 1`nbranch refs/heads/issue-9-x`n"
+        Test-WorktreeStillRegistered -Porcelain $p -Path 'C:/Users/CRISTO~1/AppData/Local/Temp/wt/w' | Should -BeFalse
+        Test-WorktreeStillRegistered -Porcelain $p -Path 'C:/Users/CRISTO~1/AppData/Local/Temp/wt/w' -Branch 'issue-9-x' | Should -BeTrue
+    }
+    It 'reports a de-registered worktree as gone, whatever is left on disk' {
+        Test-WorktreeStillRegistered -Porcelain "worktree C:/repo`nHEAD 1`nbranch refs/heads/main`n" `
+            -Path 'C:/wt/issue-9' -Branch 'issue-9-x' | Should -BeFalse
+    }
+}
+
 Describe 'Invoke-SessionCleanup (teardown plan, #135)' {
     It 'plans kill -> worktree remove -> branch delete -> registry prune for a pwsh session, under -DryRun' {
         $s = [pscustomobject]@{ issue = 9; branch = 'issue-9-x'; workPath = 'C:\wt\issue-9'; sessionPid = 4321; via = 'pwsh' }
@@ -1253,6 +1274,78 @@ Describe 'Invoke-SessionCleanup (teardown plan, #135)' {
         ($acts -join ' ') | Should -Not -Match 'branch -'
         ($acts -join ' ') | Should -Not -Match 'prune #3'
         Should -Invoke Remove-SessionRegistryEntry -Times 0 -Exactly
+    }
+}
+
+Describe 'Invoke-SessionCleanup asks git, not the disk (#289)' {
+    # Real repo + real worktree + a REAL held handle: the whole bug is what the OS and git do to
+    # each other here, so a mock would only re-assert my own assumption. The handle stands in for
+    # the untracked `wt` tab shell that Invoke-SessionCleanup deliberately never kills (PR #269),
+    # which makes this the DESIGNED case for -Launch sessions, not a rare one.
+    BeforeEach {
+        $script:Repo2 = Join-Path $TestDrive ('h' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Work2 = "$($script:Repo2)-wt"
+        New-Item -ItemType Directory -Path $script:Repo2 | Out-Null
+        Push-Location $script:Repo2
+        git init -q -b main
+        'x' | Set-Content (Join-Path $script:Repo2 'a.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git worktree add -q -b issue-21-h $script:Work2 2>&1 | Out-Null
+        Mock Remove-SessionRegistryEntry { }
+        # Deny-share handle on a file INSIDE the worktree - what a shell cwd'd in there does.
+        $script:Handle = [System.IO.File]::Open((Join-Path $script:Work2 'a.txt'), 'Open', 'Read', 'None')
+        function script:New-HSession {
+            [pscustomobject]@{ issue = 21; branch = 'issue-21-h'; workPath = $script:Work2; sessionPid = 0; via = 'wt' }
+        }
+    }
+    AfterEach {
+        if ($script:Handle) { $script:Handle.Close(); $script:Handle = $null }
+        Pop-Location
+    }
+
+    It 'finishes the teardown in ONE pass when git released the worktree but the folder lingers' {
+        # THE BUG: `remove --force` de-registers the worktree AND fails to delete the directory.
+        # Test-Path saw the folder and reported "still present" about something git had let go,
+        # so the branch and the registry entry were kept.
+        $acts = @(Invoke-SessionCleanup -Session (New-HSession) -PrMerged)
+        Test-Path $script:Work2 | Should -BeTrue                      # folder survives: the handle
+        ((git worktree list --porcelain) -join "`n") | Should -Not -Match 'issue-21-h'  # git let go
+        ($acts -join ' ') | Should -Not -Match 'FAIL'
+        ($acts -join ' ') | Should -Match 'NOTA'                      # litter is reported...
+        # Parenthesised: Pester binds -Match to the literal '[regex]::Escape' otherwise.
+        ($acts -join ' ') | Should -Match ([regex]::Escape($script:Work2))  # ...with its path
+        ($acts -join ' ') | Should -Match 'branch -D issue-21-h'
+        ($acts -join ' ') | Should -Match 'prune #21'
+        (git branch --list 'issue-21-h') | Should -BeNullOrEmpty
+        Should -Invoke Remove-SessionRegistryEntry -Times 1 -Exactly
+    }
+
+    It 'the OLD Test-Path retry could never converge - the second pass is not a working tree' {
+        # Why this mattered more here than in the doctor: workPath comes from the REGISTRY, so a
+        # retry re-runs the removal on a path git already forgot. Pin git's real behaviour, which
+        # is the whole reason "retry next run" was never going to clean this up.
+        git worktree remove --force $script:Work2 2>&1 | Out-Null     # pass 1: de-registers, folder stays
+        Test-Path $script:Work2 | Should -BeTrue
+        $out = (git worktree remove --force $script:Work2 2>&1) -join ' '   # pass 2, as a later run would
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -Match 'not a working tree'
+        Test-Path $script:Work2 | Should -BeTrue      # ...so Test-Path stays true FOREVER
+    }
+
+    It 'still keeps branch + registry when git REALLY still registers the worktree' {
+        # The guard that must not be lost: a locked worktree survives `remove --force` and stays
+        # registered, so the teardown must refuse - branch and tracking both stay.
+        git worktree lock $script:Work2 2>&1 | Out-Null
+        try {
+            $acts = @(Invoke-SessionCleanup -Session (New-HSession) -PrMerged)
+            ((git worktree list --porcelain) -join "`n") | Should -Match 'issue-21-h'
+            ($acts -join ' ') | Should -Match 'FAIL'
+            ($acts -join ' ') | Should -Not -Match 'branch -'
+            ($acts -join ' ') | Should -Not -Match 'prune #21'
+            (git branch --list 'issue-21-h') | Should -Not -BeNullOrEmpty
+            Should -Invoke Remove-SessionRegistryEntry -Times 0 -Exactly
+        } finally { git worktree unlock $script:Work2 2>&1 | Out-Null }
     }
 }
 


### PR DESCRIPTION
Closes #289