### PR TITLE
work: teardown can still fail OPEN when the worktree drifted off its branch AND the path strings disagree

### DIFF
--- a/plugins/agentic-board/scripts/Board-Doctor.ps1
+++ b/plugins/agentic-board/scripts/Board-Doctor.ps1
@@ -498,19 +498,25 @@ function Remove-BranchAndWorktree {
         }
         $did += "git worktree remove --force $($Row.WorktreePath)"
         if (-not $DryRun) {
+            # Ask GIT whether the removal took, not the filesystem (#287). An empty folder left
+            # behind by an open handle is not a failed removal, and treating it as one kept a
+            # proven-merged branch and forced a second -Fix pass over the 58-branch cleanup.
+            # Snapshot BEFORE too: see Test-WorktreeRemovalTook - failing to RECOGNISE our
+            # worktree in the listing is not proof that it left it (#291).
+            $before = (git worktree list --porcelain 2>$null) -join "`n"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "     FAIL no pude leer 'git worktree list' antes del remove - conservo la rama $($Row.Branch) por si acaso." -ForegroundColor Red
+                return $did
+            }
             git worktree remove --force $Row.WorktreePath 2>&1 | Out-Null
-            # Ask GIT whether the removal took, not the filesystem (#287). See
-            # Test-WorktreeStillRegistered: an empty folder left behind by an open handle is not
-            # a failed removal, and treating it as one kept a proven-merged branch and forced a
-            # second -Fix pass over the 58-branch cleanup.
             $after = (git worktree list --porcelain 2>$null) -join "`n"
             if ($LASTEXITCODE -ne 0) {
                 # FAIL CLOSED: "I could not ask git" is not "it is gone" (the #277 rule).
                 Write-Host "     FAIL no pude releer 'git worktree list' tras el remove - conservo la rama $($Row.Branch) por si acaso." -ForegroundColor Red
                 return $did
             }
-            if (Test-WorktreeStillRegistered -Porcelain $after -Path $Row.WorktreePath -Branch $Row.Branch) {
-                Write-Host "     FAIL git sigue registrando un worktree con la rama $($Row.Branch) (handle abierto? locked?) - conservo la rama." -ForegroundColor Red
+            if (-not (Test-WorktreeRemovalTook -Before $before -After $after -Path $Row.WorktreePath -Branch $Row.Branch)) {
+                Write-Host "     FAIL git sigue registrando el worktree de $($Row.Branch) (handle abierto? locked?) - conservo la rama." -ForegroundColor Red
                 return $did
             }
             if (Test-Path $Row.WorktreePath) {

--- a/plugins/agentic-board/scripts/Board-Doctor.ps1
+++ b/plugins/agentic-board/scripts/Board-Doctor.ps1
@@ -501,13 +501,10 @@ function Remove-BranchAndWorktree {
             # Ask GIT whether the removal took, not the filesystem (#287). An empty folder left
             # behind by an open handle is not a failed removal, and treating it as one kept a
             # proven-merged branch and forced a second -Fix pass over the 58-branch cleanup.
-            # Snapshot BEFORE too: see Test-WorktreeRemovalTook - failing to RECOGNISE our
-            # worktree in the listing is not proof that it left it (#291).
-            $before = (git worktree list --porcelain 2>$null) -join "`n"
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "     FAIL no pude leer 'git worktree list' antes del remove - conservo la rama $($Row.Branch) por si acaso." -ForegroundColor Red
-                return $did
-            }
+            # Resolve the path into git's own form first, while the directory still exists to
+            # resolve from - otherwise a DETACHED worktree whose path spells differently is
+            # invisible to both signals and reads as "gone" (#291). See Resolve-GitPathForm.
+            $wtPathForGit = Resolve-GitPathForm $Row.WorktreePath
             git worktree remove --force $Row.WorktreePath 2>&1 | Out-Null
             $after = (git worktree list --porcelain 2>$null) -join "`n"
             if ($LASTEXITCODE -ne 0) {
@@ -515,7 +512,7 @@ function Remove-BranchAndWorktree {
                 Write-Host "     FAIL no pude releer 'git worktree list' tras el remove - conservo la rama $($Row.Branch) por si acaso." -ForegroundColor Red
                 return $did
             }
-            if (-not (Test-WorktreeRemovalTook -Before $before -After $after -Path $Row.WorktreePath -Branch $Row.Branch)) {
+            if (Test-WorktreeStillRegistered -Porcelain $after -Path $wtPathForGit -Branch $Row.Branch) {
                 Write-Host "     FAIL git sigue registrando el worktree de $($Row.Branch) (handle abierto? locked?) - conservo la rama." -ForegroundColor Red
                 return $did
             }

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1873,6 +1873,39 @@ function Test-WorktreeStillRegistered {
     return $false
 }
 
+# Did `git worktree remove` REALLY take? The question every destructive caller must answer before
+# deleting a branch or dropping a registry entry, and the one Test-WorktreeStillRegistered above
+# cannot answer alone (#291, found by a Codex review of #287/#289).
+#
+# That helper proves "still there" by NAME - branch first, path second. Both names can miss the
+# SAME registered worktree at once: the branch signal misses when the worktree drifted onto another
+# branch or went detached, and the path signal misses on exactly the 8.3 short name it was written
+# to survive. "I could not find it" then read as "it is gone" and licensed the delete - a fail-open
+# in a destructive path, and the third one today rooted in comparing paths across producers.
+#
+# So stop asking "can I still find MY worktree?" - our name for it may be wrong - and also ask "did
+# ANY worktree leave the registry?". The removal named a path and GIT resolved it, so if git's own
+# listing is unchanged, nothing was removed, whatever we can or cannot recognise. That compares
+# git's porcelain against git's own porcelain: one producer, one format, no mismatch to fool us.
+#
+# Both signals must agree before we call it gone: positive proof by name that it is STILL there
+# wins outright, and an unchanged registry is a refusal on its own. PURE -> unit-testable.
+function Test-WorktreeRemovalTook {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Before,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$After,
+        [string]$Path   = '',
+        [string]$Branch = ''
+    )
+    if (Test-WorktreeStillRegistered -Porcelain $After -Path $Path -Branch $Branch) { return $false }
+    # Set difference, not a count: a worktree added concurrently would keep the count level and
+    # mask a real removal. An empty/unreadable BEFORE proves nothing -> no records left -> refuse.
+    $beforePaths = @(Get-WorktreeRecords -Porcelain $Before | ForEach-Object { $_.Path })
+    $afterPaths  = @(Get-WorktreeRecords -Porcelain $After  | ForEach-Object { $_.Path })
+    $left = @($beforePaths | Where-Object { $afterPaths -notcontains $_ })
+    return ($left.Count -gt 0)
+}
+
 # Tear down a finished session: kill the tab shell FIRST (the `pwsh -NoExit` left cwd'd
 # inside the worktree keeps a handle -> `git worktree remove` fails with Permission denied),
 # then remove the worktree, delete the local branch, and prune the registry entry. Returns
@@ -1934,6 +1967,13 @@ function Invoke-SessionCleanup {
     if ($Session.workPath) {
         $actions += "git worktree remove --force $($Session.workPath)"
         if (-not $DryRun) {
+            # Snapshot the registry BEFORE: "did anything leave?" is the only signal that survives
+            # our name for the worktree being wrong (#291).
+            $before = (git worktree list --porcelain 2>$null) -join "`n"
+            if ($LASTEXITCODE -ne 0) {
+                $actions += "FAIL no pude leer 'git worktree list' antes del remove - conservo la rama y el registro de #$($Session.issue) para reintentar"
+                return $actions
+            }
             git worktree remove --force $Session.workPath 2>&1 | Out-Null
             $after = (git worktree list --porcelain 2>$null) -join "`n"
             if ($LASTEXITCODE -ne 0) {
@@ -1941,7 +1981,7 @@ function Invoke-SessionCleanup {
                 $actions += "FAIL no pude releer 'git worktree list' tras el remove - conservo la rama y el registro de #$($Session.issue) para reintentar"
                 return $actions
             }
-            $worktreeGone = -not (Test-WorktreeStillRegistered -Porcelain $after -Path $Session.workPath -Branch $Session.branch)
+            $worktreeGone = Test-WorktreeRemovalTook -Before $before -After $after -Path $Session.workPath -Branch $Session.branch
             # Litter, not a blocker: git let it go, so the teardown continues. Name the path -
             # nothing else will ever clean it up, since git no longer knows about it.
             if ($worktreeGone -and (Test-Path $Session.workPath)) {

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1873,37 +1873,30 @@ function Test-WorktreeStillRegistered {
     return $false
 }
 
-# Did `git worktree remove` REALLY take? The question every destructive caller must answer before
-# deleting a branch or dropping a registry entry, and the one Test-WorktreeStillRegistered above
-# cannot answer alone (#291, found by a Codex review of #287/#289).
+# Put a path into the form git prints, so it can be compared with `git worktree list` output at all
+# (#291, found by a Codex review of #287/#289).
 #
-# That helper proves "still there" by NAME - branch first, path second. Both names can miss the
-# SAME registered worktree at once: the branch signal misses when the worktree drifted onto another
-# branch or went detached, and the path signal misses on exactly the 8.3 short name it was written
-# to survive. "I could not find it" then read as "it is gone" and licensed the delete - a fail-open
-# in a destructive path, and the third one today rooted in comparing paths across producers.
+# Test-WorktreeStillRegistered proves "still there" by NAME: branch first, path second. Both can
+# miss the SAME registered worktree - the branch signal is blind to a DETACHED worktree, and the
+# path signal is blind whenever the two strings disagree for one directory. They disagree for a
+# real reason: git prints the LONG form `C:/Users/Cristobal/...`, while a path that travelled
+# through %TEMP% (or any 8.3-shortened parent) carries `C:/Users/CRISTO~1/...`. "I could not find
+# it" then read as "it is gone" and licensed the delete.
 #
-# So stop asking "can I still find MY worktree?" - our name for it may be wrong - and also ask "did
-# ANY worktree leave the registry?". The removal named a path and GIT resolved it, so if git's own
-# listing is unchanged, nothing was removed, whatever we can or cannot recognise. That compares
-# git's porcelain against git's own porcelain: one producer, one format, no mismatch to fool us.
+# Only the FILESYSTEM can expand a short name, so this is deliberately impure - Get-Item does the
+# expansion, and `(Resolve-Path).Path` is NOT a substitute (it preserves the short form; measured).
+# When the directory is gone we cannot expand, and we do not need to: git cannot still hold a LIVE
+# worktree at a path that does not exist, so falling back to the raw string cannot hide one.
 #
-# Both signals must agree before we call it gone: positive proof by name that it is STILL there
-# wins outright, and an unchanged registry is a refusal on its own. PURE -> unit-testable.
-function Test-WorktreeRemovalTook {
-    param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$Before,
-        [Parameter(Mandatory)][AllowEmptyString()][string]$After,
-        [string]$Path   = '',
-        [string]$Branch = ''
-    )
-    if (Test-WorktreeStillRegistered -Porcelain $After -Path $Path -Branch $Branch) { return $false }
-    # Set difference, not a count: a worktree added concurrently would keep the count level and
-    # mask a real removal. An empty/unreadable BEFORE proves nothing -> no records left -> refuse.
-    $beforePaths = @(Get-WorktreeRecords -Porcelain $Before | ForEach-Object { $_.Path })
-    $afterPaths  = @(Get-WorktreeRecords -Porcelain $After  | ForEach-Object { $_.Path })
-    $left = @($beforePaths | Where-Object { $afterPaths -notcontains $_ })
-    return ($left.Count -gt 0)
+# NOTE this is why the fix is a resolver and not a before/after diff of the registry. Proving "some
+# worktree left the list" instead of "MY worktree is not in it" sounds safer and is worse: it makes
+# an already-de-registered worktree - a stale sessions.json entry, one the user removed by hand -
+# unprovable forever, so every retry refuses and the entry leaks. That is exactly the #289 disease,
+# and Codex caught this file re-introducing it.
+function Resolve-GitPathForm {
+    param([string]$Path)
+    if (-not $Path) { return '' }
+    try { return (Get-Item -LiteralPath $Path -ErrorAction Stop).FullName } catch { return $Path }
 }
 
 # Tear down a finished session: kill the tab shell FIRST (the `pwsh -NoExit` left cwd'd
@@ -1967,13 +1960,9 @@ function Invoke-SessionCleanup {
     if ($Session.workPath) {
         $actions += "git worktree remove --force $($Session.workPath)"
         if (-not $DryRun) {
-            # Snapshot the registry BEFORE: "did anything leave?" is the only signal that survives
-            # our name for the worktree being wrong (#291).
-            $before = (git worktree list --porcelain 2>$null) -join "`n"
-            if ($LASTEXITCODE -ne 0) {
-                $actions += "FAIL no pude leer 'git worktree list' antes del remove - conservo la rama y el registro de #$($Session.issue) para reintentar"
-                return $actions
-            }
+            # Resolve BEFORE the removal, while the directory still exists to be resolved: after a
+            # successful remove there may be nothing left to expand the short name from (#291).
+            $wtPathForGit = Resolve-GitPathForm $Session.workPath
             git worktree remove --force $Session.workPath 2>&1 | Out-Null
             $after = (git worktree list --porcelain 2>$null) -join "`n"
             if ($LASTEXITCODE -ne 0) {
@@ -1981,7 +1970,7 @@ function Invoke-SessionCleanup {
                 $actions += "FAIL no pude releer 'git worktree list' tras el remove - conservo la rama y el registro de #$($Session.issue) para reintentar"
                 return $actions
             }
-            $worktreeGone = Test-WorktreeRemovalTook -Before $before -After $after -Path $Session.workPath -Branch $Session.branch
+            $worktreeGone = -not (Test-WorktreeStillRegistered -Porcelain $after -Path $wtPathForGit -Branch $Session.branch)
             # Litter, not a blocker: git let it go, so the teardown continues. Name the path -
             # nothing else will ever clean it up, since git no longer knows about it.
             if ($worktreeGone -and (Test-Path $Session.workPath)) {

--- a/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
@@ -198,12 +198,20 @@ Describe 'Remove-BranchAndWorktree asks git, not the disk (#287)' {
     }
 
     It 'gates the branch delete on the porcelain registry' {
-        ($script:RemoveFn -match 'Test-WorktreeStillRegistered') | Should -BeTrue
+        ($script:RemoveFn -match 'Test-WorktreeRemovalTook') | Should -BeTrue
     }
     It 'passes the BRANCH to the gate, not only the path' {
         # Path-only is the fail-open case (see the 8.3 short-name test above): the branch is the
         # signal that actually decides whether `git branch -D` can succeed.
         ($script:RemoveFn -match '-Branch \$Row\.Branch') | Should -BeTrue
+    }
+    It 'snapshots the registry BEFORE the remove, so it can tell "left" from "unrecognised" (#291)' {
+        # Both name signals can miss the same still-registered worktree; only the before/after
+        # difference survives that. If the BEFORE read is dropped, #291 is back.
+        $snap = $script:RemoveFn.IndexOf('$before = (git worktree list')
+        $rm   = $script:RemoveFn.IndexOf('git worktree remove --force $Row.WorktreePath 2>&1')
+        $snap | Should -BeGreaterThan 0
+        $snap | Should -BeLessThan $rm
     }
     It 'never lets Test-Path of the worktree path veto the delete again' {
         # Test-Path may still REPORT a leftover folder - that note is useful. What must never come
@@ -213,7 +221,7 @@ Describe 'Remove-BranchAndWorktree asks git, not the disk (#287)' {
     }
     It 'checks the registry BEFORE deleting the branch, not after' {
         # A gate that runs after `git branch -D` is decorative.
-        $gate = $script:RemoveFn.IndexOf('Test-WorktreeStillRegistered')
+        $gate = $script:RemoveFn.IndexOf('Test-WorktreeRemovalTook')
         $del  = $script:RemoveFn.IndexOf('git branch $BranchFlag')
         $gate | Should -BeGreaterThan 0
         $gate | Should -BeLessThan $del

--- a/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
@@ -198,20 +198,21 @@ Describe 'Remove-BranchAndWorktree asks git, not the disk (#287)' {
     }
 
     It 'gates the branch delete on the porcelain registry' {
-        ($script:RemoveFn -match 'Test-WorktreeRemovalTook') | Should -BeTrue
+        ($script:RemoveFn -match 'Test-WorktreeStillRegistered') | Should -BeTrue
     }
     It 'passes the BRANCH to the gate, not only the path' {
         # Path-only is the fail-open case (see the 8.3 short-name test above): the branch is the
         # signal that actually decides whether `git branch -D` can succeed.
         ($script:RemoveFn -match '-Branch \$Row\.Branch') | Should -BeTrue
     }
-    It 'snapshots the registry BEFORE the remove, so it can tell "left" from "unrecognised" (#291)' {
-        # Both name signals can miss the same still-registered worktree; only the before/after
-        # difference survives that. If the BEFORE read is dropped, #291 is back.
-        $snap = $script:RemoveFn.IndexOf('$before = (git worktree list')
-        $rm   = $script:RemoveFn.IndexOf('git worktree remove --force $Row.WorktreePath 2>&1')
-        $snap | Should -BeGreaterThan 0
-        $snap | Should -BeLessThan $rm
+    It 'resolves the path BEFORE the remove, while there is still a directory to resolve (#291)' {
+        # A detached worktree is invisible to the branch signal, so the path is the only signal
+        # left - and it only works once both sides spell the directory the same way. Resolving
+        # after the removal would be too late: the directory may be gone.
+        $res = $script:RemoveFn.IndexOf('Resolve-GitPathForm')
+        $rm  = $script:RemoveFn.IndexOf('git worktree remove --force $Row.WorktreePath 2>&1')
+        $res | Should -BeGreaterThan 0
+        $res | Should -BeLessThan $rm
     }
     It 'never lets Test-Path of the worktree path veto the delete again' {
         # Test-Path may still REPORT a leftover folder - that note is useful. What must never come
@@ -221,7 +222,7 @@ Describe 'Remove-BranchAndWorktree asks git, not the disk (#287)' {
     }
     It 'checks the registry BEFORE deleting the branch, not after' {
         # A gate that runs after `git branch -D` is decorative.
-        $gate = $script:RemoveFn.IndexOf('Test-WorktreeRemovalTook')
+        $gate = $script:RemoveFn.IndexOf('Test-WorktreeStillRegistered')
         $del  = $script:RemoveFn.IndexOf('git branch $BranchFlag')
         $gate | Should -BeGreaterThan 0
         $gate | Should -BeLessThan $del

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1236,64 +1236,36 @@ Describe 'Worktree registry helpers live here now (#289)' {
     }
 }
 
-Describe 'Test-WorktreeRemovalTook (did the removal REALLY take, #291)' {
-    # Found by a Codex review of #287/#289 and reproduced. Test-WorktreeStillRegistered proves
-    # "still there" by NAME - branch first, path second. Both names can miss the SAME registered
-    # worktree at once: the branch signal misses when the worktree drifted to another branch (or
-    # detached), and the path signal misses on the 8.3 short name it was written to survive. Not
-    # finding it then read as "gone" and licensed the delete - a fail-open in a destructive path.
+Describe 'Resolve-GitPathForm (make our path comparable to git''s, #291)' {
+    # Found by a Codex review of #287/#289. Test-WorktreeStillRegistered proves "still there" by
+    # NAME: branch first, path second. Both can miss the SAME registered worktree - the branch
+    # signal is blind to a DETACHED one, and the path signal is blind when the two strings spell
+    # one directory differently. "Could not find it" then read as "gone" and licensed the delete.
     #
-    # The cure is to stop asking "can I still find MY worktree?" (my name for it may be wrong) and
-    # ask "did ANY worktree leave the registry?". That compares git's porcelain against git's own
-    # porcelain - one producer, one format - so no cross-producer string mismatch can fool it.
-    BeforeAll {
-        $script:Main = "worktree C:/repo`nHEAD 111`nbranch refs/heads/main`n"
-        # The session's worktree, still on its branch. Long path, as git prints it.
-        $script:Mine = "worktree C:/Users/Cristobal/AppData/Local/Temp/s/wt`nHEAD 222`nbranch refs/heads/issue-21-h`n"
-        # The SAME worktree, drifted off its branch. DETACHED is the realistic shape: git refuses
-        # `checkout <branch>` for a branch already checked out in another worktree ("fatal: 'main'
-        # is already used by worktree at ..."), so a drifted worktree is detached or on some third
-        # branch - never a duplicate of main. Verified against a real repo.
-        $script:Drift = "worktree C:/Users/Cristobal/AppData/Local/Temp/s/wt`nHEAD 222`ndetached`n"
-        $script:Short = 'C:/Users/CRISTO~1/AppData/Local/Temp/s/wt'   # what the registry stored
-        $script:Br    = 'issue-21-h'
+    # The strings differ for a real reason, so the cure is to stop them differing at the source.
+    It 'expands an 8.3 short name into the long form git prints' {
+        # THE #291 ROOT CAUSE. %TEMP% is short-named on this machine, which is how the bug was
+        # first seen. Guard the assumption itself: if this ever stops being true the fix is moot.
+        $short = $env:TEMP
+        $short | Should -Match 'CRISTO~1|~1'          # precondition: the input really is shortened
+        (Resolve-GitPathForm $short) | Should -Not -Match '~1'
+        (Resolve-GitPathForm $short) | Should -Be (Get-Item -LiteralPath $short).FullName
     }
-
-    It 'THE #291 FAIL-OPEN: a drifted worktree whose path does not string-match is NOT "gone"' {
-        # Both name signals miss, yet git plainly still lists the worktree: the registry is
-        # unchanged. Before the fix this returned "gone" and the teardown deleted the branch and
-        # pruned the registry entry out from under a live worktree (breaking the #269 invariant).
-        $before = $script:Main + "`n" + $script:Drift
-        Test-WorktreeStillRegistered -Porcelain $before -Path $script:Short -Branch $script:Br | Should -BeFalse  # both names miss
-        Test-WorktreeRemovalTook -Before $before -After $before -Path $script:Short -Branch $script:Br | Should -BeFalse
+    It 'makes the short and long spellings of one directory match in the registry check' {
+        # The end-to-end point of the resolver, at the level the caller cares about.
+        $long = (Get-Item -LiteralPath $env:TEMP).FullName
+        $p = "worktree $($long.Replace([char]92, '/'))`nHEAD 222`ndetached`n"   # detached: branch signal is blind
+        Test-WorktreeStillRegistered -Porcelain $p -Path $env:TEMP                        | Should -BeFalse  # raw: misses
+        Test-WorktreeStillRegistered -Porcelain $p -Path (Resolve-GitPathForm $env:TEMP)  | Should -BeTrue   # resolved: catches
     }
-    It 'says the removal took when a record actually left the registry' {
-        # The #287 case: the handle keeps the FOLDER, but git de-registered the worktree. The
-        # teardown must continue - this is what the whole fix exists to allow.
-        $before = $script:Main + "`n" + $script:Mine
-        Test-WorktreeRemovalTook -Before $before -After $script:Main -Path $script:Short -Branch $script:Br | Should -BeTrue
+    It 'returns a non-existent path unchanged instead of throwing' {
+        # We cannot expand what is not there - and need not: git cannot hold a LIVE worktree at a
+        # path that does not exist, so the raw fallback cannot hide one.
+        $gone = Join-Path $env:TEMP 'definitely-not-here-291'
+        (Resolve-GitPathForm $gone) | Should -Be $gone
     }
-    It 'refuses when nothing left the registry, even with no name to match on' {
-        Test-WorktreeRemovalTook -Before $script:Main -After $script:Main | Should -BeFalse
-    }
-    It 'a still-registered worktree wins outright, whatever else changed' {
-        # Positive proof by name is never overridden by the set having shrunk for other reasons.
-        $before = $script:Main + "`n" + $script:Mine + "`nworktree C:/other`nHEAD 333`nbranch refs/heads/z`n"
-        $after  = $script:Main + "`n" + $script:Mine      # C:/other left; OURS did not
-        Test-WorktreeRemovalTook -Before $before -After $after -Path $script:Short -Branch $script:Br | Should -BeFalse
-    }
-    It 'a concurrently ADDED worktree does not mask our removal' {
-        # Counting records would break here (2 before, 2 after); the set difference does not.
-        $before = $script:Main + "`n" + $script:Mine
-        $after  = $script:Main + "`nworktree C:/brand-new`nHEAD 444`nbranch refs/heads/new`n"
-        Test-WorktreeRemovalTook -Before $before -After $after -Path $script:Short -Branch $script:Br | Should -BeTrue
-    }
-    It 'fails closed when the BEFORE listing is empty (nothing can be proven gone)' {
-        Test-WorktreeRemovalTook -Before '' -After $script:Main -Path $script:Short -Branch $script:Br | Should -BeFalse
-    }
-    It 'still catches the plain still-registered case by branch' {
-        $before = $script:Main + "`n" + $script:Mine
-        Test-WorktreeRemovalTook -Before $before -After $before -Path '' -Branch $script:Br | Should -BeFalse
+    It 'returns empty for an empty path rather than throwing' {
+        (Resolve-GitPathForm '') | Should -Be ''
     }
 }
 
@@ -1396,9 +1368,9 @@ Describe 'Invoke-SessionCleanup asks git, not the disk (#289)' {
 
     It 'keeps branch + registry when the worktree is still registered but DETACHED (#291)' {
         # The Codex finding, on a real repo. Detached => the branch signal cannot see it; locked
-        # => `remove --force` genuinely leaves it registered. With a workPath that does not
-        # string-match git's porcelain (the 8.3 case), BOTH name signals miss the same live
-        # worktree, and "I cannot find it" used to mean "it is gone" -> delete + prune.
+        # => `remove --force` genuinely leaves it registered. Only the resolved path can catch it,
+        # and before the fix "I cannot find it" meant "it is gone" -> delete + prune, out from
+        # under a live worktree.
         git -C $script:Work2 checkout --detach 2>&1 | Out-Null
         git worktree lock $script:Work2 2>&1 | Out-Null
         try {
@@ -1411,6 +1383,21 @@ Describe 'Invoke-SessionCleanup asks git, not the disk (#289)' {
             ($acts -join ' ') | Should -Not -Match 'prune #21'
             Should -Invoke Remove-SessionRegistryEntry -Times 0 -Exactly
         } finally { git worktree unlock $script:Work2 2>&1 | Out-Null }
+    }
+
+    It 'CONVERGES on an already-de-registered worktree instead of leaking it forever (#291)' {
+        # Codex caught the first cut of this fix re-creating the #289 disease. Proving "some
+        # worktree LEFT the list" instead of "MY worktree is not IN it" makes a stale registry
+        # entry - one whose worktree git already forgot, e.g. removed by hand - unprovable: the
+        # before/after listings are identical, so every retry refused and the entry leaked.
+        # workPath here comes from sessions.json, so nothing else would ever clear it.
+        $script:Handle.Close(); $script:Handle = $null
+        git worktree remove --force $script:Work2 2>&1 | Out-Null     # git already forgot it
+        ((git worktree list --porcelain) -join "`n") | Should -Not -Match 'issue-21-h'
+        $acts = @(Invoke-SessionCleanup -Session (New-HSession) -PrMerged)
+        ($acts -join ' ') | Should -Not -Match 'FAIL'
+        ($acts -join ' ') | Should -Match 'prune #21'                  # the entry is finally cleared
+        Should -Invoke Remove-SessionRegistryEntry -Times 1 -Exactly
     }
 
     It 'still keeps branch + registry when git REALLY still registers the worktree' {

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1236,6 +1236,67 @@ Describe 'Worktree registry helpers live here now (#289)' {
     }
 }
 
+Describe 'Test-WorktreeRemovalTook (did the removal REALLY take, #291)' {
+    # Found by a Codex review of #287/#289 and reproduced. Test-WorktreeStillRegistered proves
+    # "still there" by NAME - branch first, path second. Both names can miss the SAME registered
+    # worktree at once: the branch signal misses when the worktree drifted to another branch (or
+    # detached), and the path signal misses on the 8.3 short name it was written to survive. Not
+    # finding it then read as "gone" and licensed the delete - a fail-open in a destructive path.
+    #
+    # The cure is to stop asking "can I still find MY worktree?" (my name for it may be wrong) and
+    # ask "did ANY worktree leave the registry?". That compares git's porcelain against git's own
+    # porcelain - one producer, one format - so no cross-producer string mismatch can fool it.
+    BeforeAll {
+        $script:Main = "worktree C:/repo`nHEAD 111`nbranch refs/heads/main`n"
+        # The session's worktree, still on its branch. Long path, as git prints it.
+        $script:Mine = "worktree C:/Users/Cristobal/AppData/Local/Temp/s/wt`nHEAD 222`nbranch refs/heads/issue-21-h`n"
+        # The SAME worktree, drifted off its branch. DETACHED is the realistic shape: git refuses
+        # `checkout <branch>` for a branch already checked out in another worktree ("fatal: 'main'
+        # is already used by worktree at ..."), so a drifted worktree is detached or on some third
+        # branch - never a duplicate of main. Verified against a real repo.
+        $script:Drift = "worktree C:/Users/Cristobal/AppData/Local/Temp/s/wt`nHEAD 222`ndetached`n"
+        $script:Short = 'C:/Users/CRISTO~1/AppData/Local/Temp/s/wt'   # what the registry stored
+        $script:Br    = 'issue-21-h'
+    }
+
+    It 'THE #291 FAIL-OPEN: a drifted worktree whose path does not string-match is NOT "gone"' {
+        # Both name signals miss, yet git plainly still lists the worktree: the registry is
+        # unchanged. Before the fix this returned "gone" and the teardown deleted the branch and
+        # pruned the registry entry out from under a live worktree (breaking the #269 invariant).
+        $before = $script:Main + "`n" + $script:Drift
+        Test-WorktreeStillRegistered -Porcelain $before -Path $script:Short -Branch $script:Br | Should -BeFalse  # both names miss
+        Test-WorktreeRemovalTook -Before $before -After $before -Path $script:Short -Branch $script:Br | Should -BeFalse
+    }
+    It 'says the removal took when a record actually left the registry' {
+        # The #287 case: the handle keeps the FOLDER, but git de-registered the worktree. The
+        # teardown must continue - this is what the whole fix exists to allow.
+        $before = $script:Main + "`n" + $script:Mine
+        Test-WorktreeRemovalTook -Before $before -After $script:Main -Path $script:Short -Branch $script:Br | Should -BeTrue
+    }
+    It 'refuses when nothing left the registry, even with no name to match on' {
+        Test-WorktreeRemovalTook -Before $script:Main -After $script:Main | Should -BeFalse
+    }
+    It 'a still-registered worktree wins outright, whatever else changed' {
+        # Positive proof by name is never overridden by the set having shrunk for other reasons.
+        $before = $script:Main + "`n" + $script:Mine + "`nworktree C:/other`nHEAD 333`nbranch refs/heads/z`n"
+        $after  = $script:Main + "`n" + $script:Mine      # C:/other left; OURS did not
+        Test-WorktreeRemovalTook -Before $before -After $after -Path $script:Short -Branch $script:Br | Should -BeFalse
+    }
+    It 'a concurrently ADDED worktree does not mask our removal' {
+        # Counting records would break here (2 before, 2 after); the set difference does not.
+        $before = $script:Main + "`n" + $script:Mine
+        $after  = $script:Main + "`nworktree C:/brand-new`nHEAD 444`nbranch refs/heads/new`n"
+        Test-WorktreeRemovalTook -Before $before -After $after -Path $script:Short -Branch $script:Br | Should -BeTrue
+    }
+    It 'fails closed when the BEFORE listing is empty (nothing can be proven gone)' {
+        Test-WorktreeRemovalTook -Before '' -After $script:Main -Path $script:Short -Branch $script:Br | Should -BeFalse
+    }
+    It 'still catches the plain still-registered case by branch' {
+        $before = $script:Main + "`n" + $script:Mine
+        Test-WorktreeRemovalTook -Before $before -After $before -Path '' -Branch $script:Br | Should -BeFalse
+    }
+}
+
 Describe 'Invoke-SessionCleanup (teardown plan, #135)' {
     It 'plans kill -> worktree remove -> branch delete -> registry prune for a pwsh session, under -DryRun' {
         $s = [pscustomobject]@{ issue = 9; branch = 'issue-9-x'; workPath = 'C:\wt\issue-9'; sessionPid = 4321; via = 'pwsh' }
@@ -1331,6 +1392,25 @@ Describe 'Invoke-SessionCleanup asks git, not the disk (#289)' {
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'not a working tree'
         Test-Path $script:Work2 | Should -BeTrue      # ...so Test-Path stays true FOREVER
+    }
+
+    It 'keeps branch + registry when the worktree is still registered but DETACHED (#291)' {
+        # The Codex finding, on a real repo. Detached => the branch signal cannot see it; locked
+        # => `remove --force` genuinely leaves it registered. With a workPath that does not
+        # string-match git's porcelain (the 8.3 case), BOTH name signals miss the same live
+        # worktree, and "I cannot find it" used to mean "it is gone" -> delete + prune.
+        git -C $script:Work2 checkout --detach 2>&1 | Out-Null
+        git worktree lock $script:Work2 2>&1 | Out-Null
+        try {
+            $s = [pscustomobject]@{ issue = 21; branch = 'issue-21-h'; workPath = $script:Work2
+                                    sessionPid = 0; via = 'wt' }
+            $acts = @(Invoke-SessionCleanup -Session $s -PrMerged)
+            ((git worktree list --porcelain) -join "`n") | Should -Match 'detached'   # still registered
+            ($acts -join ' ') | Should -Match 'FAIL'
+            ($acts -join ' ') | Should -Not -Match 'branch -'
+            ($acts -join ' ') | Should -Not -Match 'prune #21'
+            Should -Invoke Remove-SessionRegistryEntry -Times 0 -Exactly
+        } finally { git worktree unlock $script:Work2 2>&1 | Out-Null }
     }
 
     It 'still keeps branch + registry when git REALLY still registers the worktree' {

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1243,20 +1243,43 @@ Describe 'Resolve-GitPathForm (make our path comparable to git''s, #291)' {
     # one directory differently. "Could not find it" then read as "gone" and licensed the delete.
     #
     # The strings differ for a real reason, so the cure is to stop them differing at the source.
+    # Build a REAL short name rather than assuming %TEMP% carries one: it does on this machine and
+    # on the windows-latest runner (RUNNER~1), but that is the runner's business, not a contract.
+    # 8.3 generation can also be off per-volume (fsutil 8dot3name), so skip rather than fail there.
+    BeforeAll {
+        $script:LongDir = Join-Path $TestDrive 'un-nombre-muy-largo-para-forzar-8dot3'
+        $script:ShortDir = ''
+        if ($IsWindows) {
+            New-Item -ItemType Directory -Path $script:LongDir -Force | Out-Null
+            try {
+                $fso = New-Object -ComObject Scripting.FileSystemObject
+                $script:ShortDir = $fso.GetFolder($script:LongDir).ShortPath
+            } catch { $script:ShortDir = '' }
+        }
+    }
+
     It 'expands an 8.3 short name into the long form git prints' {
-        # THE #291 ROOT CAUSE. %TEMP% is short-named on this machine, which is how the bug was
-        # first seen. Guard the assumption itself: if this ever stops being true the fix is moot.
-        $short = $env:TEMP
-        $short | Should -Match 'CRISTO~1|~1'          # precondition: the input really is shortened
-        (Resolve-GitPathForm $short) | Should -Not -Match '~1'
-        (Resolve-GitPathForm $short) | Should -Be (Get-Item -LiteralPath $short).FullName
+        # THE #291 ROOT CAUSE, pinned on a path we shortened ourselves.
+        if (-not $script:ShortDir -or $script:ShortDir -notlike '*~*') {
+            Set-ItResult -Skipped -Because 'this volume does not generate 8.3 short names'
+            return
+        }
+        $resolved = Resolve-GitPathForm $script:ShortDir
+        $resolved | Should -Not -Match '~'
+        $resolved | Should -BeLike '*un-nombre-muy-largo-para-forzar-8dot3'
     }
     It 'makes the short and long spellings of one directory match in the registry check' {
-        # The end-to-end point of the resolver, at the level the caller cares about.
-        $long = (Get-Item -LiteralPath $env:TEMP).FullName
-        $p = "worktree $($long.Replace([char]92, '/'))`nHEAD 222`ndetached`n"   # detached: branch signal is blind
-        Test-WorktreeStillRegistered -Porcelain $p -Path $env:TEMP                        | Should -BeFalse  # raw: misses
-        Test-WorktreeStillRegistered -Porcelain $p -Path (Resolve-GitPathForm $env:TEMP)  | Should -BeTrue   # resolved: catches
+        # The end-to-end point of the resolver, at the level the caller cares about. Measured:
+        # (Resolve-Path).Path and the FileSystemObject both PRESERVE the short form - only
+        # Get-Item/DirectoryInfo expand it - which is why the resolver is written the way it is.
+        if (-not $script:ShortDir -or $script:ShortDir -notlike '*~*') {
+            Set-ItResult -Skipped -Because 'this volume does not generate 8.3 short names'
+            return
+        }
+        $gitForm = (Get-Item -LiteralPath $script:LongDir).FullName.Replace([char]92, '/')
+        $p = "worktree $gitForm`nHEAD 222`ndetached`n"      # detached => the branch signal is blind
+        Test-WorktreeStillRegistered -Porcelain $p -Path $script:ShortDir | Should -BeFalse                        # raw: misses it
+        Test-WorktreeStillRegistered -Porcelain $p -Path (Resolve-GitPathForm $script:ShortDir) | Should -BeTrue   # resolved: catches it
     }
     It 'returns a non-existent path unchanged instead of throwing' {
         # We cannot expand what is not there - and need not: git cannot hold a LIVE worktree at a


### PR DESCRIPTION
Closes #291