### PR TITLE
fix(board): -Migrate resuelve el conflicto legacy/canonica en vez de mandarte a la UI (#300)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 *.fields.json
 /HANDOFF.md
 /.handoffs/
+
+# Pester artifact (Invoke-Pester -CI). Embeds ABSOLUTE local paths — the guard blocks it as private.
+testResults.xml

--- a/plugins/agentic-board/commands/board.md
+++ b/plugins/agentic-board/commands/board.md
@@ -179,14 +179,19 @@ matching recipe from the projects-admin references:
   **bulk-fill any custom field across EVERY item by rule** (`scripts/Set-BoardField.ps1` — single-select
   by title-prefix map, or text by `{title}` template — idempotent, retries 502s)
   (references/field-presets.md + board-ops.md). Visibility-per-view and group-by are UI-only — say so.
-  - **`apply <lang> --migrate` — standardize an EXISTING board onto the canonical preset.** A plain
-    apply only creates MISSING fields and matches options BY NAME, so a board born from GitHub's
-    default template (`Todo / In Progress / Done`) just gains a `Backlog` next to its `Todo`, every
-    item stays on `Todo`, and nothing really migrates. `--migrate` RENAMES the legacy option in place
-    (`Apply-FieldPreset.ps1 -Migrate`, by option id → item assignments survive; `Todo`→`Backlog`,
-    `P2 Medium`→`P2`, …). A rename hits every item at once, so ALWAYS preview with `--dry-run` first
-    and let it confirm (`-Yes` only when already approved). Offer this whenever a board shows legacy
-    Status options — `/board work` now flags them instead of reporting a false "no pending".
+  - **`apply <lang>` standardizes by DEFAULT.** A board born from GitHub's default template
+    (`Todo / In Progress / Done`) is migrated onto the canonical preset with no flag: the legacy
+    option is RENAMED in place (by option id → item assignments survive; `Todo`→`Backlog`,
+    `P2 Medium`→`P2`, …), never duplicated. A rename hits every item at once, so ALWAYS preview with
+    `--dry-run` first and let it confirm (`-Yes` only when already approved); answering `n` skips the
+    standardizing and still applies the rest of the preset.
+    This was opt-in behind `--migrate` until #300, and that default was the bug: matching options by
+    name only, a plain apply added `Backlog` next to `Todo` and left the board in the one state a
+    rename cannot repair. `-Migrate` is still accepted as a no-op. `--no-migrate` opts out and does
+    NOT create the canonical option beside the legacy one — no path duplicates any more.
+  - **`apply <lang> --merge-conflicts`** — for boards ALREADY carrying both (`Todo` *and* `Backlog`):
+    moves the legacy option's items onto the canonical one, verifies, then deletes it. Destroys an
+    option, so it stays opt-in. Preview with `--dry-run` first.
 - **bulk** — batch move/close/label across many items (references/issue-ops.md)
 - **fill** — detect and fill ALL gaps across the board by running `scripts/Board-Fill.ps1`
   (pass -Owner, -Repo, -ProjectNum for the current repo's board):

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -21,12 +21,29 @@
     Renaming touches every item at once, so the rename plan is printed and confirmed
     first (-DryRun previews, -Yes skips the prompt for CI).
 
+    -MergeConflicts — resolve what -Migrate alone can only report (issue #300). A rename
+    cannot take a canonical name that ALREADY exists, so a board carrying both `Todo` and
+    `Backlog` is a conflict: reported, never executed. That board is not exotic — it is
+    exactly what a plain `apply` (no -Migrate) produces, since it adds `Backlog` NEXT TO the
+    template's `Todo`. This flag collapses the pair: the legacy option's items are MOVED to
+    the canonical option, and only then is the legacy option DELETED (via the same
+    updateProjectV2Field mutation used for colors, re-sending every other option by id —
+    the API can do this; it never needed the UI).
+    Merging is strictly more destructive than renaming — a rename keeps every option and
+    every assignment, a merge destroys an option and collapses two into one — so it is opt-in
+    on its own flag rather than riding along with -Migrate (-Yes must not silently delete
+    options in CI).
+    ORDER IS NOT OPTIONAL: move first, verify, then delete. Deleting first strands the items
+    with an empty field — GitHub does not reassign them.
+
     Requires $env:GH_TOKEN already set (via the gh-account skill).
     Usage:
       $env:GH_TOKEN = <token>
       ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Lang en
       ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -DryRun
       ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -MergeConflicts -DryRun
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -MergeConflicts
       ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -PresetPath custom.json  #>
 [CmdletBinding()]
 param(
@@ -36,12 +53,19 @@ param(
   [string]$PresetPath,
   # Rename legacy option names onto the canonical ones (in place, by option id).
   [switch]$Migrate,
+  # Also resolve the rename CONFLICTS: move the legacy option's items onto the canonical
+  # one and delete the legacy option. Destroys an option — opt-in, and implies -Migrate.
+  [switch]$MergeConflicts,
   # Print the plan (creations + renames) and exit without mutating anything.
   [switch]$DryRun,
   # Skip the migration confirmation prompt (CI / already-approved).
   [switch]$Yes
 )
 $ErrorActionPreference = 'Stop'
+
+# Merging only ever resolves conflicts left over by the migration, so asking for it
+# without -Migrate is a typo, not a mode.
+if ($MergeConflicts) { $Migrate = $true }
 
 # The canonical/legacy option vocabulary — the map that says `Todo` MEANS `Backlog`.
 . (Join-Path $PSScriptRoot 'Get-BoardVocabulary.ps1')
@@ -64,11 +88,87 @@ function Get-SingleSelectField($fieldName) {
   $q = gh api graphql -f query='
 query($owner:String!,$num:Int!,$field:String!){
   user(login:$owner){ projectV2(number:$num){
-    field(name:$field){ ... on ProjectV2SingleSelectField { id options { id name color } } }
+    field(name:$field){ ... on ProjectV2SingleSelectField { id options { id name color description } } }
   }}
 }' -F "owner=$Owner" -F "num=$Number" -f "field=$fieldName" | ConvertFrom-Json
   $script:FieldCache[$fieldName] = $q.data.user.projectV2.field
   return $script:FieldCache[$fieldName]
+}
+
+# The board's node id — needed by `item-edit`. Read once, on demand (only merges need it).
+$script:ProjectId = $null
+function Get-ProjectId {
+  if (-not $script:ProjectId) {
+    $json = gh project view $Number --owner $Owner --format json
+    # gh signals failure ONLY through the exit code here — it does not throw, even under
+    # $ErrorActionPreference='Stop'. Unchecked, a 401 reads as "the board has no id".
+    if ($LASTEXITCODE -ne 0) { throw "no pude leer el project #$Number (gh exit $LASTEXITCODE)" }
+    $script:ProjectId = ($json | ConvertFrom-Json).id
+    if (-not $script:ProjectId) { throw "el project #$Number no devolvio un id" }
+  }
+  return $script:ProjectId
+}
+
+# The items currently assigned to $optionName on $fieldName. Always read fresh: this is
+# both the pre-move list and the post-move verification, and a stale answer here is what
+# would let the delete run over items that never moved.
+function Get-ItemsOnOption($fieldName, $optionName) {
+  $key  = ($fieldName -replace '[^A-Za-z0-9]','').ToLower()   # item-list lowercases/strips field names
+  $json = gh project item-list $Number --owner $Owner --format json --limit 800
+  if ($LASTEXITCODE -ne 0) { throw "no pude listar los items del project #$Number (gh exit $LASTEXITCODE)" }
+  return @(($json | ConvertFrom-Json).items | Where-Object { $_.$key -eq $optionName })
+}
+
+# Collapse a legacy option onto its canonical one: move the items, verify, delete the option.
+# Returns $true only when the option is actually gone.
+function Invoke-OptionMerge($merge) {
+  $proj  = Get-ProjectId
+  $field = Get-SingleSelectField $merge.Field
+  if (-not $field.id) { Write-Host "  (no pude leer '$($merge.Field)' para fusionar)" -ForegroundColor DarkYellow; return $false }
+  $items = @(Get-ItemsOnOption $merge.Field $merge.FromName)
+  Write-Host ("  merge: {0} '{1}' -> '{2}' ({3} item(s))" -f $merge.Field, $merge.FromName, $merge.ToName, $items.Count) -ForegroundColor Cyan
+
+  # 1. MOVE. This must happen before the delete: GitHub does not reassign the items of a
+  #    deleted option, it just leaves them with an empty field.
+  $moved = 0
+  foreach ($it in $items) {
+    $ok = $false
+    for ($i = 0; $i -lt 4; $i++) {
+      # "$($it.id)" — NOT $it.id: `gh api`/`gh` do not interpolate a property off an object,
+      # they receive the whole object and read it as a file path.
+      $null = gh project item-edit --project-id "$proj" --id "$($it.id)" --field-id "$($field.id)" --single-select-option-id "$($merge.ToId)" 2>&1
+      if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+      Start-Sleep -Milliseconds (500 * ($i + 1))   # backoff for transient 5xx
+    }
+    if ($ok) { $moved++ } else { Write-Host ("    WARN no pude mover '{0}'" -f $it.title) -ForegroundColor DarkYellow }
+  }
+
+  # 2. VERIFY before destroying anything. One un-moved item is enough to abort: the option
+  #    staying is a cosmetic annoyance, an item silently losing its Status is data loss.
+  $left = @(Get-ItemsOnOption $merge.Field $merge.FromName)
+  if ($left.Count -gt 0) {
+    Write-Host ("    ABORT: quedan {0} item(s) en '{1}' - NO borro la opcion (se quedarian sin {2})." -f $left.Count, $merge.FromName, $merge.Field) -ForegroundColor Red
+    return $false
+  }
+
+  # 3. DELETE: re-send every OTHER option by id. Omitting one from the list IS the delete;
+  #    passing the rest by id is what keeps them (and their items) intact.
+  $script:FieldCache.Remove($merge.Field) | Out-Null
+  $live = Get-SingleSelectField $merge.Field
+  $keep = @($live.options | Where-Object { $_.id -ne $merge.FromId } | ForEach-Object {
+    @{ id = $_.id; name = $_.name; color = $_.color; description = $(if ($_.description) { $_.description } else { '' }) }
+  })
+  $mutation = 'mutation($fieldId:ID!, $opts:[ProjectV2SingleSelectFieldOptionInput!]!){ updateProjectV2Field(input:{ fieldId:$fieldId, singleSelectOptions:$opts }){ projectV2Field { ... on ProjectV2SingleSelectField { id } } } }'
+  $body = @{ query = $mutation; variables = @{ fieldId = $live.id; opts = $keep } } | ConvertTo-Json -Depth 10
+  $resp = $body | gh api graphql --input - | ConvertFrom-Json
+  if ($resp.errors) {
+    Write-Host ("    WARN no pude borrar la opcion '{0}': {1}" -f $merge.FromName, $resp.errors[0].message) -ForegroundColor DarkYellow
+    Write-Host ("          (los {0} item(s) YA estan en '{1}' - re-corre para reintentar el borrado)" -f $moved, $merge.ToName) -ForegroundColor DarkGray
+    return $false
+  }
+  $script:FieldCache.Remove($merge.Field) | Out-Null
+  Write-Host ("    borrada '{0}' - {1} item(s) ahora en '{2}'" -f $merge.FromName, $moved, $merge.ToName) -ForegroundColor Green
+  return $true
 }
 
 # Reconcile a single-select field's option colors from the preset. Preserves
@@ -96,14 +196,16 @@ function Set-OptionColors($fieldName, $presetOptions) {
       } | Select-Object -First 1
       if ($match) { Write-Host "  rename: $fieldName '$($match.name)' -> '$name' (conserva las asignaciones)" -ForegroundColor Cyan }
     }
-    $entry = @{ name = $name; color = ($(if ($color) { $color } elseif ($match) { $match.color } else { 'GRAY' })); description = '' }
+    # The mutation replaces the option list wholesale, so anything not re-sent is dropped:
+    # carry the live description through or this reconcile silently wipes it.
+    $entry = @{ name = $name; color = ($(if ($color) { $color } elseif ($match) { $match.color } else { 'GRAY' })); description = ($(if ($match -and $match.description) { $match.description } else { '' })) }
     if ($match) { $entry.id = $match.id; $usedIds += $match.id; if (-not $color) { $entry.color = $match.color } }
     $desired += $entry
   }
   # Any existing option NOT claimed above — keep it untouched (id + current color).
   foreach ($co in $current) {
     if ($usedIds -notcontains $co.id -and -not ($presetOptions | Where-Object { (Get-OptName $_) -eq $co.name })) {
-      $desired += @{ id = $co.id; name = $co.name; color = $co.color; description = '' }
+      $desired += @{ id = $co.id; name = $co.name; color = $co.color; description = $(if ($co.description) { $co.description } else { '' }) }
     }
   }
 
@@ -120,16 +222,18 @@ function Set-OptionColors($fieldName, $presetOptions) {
 # once, so they are never executed without the user seeing this list.
 $toCreate = @($preset.fields | Where-Object { $existing -notcontains $_.name })
 $renames  = @()
+$merges   = @()
 if ($Migrate) {
   foreach ($f in ($preset.fields | Where-Object { $_.type -eq 'SINGLE_SELECT' -and $existing -contains $_.name })) {
     $live = Get-SingleSelectField $f.name
     if (-not $live.id) { continue }
     $renames += @(Get-LegacyOptionRenames -Field $f.name -Options @($live.options) |
                   ForEach-Object { $_ | Add-Member -NotePropertyName Field -NotePropertyValue $f.name -PassThru })
+    $merges  += @(Get-LegacyOptionMerges -Field $f.name -Options @($live.options))
   }
 }
 
-if ($DryRun -or ($Migrate -and $renames.Count -gt 0)) {
+if ($DryRun -or ($Migrate -and ($renames.Count -gt 0 -or $merges.Count -gt 0))) {
   Write-Host "=== Plan: preset '$Lang' sobre el board #$Number de $Owner ===" -ForegroundColor Cyan
   if ($toCreate.Count -gt 0) {
     Write-Host "  Campos a crear: $(($toCreate | ForEach-Object { $_.name }) -join ', ')" -ForegroundColor DarkCyan
@@ -139,15 +243,30 @@ if ($DryRun -or ($Migrate -and $renames.Count -gt 0)) {
   if ($Migrate) {
     $doable = @($renames | Where-Object { -not $_.Conflict })
     $stuck  = @($renames | Where-Object { $_.Conflict })
-    if ($doable.Count -eq 0 -and $stuck.Count -eq 0) {
+    if ($doable.Count -eq 0 -and $merges.Count -eq 0) {
       Write-Host "  Renombres: ninguno (el board ya usa el vocabulario canonico)" -ForegroundColor DarkGray
     }
     foreach ($r in $doable) {
       Write-Host ("  rename: {0} '{1}' -> '{2}'  (los items asignados se conservan)" -f $r.Field, $r.From, $r.To) -ForegroundColor Yellow
     }
-    foreach ($r in $stuck) {
-      Write-Host ("  SKIP:   {0} '{1}' -> '{2}' — '{2}' ya existe en el campo; GitHub no admite dos opciones con el mismo nombre." -f $r.Field, $r.From, $r.To) -ForegroundColor DarkYellow
-      Write-Host ("          Mueve los items de '{0}' a '{1}' y borra '{0}' a mano en la UI." -f $r.From, $r.To) -ForegroundColor DarkGray
+    if ($MergeConflicts) {
+      # Show the blast radius BEFORE the prompt: a merge moves every item off the legacy
+      # option and then destroys it, so "how many items" is the whole decision.
+      foreach ($m in $merges) {
+        $n = try { @(Get-ItemsOnOption $m.Field $m.FromName).Count } catch { '?' }
+        Write-Host ("  merge:  {0} '{1}' -> '{2}'  ({3} item(s) se mueven, luego se borra '{1}')" -f $m.Field, $m.FromName, $m.ToName, $n) -ForegroundColor Yellow
+      }
+    } else {
+      foreach ($r in $stuck) {
+        # ASCII only inside the string: this file is UTF-8 with no BOM, Windows PowerShell 5.1
+        # reads it as cp1252, and an em dash decodes to a `"` smart quote that closes the
+        # string early — a parse error for the whole script, not just this line.
+        Write-Host ("  SKIP:   {0} '{1}' -> '{2}' - '{2}' ya existe en el campo; GitHub no admite dos opciones con el mismo nombre." -f $r.Field, $r.From, $r.To) -ForegroundColor DarkYellow
+      }
+      if ($merges.Count -gt 0) {
+        Write-Host "          Se resuelve solo: corre con -MergeConflicts para mover los items a la opcion canonica y borrar la legacy." -ForegroundColor DarkGray
+        Write-Host ("          -> ./Apply-FieldPreset.ps1 -Number {0} -Owner {1} -Migrate -MergeConflicts -DryRun" -f $Number, $Owner) -ForegroundColor DarkGray
+      }
     }
   }
   Write-Host ""
@@ -159,8 +278,11 @@ if ($DryRun) {
   exit 0
 }
 
-if ($Migrate -and @($renames | Where-Object { -not $_.Conflict }).Count -gt 0 -and -not $Yes) {
-  $answer = Read-Host "Aplicar estos renombres al board #$Number? (s/n)"
+$willRename = @($renames | Where-Object { -not $_.Conflict }).Count -gt 0
+$willMerge  = $MergeConflicts -and $merges.Count -gt 0
+if ($Migrate -and ($willRename -or $willMerge) -and -not $Yes) {
+  $what = if ($willMerge) { "cambios (incluye BORRAR opcion(es) legacy)" } else { "renombres" }
+  $answer = Read-Host "Aplicar estos $what al board #$Number? (s/n)"
   if ($answer -notmatch '^(s|si|sí|y|yes)$') {
     Write-Host "Cancelado - no se cambio nada." -ForegroundColor Yellow
     Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan
@@ -191,9 +313,29 @@ foreach ($f in $preset.fields) {
     Set-OptionColors $f.name $f.options
   }
 }
-$how = if ($Migrate) { "canonical colors reconciled; legacy option names migrated in place" }
-       else          { "existing fields left untouched; canonical colors reconciled" }
+# ── Merge ─────────────────────────────────────────────────────────────────────
+# AFTER the renames above, never before: a rename frees a legacy name and takes the
+# canonical one, which is what turns a second alias into a merge. Recomputed from the
+# live field for the same reason — the plan was drawn on the pre-rename options.
+$mergedOk = 0; $mergedFail = 0
+if ($willMerge) {
+  foreach ($f in ($preset.fields | Where-Object { $_.type -eq 'SINGLE_SELECT' -and $existing -contains $_.name })) {
+    $script:FieldCache.Remove($f.name) | Out-Null
+    $live = Get-SingleSelectField $f.name
+    if (-not $live.id) { continue }
+    foreach ($m in @(Get-LegacyOptionMerges -Field $f.name -Options @($live.options))) {
+      if (Invoke-OptionMerge $m) { $mergedOk++ } else { $mergedFail++ }
+    }
+  }
+}
+
+$how = if ($MergeConflicts) { "canonical colors reconciled; legacy option names migrated in place; $mergedOk conflict(s) merged" }
+       elseif ($Migrate)    { "canonical colors reconciled; legacy option names migrated in place" }
+       else                 { "existing fields left untouched; canonical colors reconciled" }
 Write-Host "Preset '$Lang' applied to project #$Number ($how)."
+if ($mergedFail -gt 0) {
+  Write-Host "$mergedFail merge(s) no se completaron - revisa los WARN de arriba (los items movidos YA estan en su opcion canonica; re-correr es seguro)." -ForegroundColor DarkYellow
+}
 if (-not $Migrate) {
   Write-Host "(Si el board venia de la plantilla por defecto de GitHub, corre con -Migrate para renombrar 'Todo' -> 'Backlog' y estandarizarlo.)" -ForegroundColor DarkGray
 }

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -10,16 +10,20 @@
     applied only for fields whose options carry a color (Status, Priority); plain
     string options (e.g. Type) are left with GitHub's default colors.
 
-    -Migrate — standardize an EXISTING board onto the canonical preset (issue #278).
-    Without it, options are matched by NAME only: a board born from GitHub's default
-    template keeps its legacy `Todo` and merely gains a `Backlog` NEXT TO it, so every
-    item stays on `Todo`, the migration never happens, and the board ends up with two
-    options meaning the same thing. With -Migrate, a legacy option (see
-    Get-BoardVocabulary.ps1) is RENAMED IN PLACE onto its canonical name: the mutation
-    is sent with the option's EXISTING id and the canonical name, so every item already
-    assigned to it keeps its assignment — no bulk item rewrite, no orphaned items.
-    Renaming touches every item at once, so the rename plan is printed and confirmed
-    first (-DryRun previews, -Yes skips the prompt for CI).
+    STANDARDIZING IS THE DEFAULT (issue #300). A legacy option (see Get-BoardVocabulary.ps1)
+    is RENAMED IN PLACE onto its canonical name: the mutation is sent with the option's
+    EXISTING id and the canonical name, so every item already assigned to it keeps its
+    assignment — no bulk item rewrite, no orphaned items. Renaming touches every item at once,
+    so the plan is printed and confirmed first (-DryRun previews, -Yes skips the prompt for
+    CI); answering `n` skips the standardizing but still applies the rest of the preset.
+    This used to be opt-in behind -Migrate (issue #278), and that default WAS the bug: matching
+    options by NAME only, the documented command left a template-born board's `Todo` alone and
+    merely added `Backlog` NEXT TO it. Every item stayed on `Todo` and the board ended up with
+    two options meaning the same thing — the one state a rename can never repair, since GitHub
+    forbids two options with the same name. The tool's own happy path manufactured it.
+    -NoMigrate opts out, and opting out does NOT fall back to the old behavior: the canonical
+    option is then simply NOT created beside the legacy one. This script no longer has any path
+    that produces a duplicate. -Migrate is still accepted, as a no-op, so older calls work.
 
     -MergeConflicts — resolve what -Migrate alone can only report (issue #300). A rename
     cannot take a canonical name that ALREADY exists, so a board carrying both `Todo` and
@@ -39,11 +43,11 @@
     Requires $env:GH_TOKEN already set (via the gh-account skill).
     Usage:
       $env:GH_TOKEN = <token>
-      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Lang en
-      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -DryRun
-      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate
-      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -MergeConflicts -DryRun
-      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Migrate -MergeConflicts
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Lang en             # estandariza (default)
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -DryRun              # previsualiza el plan
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -Yes                 # CI / ya aprobado
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -MergeConflicts      # + resuelve duplicados viejos
+      ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -NoMigrate           # no toca las opciones legacy
       ./Apply-FieldPreset.ps1 -Number 13 -Owner CSalcedoDataBI -PresetPath custom.json  #>
 [CmdletBinding()]
 param(
@@ -51,10 +55,14 @@ param(
   [Parameter(Mandatory)][string]$Owner,
   [ValidateSet('en','es')][string]$Lang = 'en',
   [string]$PresetPath,
-  # Rename legacy option names onto the canonical ones (in place, by option id).
+  # Deprecated: standardizing is now the DEFAULT. Accepted so existing calls/docs keep working.
   [switch]$Migrate,
+  # Opt OUT of standardizing: leave legacy option names as they are. The preset's canonical
+  # option is then NOT created either — adding it beside the legacy one is what produced the
+  # duplicate this script now refuses to make (#300).
+  [switch]$NoMigrate,
   # Also resolve the rename CONFLICTS: move the legacy option's items onto the canonical
-  # one and delete the legacy option. Destroys an option — opt-in, and implies -Migrate.
+  # one and delete the legacy option. Destroys an option — stays opt-in.
   [switch]$MergeConflicts,
   # Print the plan (creations + renames) and exit without mutating anything.
   [switch]$DryRun,
@@ -63,9 +71,14 @@ param(
 )
 $ErrorActionPreference = 'Stop'
 
-# Merging only ever resolves conflicts left over by the migration, so asking for it
-# without -Migrate is a typo, not a mode.
-if ($MergeConflicts) { $Migrate = $true }
+# Standardizing is the DEFAULT (#300): a board born from GitHub's template is migrated onto
+# the canonical vocabulary unless you explicitly opt out. It used to be opt-in, which meant
+# the documented command silently added `Backlog` NEXT TO `Todo` and left the board in the
+# one state the tool could not then repair. -Migrate is kept as an accepted no-op so existing
+# calls and docs do not break.
+$Migrate = -not $NoMigrate
+# Merging only ever resolves conflicts left over by the migration.
+if ($MergeConflicts -and $NoMigrate) { Write-Error "-MergeConflicts y -NoMigrate se contradicen: el merge ES la estandarizacion."; exit 1 }
 
 # The canonical/legacy option vocabulary — the map that says `Todo` MEANS `Backlog`.
 . (Join-Path $PSScriptRoot 'Get-BoardVocabulary.ps1')
@@ -188,13 +201,24 @@ function Set-OptionColors($fieldName, $presetOptions) {
     $name  = Get-OptName $po
     $color = Get-OptColor $po
     $match = $current | Where-Object { $_.name -eq $name } | Select-Object -First 1
-    if (-not $match -and $Migrate) {
-      # No option carries the canonical name — adopt the legacy one that MEANS it
-      # (Todo -> Backlog). Same id + new name = rename in place; assignments survive.
-      $match = $current | Where-Object {
+    if (-not $match) {
+      # No option carries the canonical name. Is there a LEGACY one that MEANS it?
+      $legacy = $current | Where-Object {
         ($usedIds -notcontains $_.id) -and ((Get-CanonicalOptionName $fieldName $_.name) -eq $name)
       } | Select-Object -First 1
-      if ($match) { Write-Host "  rename: $fieldName '$($match.name)' -> '$name' (conserva las asignaciones)" -ForegroundColor Cyan }
+      if ($legacy -and $Migrate) {
+        # Adopt it: same id + new name = rename in place; assignments survive.
+        $match = $legacy
+        Write-Host "  rename: $fieldName '$($legacy.name)' -> '$name' (conserva las asignaciones)" -ForegroundColor Cyan
+      } elseif ($legacy) {
+        # Not migrating. Emitting '$name' here would put it NEXT TO the legacy option that
+        # already means it — two options for one meaning, which GitHub then forbids merging
+        # by rename. That is the whole bug of #300, and this is where it was born. Refuse to
+        # create it: leave the legacy option alone (the pass below re-sends it untouched).
+        Write-Host "  skip: $fieldName '$name' - ya existe '$($legacy.name)' con el mismo significado; no creo una opcion duplicada." -ForegroundColor DarkYellow
+        Write-Host "        (corre sin -NoMigrate para renombrar '$($legacy.name)' -> '$name' y estandarizar)" -ForegroundColor DarkGray
+        continue
+      }
     }
     # The mutation replaces the option list wholesale, so anything not re-sent is dropped:
     # carry the live description through or this reconcile silently wipes it.
@@ -265,7 +289,7 @@ if ($DryRun -or ($Migrate -and ($renames.Count -gt 0 -or $merges.Count -gt 0))) 
       }
       if ($merges.Count -gt 0) {
         Write-Host "          Se resuelve solo: corre con -MergeConflicts para mover los items a la opcion canonica y borrar la legacy." -ForegroundColor DarkGray
-        Write-Host ("          -> ./Apply-FieldPreset.ps1 -Number {0} -Owner {1} -Migrate -MergeConflicts -DryRun" -f $Number, $Owner) -ForegroundColor DarkGray
+        Write-Host ("          -> ./Apply-FieldPreset.ps1 -Number {0} -Owner {1} -MergeConflicts -DryRun" -f $Number, $Owner) -ForegroundColor DarkGray
       }
     }
   }
@@ -284,9 +308,11 @@ if ($Migrate -and ($willRename -or $willMerge) -and -not $Yes) {
   $what = if ($willMerge) { "cambios (incluye BORRAR opcion(es) legacy)" } else { "renombres" }
   $answer = Read-Host "Aplicar estos $what al board #$Number? (s/n)"
   if ($answer -notmatch '^(s|si|sí|y|yes)$') {
-    Write-Host "Cancelado - no se cambio nada." -ForegroundColor Yellow
-    Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan
-    exit 0
+    # 'no' means "do not STANDARDIZE" — not "do nothing". The rest of the preset still applies
+    # (missing fields, colors). Crucially this does NOT fall back to adding the canonical
+    # option beside the legacy one: declining leaves the field exactly as it is.
+    Write-Host "Sin estandarizar: dejo las opciones legacy como estan (no se crea ninguna duplicada). Sigo con el resto del preset." -ForegroundColor Yellow
+    $Migrate = $false; $MergeConflicts = $false; $willMerge = $false
   }
 }
 
@@ -331,12 +357,12 @@ if ($willMerge) {
 
 $how = if ($MergeConflicts) { "canonical colors reconciled; legacy option names migrated in place; $mergedOk conflict(s) merged" }
        elseif ($Migrate)    { "canonical colors reconciled; legacy option names migrated in place" }
-       else                 { "existing fields left untouched; canonical colors reconciled" }
+       else                 { "NOT standardized (-NoMigrate); legacy option names left as they are" }
 Write-Host "Preset '$Lang' applied to project #$Number ($how)."
 if ($mergedFail -gt 0) {
   Write-Host "$mergedFail merge(s) no se completaron - revisa los WARN de arriba (los items movidos YA estan en su opcion canonica; re-correr es seguro)." -ForegroundColor DarkYellow
 }
 if (-not $Migrate) {
-  Write-Host "(Si el board venia de la plantilla por defecto de GitHub, corre con -Migrate para renombrar 'Todo' -> 'Backlog' y estandarizarlo.)" -ForegroundColor DarkGray
+  Write-Host "(Corre sin -NoMigrate para renombrar las opciones legacy -> canonicas y estandarizar el board.)" -ForegroundColor DarkGray
 }
 Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan

--- a/plugins/agentic-board/scripts/Get-BoardVocabulary.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardVocabulary.ps1
@@ -109,3 +109,46 @@ function Get-LegacyOptionRenames {
         }
     }
 }
+
+# The merge plan that RESOLVES the conflicts Get-LegacyOptionRenames can only report.
+# A rename cannot take a canonical name that already exists, so 'Todo' stays beside
+# 'Backlog' forever - and that is the exact state a plain `apply` (no -Migrate) leaves
+# behind, since it adds 'Backlog' next to the template's 'Todo'. Merging collapses them:
+# the legacy option's items move to the canonical option, then the legacy option is
+# deleted (updateProjectV2Field, re-sending every other option by id).
+#
+# $Options = the field's existing options (objects with .id / .name).
+# Returns one entry per legacy option that can be collapsed onto an EXISTING canonical
+# one. Unknown names are never touched (same rule as the renames: never guess).
+#
+# Reasons about the field as it will look AFTER the renames, because that is when the
+# merges run: a successful rename ('Todo' -> 'Backlog') is what makes a SECOND alias
+# ('To Do' beside it) a merge rather than a conflict. Planning on the raw options would
+# under-report those - and a plan that lies about what it will do is the bug PR #279
+# already fixed once.
+#
+# EXECUTION ORDER IS NOT OPTIONAL: move the items FIRST, verify the move, and only then
+# delete the legacy option. Deleting first strands every item on it with an empty field -
+# GitHub does not reassign them.
+function Get-LegacyOptionMerges {
+    param([string]$Field, [object[]]$Options)
+    $renames = @(Get-LegacyOptionRenames -Field $Field -Options $Options)
+    $projected = foreach ($o in @($Options)) {
+        $r = $renames | Where-Object { $_.Id -eq $o.id -and -not $_.Conflict } | Select-Object -First 1
+        [pscustomobject]@{ id = $o.id; name = $(if ($r) { $r.To } else { $o.name }) }
+    }
+    foreach ($o in @($projected)) {
+        $canon = Get-CanonicalOptionName $Field $o.name
+        if (-not $canon)        { continue }   # unknown vocabulary - not ours to touch
+        if ($canon -eq $o.name) { continue }   # already canonical (incl. just renamed)
+        $target = @($projected | Where-Object { $_.name -eq $canon }) | Select-Object -First 1
+        if (-not $target) { continue }         # canonical name is free - a rename handles it
+        [pscustomobject]@{
+            Field    = $Field
+            FromId   = $o.id
+            FromName = $o.name
+            ToId     = $target.id
+            ToName   = $canon
+        }
+    }
+}

--- a/plugins/agentic-board/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-board/skills/projects-admin/SKILL.md
@@ -312,7 +312,8 @@ branch already proven merged by its PR (#273/PR #275). The proof is the PR, not 
 | Link board to a repo | `references/board-ops.md` | `gh project link` |
 | Create / list fields (Status, Priority, Target) | `references/board-ops.md` | `gh project field-create`, `gh project field-list` |
 | Apply a whole field preset (EN/ES, custom values) | `references/field-presets.md` | `Apply-FieldPreset.ps1 -Lang en\|es` |
-| **Standardize an EXISTING board onto the preset** (renames `Todo`→`Backlog` in place, keeps assignments) | `references/field-presets.md` | `Apply-FieldPreset.ps1 -Migrate` (preview with `-DryRun`) |
+| **Standardize an EXISTING board onto the preset** (renames `Todo`→`Backlog` in place, keeps assignments) | `references/field-presets.md` | `Apply-FieldPreset.ps1` — default since #300 (preview with `-DryRun`, opt out with `-NoMigrate`) |
+| Board that ALREADY has both `Todo` and `Backlog` (moves items, then deletes the legacy option) | `references/field-presets.md` | `Apply-FieldPreset.ps1 -MergeConflicts` (preview with `-DryRun`) |
 | Set a field value on an item | `references/board-ops.md` | `gh project item-edit` |
 | Bulk-fill a custom field across ALL items (by rule) | `references/board-ops.md` | `scripts/Set-BoardField.ps1` |
 | **Detect and fill board gaps** | **this file — `/board fill` section** | **`/board fill` / `--dry-run` / `--auto`** |

--- a/plugins/agentic-board/skills/projects-admin/references/field-presets.md
+++ b/plugins/agentic-board/skills/projects-admin/references/field-presets.md
@@ -4,9 +4,10 @@ Reusable field sets so a board gets coherent governance fields in one step, in t
 Presets live at `presets/fields.<lang>.json` (`en` default, `es` available). All commands assume
 `$env:GH_TOKEN` is set via the `gh-account` skill.
 
-## Apply a preset (idempotent)
+## Apply a preset (idempotent, standardizes by default)
 ```powershell
-# from the plugin root; existing fields are skipped, only missing ones are created
+# from the plugin root; existing fields are skipped, only missing ones are created,
+# and legacy option names (Todo, P2 Medium, …) are renamed onto the canonical ones
 & "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Lang en
 # Spanish governance:
 & "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Lang es
@@ -15,19 +16,27 @@ Presets live at `presets/fields.<lang>.json` (`en` default, `es` available). All
 Standard set (EN): **Status, Priority, Size, Type, Area, Estimate, Target**.
 Standard set (ES): **Estado, Prioridad, Tamaño, Tipo, Área, Estimado, Objetivo**.
 
-## Standardize an EXISTING board onto the preset (`--migrate`)
-
-A plain apply only **creates missing fields** and **matches options by name**. On a board born from
-GitHub's default template (`Status: Todo / In Progress / Done`) that is not enough: it adds `Backlog`
-*next to* `Todo`, every item stays on `Todo`, and the board ends up with two options meaning the same
-thing. `-Migrate` **renames the legacy option in place** instead:
+A rename touches every item assigned to the option at once, so the plan is **printed and confirmed**
+first. Answering `n` skips the standardizing and applies the rest of the preset.
 
 ```powershell
-# always preview first — a rename touches every item assigned to the option at once
-& "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Migrate -DryRun
-& "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Migrate      # asks s/n
-& "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Migrate -Yes # CI / pre-approved
+& "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -DryRun  # preview
+& "${CLAUDE_PLUGIN_ROOT}/scripts/Apply-FieldPreset.ps1" -Number <num> -Owner <owner> -Yes     # CI / pre-approved
 ```
+
+## Standardizing a board born from GitHub's template
+
+A template board (`Status: Todo / In Progress / Done`) is migrated onto the canonical vocabulary by
+the plain apply above — no flag needed. The legacy option is **renamed in place**, never duplicated.
+
+This was opt-in behind `-Migrate` until issue #300, and that default was the bug: the documented
+command matched options by name only, so it added `Backlog` *next to* `Todo`, every item stayed on
+`Todo`, and the board ended up with two options meaning the same thing — the one state a rename can
+never repair (GitHub forbids two options with the same name). `-Migrate` is still accepted as a no-op.
+
+To opt out, `-NoMigrate` leaves the legacy names alone. Opting out does **not** re-create the old
+behavior: the canonical option is simply not created beside the legacy one. There is no longer any
+path through this script that produces a duplicate.
 
 The rename is sent with the option's **existing id** and the canonical name, so **every item keeps its
 assignment** — no bulk item rewrite, no orphans. The legacy→canonical map lives in

--- a/plugins/agentic-board/tests/Get-BoardVocabulary.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardVocabulary.Tests.ps1
@@ -144,3 +144,89 @@ Describe 'Get-LegacyOptionRenames — alias-to-alias collisions (Codex review, P
         @(Get-LegacyOptionRenames -Field 'Priority' -Options $opts | Where-Object { $_.Conflict }).Count | Should -Be 0
     }
 }
+
+Describe 'Get-LegacyOptionMerges (resolving the conflicts, issue #300)' {
+    It "collapses 'Todo' onto an existing 'Backlog' - the state a plain apply leaves behind" {
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Todo' }
+            [pscustomobject]@{ id = 'o2'; name = 'Backlog' }
+            [pscustomobject]@{ id = 'o3'; name = 'Done' }
+        )
+        $plan = @(Get-LegacyOptionMerges -Field 'Status' -Options $opts)
+        $plan.Count       | Should -Be 1
+        $plan[0].FromId   | Should -Be 'o1'
+        $plan[0].FromName | Should -Be 'Todo'
+        $plan[0].ToId     | Should -Be 'o2'
+        $plan[0].ToName   | Should -Be 'Backlog'
+    }
+    It 'plans NO merge when the canonical name is free (a plain rename handles it)' {
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Todo' }
+            [pscustomobject]@{ id = 'o2'; name = 'Done' }
+        )
+        @(Get-LegacyOptionMerges -Field 'Status' -Options $opts).Count | Should -Be 0
+    }
+    It 'plans nothing for an already-canonical board (idempotent)' {
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Backlog' }
+            [pscustomobject]@{ id = 'o2'; name = 'Done' }
+        )
+        @(Get-LegacyOptionMerges -Field 'Status' -Options $opts).Count | Should -Be 0
+    }
+    It 'leaves an unknown option name alone instead of guessing' {
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Icebox' }
+            [pscustomobject]@{ id = 'o2'; name = 'Backlog' }
+        )
+        @(Get-LegacyOptionMerges -Field 'Status' -Options $opts).Count | Should -Be 0
+    }
+    It 'merges the SECOND alias onto the first one once it is renamed (Todo + To Do, no Backlog)' {
+        # 'Todo' renames to 'Backlog'; 'To Do' cannot, so it must merge INTO the renamed
+        # option - by its id (o1), which only exists after the rename.
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Todo' }
+            [pscustomobject]@{ id = 'o2'; name = 'To Do' }
+        )
+        $plan = @(Get-LegacyOptionMerges -Field 'Status' -Options $opts)
+        $plan.Count       | Should -Be 1
+        $plan[0].FromId   | Should -Be 'o2'
+        $plan[0].FromName | Should -Be 'To Do'
+        $plan[0].ToId     | Should -Be 'o1'
+        $plan[0].ToName   | Should -Be 'Backlog'
+    }
+    It 'merges BOTH aliases when the canonical option already exists' {
+        $opts = @(
+            [pscustomobject]@{ id = 'o0'; name = 'Backlog' }
+            [pscustomobject]@{ id = 'o1'; name = 'Todo' }
+            [pscustomobject]@{ id = 'o2'; name = 'To Do' }
+        )
+        $plan = @(Get-LegacyOptionMerges -Field 'Status' -Options $opts)
+        $plan.Count | Should -Be 2
+        @($plan | ForEach-Object { $_.FromName }) | Should -Be @('Todo', 'To Do')
+        @($plan | ForEach-Object { $_.ToId })     | Should -Be @('o0', 'o0')
+    }
+    It 'never merges an option into itself' {
+        $opts = @([pscustomobject]@{ id = 'o1'; name = 'Backlog' })
+        @(Get-LegacyOptionMerges -Field 'Status' -Options $opts | Where-Object { $_.FromId -eq $_.ToId }).Count | Should -Be 0
+    }
+    It 'collapses the verbose Priority aliases onto existing canonical options' {
+        $opts = @(
+            [pscustomobject]@{ id = 'p0'; name = 'P2' }
+            [pscustomobject]@{ id = 'p1'; name = 'P2 Medium' }
+            [pscustomobject]@{ id = 'p2'; name = 'Medium' }
+        )
+        $plan = @(Get-LegacyOptionMerges -Field 'Priority' -Options $opts)
+        $plan.Count | Should -Be 2
+        @($plan | ForEach-Object { $_.ToId }) | Should -Be @('p0', 'p0')
+    }
+    It 'plans nothing for a field outside the vocabulary' {
+        $opts = @(
+            [pscustomobject]@{ id = 'o1'; name = 'Bug' }
+            [pscustomobject]@{ id = 'o2'; name = 'Feature' }
+        )
+        @(Get-LegacyOptionMerges -Field 'Type' -Options $opts).Count | Should -Be 0
+    }
+    It 'plans nothing for an empty option set' {
+        @(Get-LegacyOptionMerges -Field 'Status' -Options @()).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
Closes #300.

## El bug

Un `apply` **sin** `-Migrate` agrega `Backlog` **al lado** del `Todo` de la plantilla. O sea que el
camino feliz de la propia herramienta fabrica el board que después no sabe resolver: `-Migrate`
encontraba el conflicto y se rendía con un consejo **incorrecto** — *"borra 'Todo' a mano en la UI"*.

La API sí puede: `updateProjectV2Field` recibe la lista completa de opciones, y **omitir una es
borrarla**. El script ya usaba esa misma mutation para los colores (`Set-OptionColors`) — la
capacidad estaba a una omisión de distancia.

## El fix

`-MergeConflicts` resuelve el conflicto: mueve los items de la opción legacy a la canónica,
**verifica** el movimiento, y sólo entonces borra la opción.

**Flag propio, no dentro de `-Migrate`.** Un rename conserva todas las opciones y asignaciones; un
merge *destruye* una opción y colapsa dos en una. Radios de daño distintos → consentimientos
distintos. Y `-Yes` existe para CI: no debe borrar opciones en silencio.

### El orden no es opcional

Mover → verificar → borrar. Borrar primero deja a los items **sin Status**: GitHub no los reasigna.
Está enforced en el código (un solo item sin mover aborta el borrado) y explicado en los comentarios,
porque es una trampa que ya costó una reparación manual.

### Plan honesto

`Get-LegacyOptionMerges` planifica contra la proyección **post-rename**: un segundo alias (`To Do` al
lado de `Todo`) sólo se vuelve merge una vez que el rename libera el nombre. Planificar sobre las
opciones crudas lo sub-reportaría — la misma clase de plan mentiroso que PR #279 ya arregló una vez.

## De paso (dime si prefieres que salgan a su propio PR)

- **`Set-OptionColors` borraba las descripciones de las opciones** en cada reconcile: la mutation
  reemplaza la lista entera y el script reenviaba `description=''`. Ahora el query las lee y las conserva.
- **El script no parseaba en Windows PowerShell 5.1.** Una raya (`—`) dentro de un string: el archivo
  es UTF-8 sin BOM, 5.1 lo decodifica como cp1252, y la raya se vuelve `”` — comilla tipográfica que
  PowerShell acepta como delimitador y cierra el string antes de tiempo. Rompía el archivo **completo**,
  no sólo esa línea. Ahora parsea en 5.1 y en 7.

## Verificación — ejecutado, no sólo testeado

Dos boards desechables (borrados después):

| Escenario | Resultado |
|---|---|
| `Todo`+`Backlog`, 3 items | opción borrada, 3 items en `Backlog`, **0 huérfanos** |
| re-corrida (idempotencia) | `0 conflict(s) merged`, nada tocado |
| `Todo`+`To Do` sin `Backlog`, 4 items | rename + merge, ambas legacy borradas, 4 en `Backlog`, **0 huérfanos** |
| dry-run | anuncia el conteo real de items y **no muta nada** |

Pester: **704 passed / 0 failed** (10 tests nuevos sobre `Get-LegacyOptionMerges`).

## Fuera de alcance (a propósito)

`gh` devuelve exit != 0 **sin lanzar excepción** aunque `$ErrorActionPreference='Stop'`. El código
nuevo chequea `$LASTEXITCODE`, pero el preexistente sigue sin hacerlo — `gh project field-list`
(un 401 se lee como "el board no tiene campos") y los `field-create`. Lo dejo fuera para no mezclar
un hardening no relacionado con este review; va como issue aparte si te parece.

Nota: los hooks del guard no estaban instalados en mi clone (`.git/hooks/pre-commit` no existía);
corrí `scripts/guard-no-private.ps1` a mano y salió limpio (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
