### PR TITLE
feat(abios-feedback): keep the tool repo English-only where the issue is written

### DIFF
--- a/.github/workflows/issue-language.yml
+++ b/.github/workflows/issue-language.yml
@@ -1,0 +1,59 @@
+name: Issue language
+
+# This repo is English-only (#305). `abios-feedback` files its issues from OTHER projects, usually
+# while the conversation is in Spanish, so the rule written in the skill needs a backstop that does
+# not depend on the agent having read it — instruction alone is what drifted, 12 issues in two days.
+#
+# This never blocks: GitHub has no pre-create hook for issues, so the honest choice is between
+# labelling and pretending. It labels, and it clears the label again on edit, so fixing the issue
+# closes the loop without anyone touching the board.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    # `lang-ok` is the escape hatch for issues that legitimately discuss Spanish in English, or
+    # quote it outside a code fence. The detector is tuned to make this rare, not impossible.
+    if: ${{ !contains(github.event.issue.labels.*.name, 'lang-ok') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Score the issue text
+        id: score
+        shell: pwsh
+        # The title and body arrive as env vars and are NEVER interpolated into the script body:
+        # an issue body is attacker-controlled text, and `${{ }}` would splice it straight into the
+        # shell before pwsh ever sees it.
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          $v = ./scripts/Test-IssueLanguage.ps1 -Title "$env:ISSUE_TITLE" -Body "$env:ISSUE_BODY"
+          Write-Host "title=$($v.TitleScore) body=$($v.BodyScore) english=$($v.IsEnglish)"
+          "is_english=$($v.IsEnglish.ToString().ToLower())" | Out-File $env:GITHUB_OUTPUT -Append
+          "reason=$($v.Reason)"                             | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Flag as needing English
+        if: ${{ steps.score.outputs.is_english == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          REASON: ${{ steps.score.outputs.reason }}
+        run: |
+          echo "Not English ($REASON) — labelling #$NUMBER"
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label needs-english
+
+      - name: Clear the flag once it reads as English
+        if: ${{ steps.score.outputs.is_english == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # --remove-label is a no-op when the label is absent, so this needs no guard.
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label needs-english || true

--- a/plugins/agentic-board/skills/abios-feedback/SKILL.md
+++ b/plugins/agentic-board/skills/abios-feedback/SKILL.md
@@ -25,6 +25,11 @@ These are absolute:
 3. **Do NOT git add / commit / write files in the current project** for this. Capture goes to the
    tool's repo only (an issue), never the cwd repo tree.
 4. **Sanitize first** (next section). The guard in the tool's repo is the backstop, not the cwd.
+5. **Write the issue in ENGLISH — title AND body — even when the conversation is in Spanish.**
+   The language follows the **target repo, not the chat**: this repo is English-only, and the target
+   is always this repo (rule 1), so the answer here is always English. Keep talking to the user in
+   their language; only the issue text is English. Do **not** generalise this rule — `/scan` and
+   `/board plan` target the user's OWN repo and may legitimately be Spanish there.
 
 ## Step 1 — Abstract / sanitize
 Describe ONLY the public tool — which skill/script/recipe is wrong and the correct behavior. Strip:
@@ -53,8 +58,18 @@ cd "$env:ABIOS_HOME"   # set ABIOS_HOME once to your local agentic-board clone p
 If `ABIOS_HOME` is unset, ask the user for the clone path; do **not** guess or write into the cwd.
 Also append a dated, sanitized note to `inbox/IMPROVEMENTS.md` in that clone (optional log).
 
-## Safety backstop (you do not rely on discipline alone)
-The tool's repo has a guard (`scripts/guard-no-private.ps1`, wired pre-commit + pre-push) that
-**blocks** any commit/push whose added lines contain a secret pattern or a term from the local
-`.abios/private-denylist.txt`. If it blocks you, it caught a leak — do not `--no-verify` unless you
-have confirmed a genuine false positive. See [[gh-account]] for identity; projects-admin for board recipes.
+## Safety backstops (you do not rely on discipline alone)
+Two, because both of these rules have been broken by an agent who meant well:
+
+- **Private content** — a guard (`scripts/guard-no-private.ps1`, wired pre-commit + pre-push)
+  **blocks** any commit/push whose added lines contain a secret pattern or a term from the local
+  `.abios/private-denylist.txt`. If it blocks you, it caught a leak — do not `--no-verify` unless you
+  have confirmed a genuine false positive. Note it is inert in a fresh clone until
+  `scripts/install-guard.ps1` has been run: hooks need `core.hooksPath`, and the denylist is
+  gitignored so it never arrives with the clone.
+- **Language** — `.github/workflows/issue-language.yml` scores every opened/edited issue and applies
+  a `needs-english` label when it reads as Spanish (rule 5). It cannot block — GitHub has no
+  pre-create hook for issues — so it is a net, not a gate: getting rule 5 right up front is still
+  your job. The label clears itself once the text is fixed. `lang-ok` opts an issue out.
+
+See [[gh-account]] for identity; projects-admin for board recipes.

--- a/plugins/agentic-board/tests/Test-IssueLanguage.Tests.ps1
+++ b/plugins/agentic-board/tests/Test-IssueLanguage.Tests.ps1
@@ -1,0 +1,119 @@
+#Requires -Modules Pester
+<#  Tests for scripts/Test-IssueLanguage.ps1 (#305).
+
+    A heuristic detector is only worth shipping if its thresholds are pinned, so this asserts BOTH
+    directions on every case: Spanish text must flag, and English text must NOT. The one-directional
+    version of this test ("it catches Spanish!") is what lets a detector quietly flag everything.
+
+    The English cases are not invented: #8 and #84 are real issues, written in English, that a naive
+    marker list flags because they *discuss* Spanish ('todo', 'no'). They are the regression that
+    justifies the marker list being as short as it is.
+
+    Measured against the full 173-issue corpus when written: 12 flagged (exactly the Spanish ones),
+    161 clean, highest English title score 0, highest English body score 2. #>
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' '..' '..' 'scripts' 'Test-IssueLanguage.ps1' |
+        Resolve-Path
+    $env:ABIOS_ISSUELANG_DOTSOURCE = '1'
+    . $script:ScriptPath
+    $env:ABIOS_ISSUELANG_DOTSOURCE = $null
+}
+
+Describe 'Test-IssueLanguage' {
+
+    Context 'Spanish is flagged' {
+        It 'flags a Spanish title' {
+            # Real shape: #295.
+            $v = Test-IssueLanguage -Title 'release: la version no se bumpeo tras #279 - el arreglo no llega' -Body ''
+            $v.IsEnglish | Should -BeFalse
+            $v.Reason    | Should -Match 'title'
+        }
+
+        It 'flags a Spanish body even when the title is technical enough to score zero' {
+            # Real shape: #298 - the title is mostly a path, the body gives it away.
+            $v = Test-IssueLanguage -Title 'knowledge writes registry.json' -Body @'
+El script escribe el registry.json en el directorio equivocado cuando la ruta tiene un hook de
+lista blanca. Esto hace que el archivo sea inusable, porque cada cambio se pierde. Falta que el
+resolver pregunte por la raiz del repo antes de escribir.
+'@
+            $v.IsEnglish | Should -BeFalse
+            $v.Reason    | Should -Match 'body'
+        }
+
+        It 'scores accented characters as the strong signal they are' {
+            (Get-SpanishScore -Text 'versión') | Should -BeGreaterThan (Get-SpanishScore -Text 'version')
+        }
+    }
+
+    Context 'English is not flagged' {
+        It 'passes an ordinary English issue' {
+            $v = Test-IssueLanguage -Title 'work: teardown can fail open when the worktree drifted off its branch' -Body @'
+## Problem
+
+Test-WorktreeStillRegistered proves "still registered" with two signals: the branch, and the path as
+a secondary. Both can miss the same worktree at once, so the teardown deletes the branch while git
+still registers the worktree.
+
+## Fix
+
+Stop comparing strings - let git resolve path identity. If neither signal can prove the worktree is
+gone, fail closed.
+'@
+            $v.IsEnglish | Should -BeTrue
+        }
+
+        It 'does not flag an English issue that discusses Spanish (#8 regression)' {
+            # 'todo' and 'no' are English words. A marker list containing them flags this.
+            $v = Test-IssueLanguage -Title "project-scan: code-marker regex must follow TAG: convention (no Spanish 'todo')" -Body ''
+            $v.IsEnglish | Should -BeTrue
+        }
+
+        It 'does not flag an English issue about a Spanish false friend (#84 regression)' {
+            $v = Test-IssueLanguage -Title "board: rename Status 'Todo' -> 'Backlog' (avoid ES false-friend)" -Body ''
+            $v.IsEnglish | Should -BeTrue
+        }
+    }
+
+    Context 'Code is not prose' {
+        It 'ignores Spanish quoted inside a fenced block' {
+            # Quoting a Windows PowerShell error is not writing Spanish. This is a real case: the
+            # es-ES parse error "Falta el parentesis de cierre" appears in repro output.
+            $body = @'
+Running the script under Windows PowerShell 5.1 fails to parse:
+
+```
+Falta el parentesis de cierre en la llamada al metodo.
+No se puede encontrar el archivo porque la ruta esta mal.
+```
+
+Use pwsh 7 instead: it reads the file as UTF-8.
+'@
+            (Test-IssueLanguage -Title 'script fails to parse under Windows PowerShell 5.1' -Body $body).IsEnglish |
+                Should -BeTrue
+        }
+
+        It 'ignores Spanish inside inline code' {
+            (Get-SpanishScore -Text 'the flag `para el archivo` is literal') | Should -Be 0
+        }
+
+        It 'strips URLs before scoring' {
+            (Get-SpanishScore -Text 'see https://example.com/la/para/el/cada/una') | Should -Be 0
+        }
+    }
+
+    Context 'Thresholds' {
+        It 'exposes the tuned defaults, so a change to them is a visible diff' {
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:ScriptPath, [ref]$null, [ref]$null)
+            $params = $ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }
+            $params | Should -Contain 'TitleThreshold'
+            $params | Should -Contain 'BodyThreshold'
+        }
+
+        It 'honours a caller-supplied threshold' {
+            $t = 'release: la version no se bumpeo tras el arreglo'
+            (Test-IssueLanguage -Title $t -Body '' -TitleThreshold 99).IsEnglish | Should -BeTrue
+            (Test-IssueLanguage -Title $t -Body '' -TitleThreshold 1).IsEnglish  | Should -BeFalse
+        }
+    }
+}

--- a/scripts/Test-IssueLanguage.ps1
+++ b/scripts/Test-IssueLanguage.ps1
@@ -1,0 +1,106 @@
+<#  Test-IssueLanguage.ps1 — flag issue text that is not in English (#305).
+
+    This repo is English-only, but `abios-feedback` files its issues from ANY project, usually while
+    the conversation with the user is in Spanish. The rule itself lives where the text is drafted
+    (skills/abios-feedback/SKILL.md); this is the CI backstop, because instruction alone is exactly
+    what drifted — 12 of 170 issues, all in two days.
+
+    It never blocks: GitHub has no pre-create hook for issues, so the only honest options are
+    "label it" or "pretend". It labels, which makes drift visible instead of silent.
+
+    Detection is deliberately conservative, because a detector that cries wolf gets muted:
+      * fenced and inline code is stripped BEFORE scoring — issues legitimately quote Spanish tool
+        output (a Windows PowerShell parse error, for instance) and that is not a language problem;
+      * markers are Spanish function words that are NOT also English words and NOT common
+        identifiers. Notably absent: 'todo', 'no', 'solo', 'con', 'es', 'un' — every one of them
+        appears in ordinary English dev prose, and 'todo'/'no' alone were enough to make a naive
+        scan flag #8 and #84, two English issues whose crime was discussing Spanish;
+      * accented characters and inverted punctuation are near-unambiguous and score double.
+
+    Thresholds are tuned against the real corpus and pinned by Test-IssueLanguage.Tests.ps1, which
+    asserts BOTH directions: the known-Spanish issues flag, and the known-English ones do not.
+
+    Usage:
+      ./scripts/Test-IssueLanguage.ps1 -Title "..." -Body "..."          # -> object
+      ./scripts/Test-IssueLanguage.ps1 -Title "..." -Body "..." -AsJson  # -> json, for CI
+#>
+[CmdletBinding()]
+param(
+    [string]$Title = '',
+    [string]$Body  = '',
+    [int]$TitleThreshold = 2,
+    [int]$BodyThreshold  = 6,
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Spanish function words with no English homograph. Kept short on purpose: every term here is one
+# that cannot plausibly appear in an English sentence about PowerShell.
+$script:SpanishMarkers = @(
+    'el','la','los','las','una','unos','unas','del','al'
+    'que','para','sin','por','pero','como','cuando','donde','porque','aunque'
+    'sobre','entre','desde','hasta','tras','segun','mientras','antes','despues'
+    'esto','este','esta','estos','estas','eso','esos','esas'
+    'esta','estan','hay','puede','pueden','debe','deben','hace','hacen','tiene','tienen'
+    'ya','muy','cada','tambien','asi','aqui','alli','siempre','nunca','ahora','entonces'
+    'falta','arreglo','mejora','fallo','archivo','rama','cambio','prueba'
+    'se','su','sus','le','les','lo','ni','mas','pero'
+)
+
+# Strong signals: characters that simply do not occur in English prose.
+$script:AccentPattern = '[áéíóúüñ¿¡]'
+
+function Remove-CodeSpans {
+    <# Strip fenced blocks, inline code and URLs. Quoting a Spanish error message is not writing
+       Spanish, and a URL is not prose. #>
+    param([string]$Text)
+    if (-not $Text) { return '' }
+    $t = $Text
+    $t = [regex]::Replace($t, '(?s)```.*?```', ' ')      # fenced blocks
+    $t = [regex]::Replace($t, '(?s)~~~.*?~~~', ' ')      # alternate fence
+    $t = [regex]::Replace($t, '`[^`]*`', ' ')            # inline code
+    $t = [regex]::Replace($t, '<!--.*?-->', ' ')         # html comments
+    $t = [regex]::Replace($t, 'https?://\S+', ' ')       # urls
+    return $t
+}
+
+function Get-SpanishScore {
+    <# Pure: text in, score out. An accented character counts double — it is the one signal that
+       cannot be an English word in disguise. #>
+    param([string]$Text)
+    if (-not $Text) { return 0 }
+    $prose = Remove-CodeSpans -Text $Text
+    $score = 0
+    foreach ($m in $script:SpanishMarkers) {
+        $score += ([regex]::Matches($prose, "\b$m\b", 'IgnoreCase')).Count
+    }
+    $score += 2 * ([regex]::Matches($prose, $script:AccentPattern, 'IgnoreCase')).Count
+    return $score
+}
+
+function Test-IssueLanguage {
+    <# Verdict for one issue. Title and body are scored separately: a Spanish title is the loud
+       failure (it is what everyone reads), a Spanish body needs more evidence because bodies are
+       long and quote things. #>
+    param([string]$Title, [string]$Body, [int]$TitleThreshold = 2, [int]$BodyThreshold = 6)
+    $titleScore = Get-SpanishScore -Text $Title
+    $bodyScore  = Get-SpanishScore -Text $Body
+    [pscustomobject]@{
+        TitleScore = $titleScore
+        BodyScore  = $bodyScore
+        IsEnglish  = ($titleScore -lt $TitleThreshold) -and ($bodyScore -lt $BodyThreshold)
+        Reason     = @(
+            if ($titleScore -ge $TitleThreshold) { "title scores $titleScore (>= $TitleThreshold)" }
+            if ($bodyScore  -ge $BodyThreshold)  { "body scores $bodyScore (>= $BodyThreshold)" }
+        ) -join '; '
+    }
+}
+
+# Dot-source guard: with $env:ABIOS_ISSUELANG_DOTSOURCE set, return after defining the pure
+# helpers WITHOUT emitting output - lets the tests unit-test them.
+if ($env:ABIOS_ISSUELANG_DOTSOURCE) { return }
+
+$verdict = Test-IssueLanguage -Title $Title -Body $Body `
+    -TitleThreshold $TitleThreshold -BodyThreshold $BodyThreshold
+if ($AsJson) { $verdict | ConvertTo-Json -Compress } else { $verdict }


### PR DESCRIPTION
Closes #305 (prevention + backstop). Translating the 12 existing Spanish issues is NOT in this PR and is tracked in #308 — `Closes #305` would close this issue, so the remaining deliverable needed a tracker that survives the merge.

## What

- **`abios-feedback/SKILL.md` — rule 5**, in the "Anti-confusion rules" block where the title is actually drafted. Scoped to the **target repo, not the chat language**, so `/scan` and `/board plan` on the user's own (possibly Spanish) repos are explicitly untouched.
- **`scripts/Test-IssueLanguage.ps1` + `.github/workflows/issue-language.yml`** — a non-blocking `needs-english` label on opened/edited issues. GitHub has no pre-create hook for issues, so a gate is not on offer; this is a net that makes drift visible, and it clears itself when the text is fixed. `lang-ok` opts out.

## Why a backstop at all

The rule was already written in `CONTRIBUTING.md:68`, in per-project agent memory, and in `board-ops.md` — none of which is loaded when `abios-feedback` fires from another repo. Instruction alone is what drifted: 12 of 170 issues, all filed over two days, two of them while this was being investigated.

## Validation

Ran the detector over the real 173-issue corpus, **both directions**:

| | Flagged | Max title score |
|---|---|---|
| The 12 Spanish issues | 12 / 12 | 1–7 |
| The 161 English issues | 0 | **0** (threshold is 2) |

`#8` and `#84` are English issues that *discuss* Spanish; a naive marker list containing `todo`/`no` flags both. They are pinned as regressions in the Pester suite, along with the case of a body quoting a Spanish tool error inside a code fence.

715 tests pass.

## Note for the reviewer

The workflow passes the issue title/body via `env:`, never `${{ }}` interpolation into `run:` — an issue body is attacker-controlled text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
