### PR TITLE
fix(work): an issue branch starts from the remote default, not the current HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-
+## [Unreleased]
+### Fixed
+- **work: an issue branch starts from the remote default branch, not the current HEAD** (#294).
+  `-Start -Branch` cut the branch from whatever HEAD happened to be, so starting an issue from a
+  feature branch dragged its unmerged commits into the issue's PR — a 1-line fix opened as 56
+  files, +2332/-253, and passed the gate. Both branch paths are fixed (the isolated worktree and
+  the in-place `checkout -b`, which had the identical defect), and `-Parallel` no longer hardcodes
+  `origin/main`: the default branch is resolved, so a `master` repo works. Basing on the current
+  branch is still available for dependent work, now as an opt-in (`-BaseCurrent` / `-Base <ref>`).
 
 ## [0.20.0] - 2026-07-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   files, +2332/-253, and passed the gate. Both branch paths are fixed (the isolated worktree and
   the in-place `checkout -b`, which had the identical defect), and `-Parallel` no longer hardcodes
   `origin/main`: the default branch is resolved, so a `master` repo works. Basing on the current
-  branch is still available for dependent work, now as an opt-in (`-BaseCurrent` / `-Base <ref>`).
+  branch is still available for dependent work, now as an opt-in (`-BaseCurrent` / `-Base <ref>`,
+  honoured by `-Parallel` too instead of being silently ignored).
 
 ## [0.20.0] - 2026-07-16
 ### Added

--- a/plugins/agentic-board/commands/board.md
+++ b/plugins/agentic-board/commands/board.md
@@ -87,6 +87,10 @@ matching recipe from the projects-admin references:
      labels, sub-issues). Then CONTINUE WORKING that issue in this session: treat the printed
      context as the task briefing. Always pass `-Branch` when the issue belongs to the current
      repo. `--dry-run` previews without mutating; a CLOSED issue is refused.
+     - The work branch always starts from the repo's **default branch, freshly fetched** — never
+       from the current HEAD, which would drag the commits of whatever branch you were standing
+       on into this issue's PR. For work that genuinely builds on the current branch, opt in with
+       `-BaseCurrent` (or `-Base <ref>` for an explicit base).
      - **Busy working copy?** If the folder has uncommitted changes or sits on another
        `issue-*` branch (another session active), `-Branch` does NOT switch — it creates an
        isolated **git worktree** `../<repo>--issue-<n>` automatically (the official
@@ -135,7 +139,8 @@ matching recipe from the projects-admin references:
   - **Parallel (several independent issues at once).** When the user picks MORE THAN ONE
     independent pending issue, batch-start them instead of looping:
     `scripts/Board-Work.ps1 -ProjectNum <n> -Parallel <n1,n2,...>` starts each (In Progress +
-    assign + claim) in its OWN worktree `../<repo>--issue-<n>` off a fresh `origin/main`;
+    assign + claim) in its OWN worktree `../<repo>--issue-<n>` off the freshly fetched default
+    branch (`origin/main` here — resolved, not assumed, so a `master` repo works too);
     blocked / claimed / closed issues are skipped with a reason (the batch never aborts).
     Add `-Launch` to open one visible Claude session per worktree — a Windows Terminal (`wt`)
     tab when available, else a `pwsh` window — each briefed to take its issue through step 5

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -27,8 +27,8 @@
       5. -ProjectNum <n> -Parallel <issueNums>
          Batch-start SEVERAL independent issues at once. For each issue it
          runs the same start logic as mode 3 (In Progress + assign + claim)
-         but ALWAYS in its own isolated git worktree (../<repo>--issue-<n>),
-         each branched off a fresh origin/main. Add -Launch to open one visible
+         but ALWAYS in its own isolated git worktree, each branched off the
+         freshly fetched default branch. Add -Launch to open one visible
          Claude session per worktree (a Windows Terminal tab when 'wt' exists,
          else a standalone pwsh window), each briefed to work its own issue
          end-to-end. -DryRun plans the whole batch (and previews the launch
@@ -98,14 +98,14 @@
 .PARAMETER Base
     With -Start -Branch / -Parallel: the ref the new issue branch starts from.
     Defaults to the remote's default branch, freshly fetched (origin/main on this
-    repo) - never the current HEAD, which would drag the commits of whatever branch
-    you happened to be standing on into the issue's PR (#294). Pass an explicit ref
-    only for deliberately dependent work.
+    repo, but resolved rather than assumed) - never the current HEAD, which would drag
+    the commits of whatever branch you happened to be standing on into the issue's PR
+    (#294). Pass an explicit ref only for deliberately dependent work.
 
 .PARAMETER BaseCurrent
-    With -Start -Branch: base the issue branch on the CURRENT HEAD instead of the
-    remote default - the opt-in for work that genuinely builds on the branch you are
-    standing on. Mutually exclusive with -Base.
+    With -Start -Branch / -Parallel: base the issue branch on the CURRENT HEAD instead
+    of the remote default - the opt-in for work that genuinely builds on the branch you
+    are standing on. Mutually exclusive with -Base.
 
 .PARAMETER TokenVar
     Windows USER env var holding the PAT. Defaults to GITHUB_TOKEN_PERSONAL;
@@ -709,6 +709,61 @@ function New-IssueWorktree([string]$repo, [int]$issueNum, [string]$branchName, [
     return $null
 }
 
+# Give the issue a place to be worked: pick the base, then either an isolated worktree
+# or the branch in place. Returns the work path ('' when the cwd is not a clone of the
+# issue's repo, so no branch was made).
+#
+# This exists as a function, rather than inline in Invoke-IssueStart, because it is the
+# WIRING that #294 got wrong - New-IssueWorktree already honoured a base ref; nobody
+# passed it one. A test that hands the base in by itself would pass against the buggy
+# code, so the base choice has to live somewhere a test can reach it with real git.
+function New-IssueWorkspace {
+    param(
+        [string]$repo,
+        [int]   $issueNum,
+        [string]$branchName,
+        [switch]$PreferWorktree,
+        [string]$Base = "",
+        [switch]$BaseCurrent
+    )
+    $originUrl = git remote get-url origin 2>$null
+    if ($LASTEXITCODE -ne 0 -or $originUrl -notmatch [regex]::Escape($repo)) {
+        Write-Host "  WARN el directorio actual no es un clon de $repo - rama NO creada." -ForegroundColor DarkYellow
+        Write-Host "       Crea la rama en ese repo con: git checkout -b $branchName" -ForegroundColor DarkYellow
+        return ""
+    }
+
+    # -- The base (#294). Explicit wins; otherwise resolve the remote default. -----
+    $baseRef = ""
+    if ($BaseCurrent) {
+        Write-Host "  -BaseCurrent: la rama nace del HEAD actual (trabajo dependiente)." -ForegroundColor DarkGray
+    } elseif ($Base) {
+        $baseRef = $Base
+    } else {
+        $baseRef = Resolve-IssueBaseRef -repo $repo
+        if (-not $baseRef) {
+            Write-Host "  WARN no pude resolver la rama por defecto del remoto - la rama nace del HEAD actual." -ForegroundColor DarkYellow
+            Write-Host "       Revisa que el PR no arrastre commits ajenos antes de mergear." -ForegroundColor DarkYellow
+        }
+    }
+
+    $dirty     = @(git status --porcelain 2>$null)
+    $curBranch = git branch --show-current 2>$null
+    # Batch (-PreferWorktree) always isolates. Single start keeps the classic
+    # dirty-tree / other-issue-branch guard: never switch a busy working copy.
+    $needWorktree = $PreferWorktree -or `
+                    ($dirty.Count -gt 0 -and $curBranch -ne $branchName) -or `
+                    ($curBranch -and $curBranch -match '^issue-\d+' -and $curBranch -ne $branchName)
+    if ($needWorktree) {
+        if (-not $PreferWorktree) {
+            Write-Host "  OCUPADO: working tree ocupado (rama actual: $curBranch) - uso un worktree aislado:" -ForegroundColor Yellow
+        }
+        return (New-IssueWorktree $repo $issueNum $branchName $baseRef)
+    }
+    New-IssueBranchInPlace $branchName $baseRef | Out-Null
+    return (Get-Location).Path
+}
+
 # Start ONE issue: find item, run safety checks, and (unless -DryRunStart) move it
 # to In Progress + assign + claim + optionally branch/worktree. Writes progress and
 # returns a structured result so callers (single or batch) can decide what to print
@@ -721,7 +776,8 @@ function Invoke-IssueStart {
         [string] $Owner,
         [switch] $MakeBranch,
         [switch] $PreferWorktree,
-        [string] $BaseRef = "",
+        [string] $Base = "",
+        [switch] $BaseCurrent,
         [switch] $DryRunStart,
         [switch] $IgnoreBlocked,
         [switch] $TakeOver
@@ -826,29 +882,8 @@ mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!) {
 
     # -- Execute: work branch (only if cwd is a clone of the issue's repo) -------
     if ($MakeBranch) {
-        $originUrl = ""
-        try { $originUrl = (git remote get-url origin 2>$null) } catch { }
-        if ($originUrl -notmatch [regex]::Escape($repo)) {
-            Write-Host "  WARN el directorio actual no es un clon de $repo - rama NO creada." -ForegroundColor DarkYellow
-            Write-Host "       Crea la rama en ese repo con: git checkout -b $branchName" -ForegroundColor DarkYellow
-        } else {
-            $dirty     = @(git status --porcelain 2>$null)
-            $curBranch = git branch --show-current 2>$null
-            # Batch (-PreferWorktree) always isolates. Single start keeps the classic
-            # dirty-tree / other-issue-branch guard: never switch a busy working copy.
-            $needWorktree = $PreferWorktree -or `
-                            ($dirty.Count -gt 0 -and $curBranch -ne $branchName) -or `
-                            ($curBranch -and $curBranch -match '^issue-\d+' -and $curBranch -ne $branchName)
-            if ($needWorktree) {
-                if (-not $PreferWorktree) {
-                    Write-Host "  OCUPADO: working tree ocupado (rama actual: $curBranch) - uso un worktree aislado:" -ForegroundColor Yellow
-                }
-                $result.workPath = New-IssueWorktree $repo $IssueNum $branchName $BaseRef
-            } else {
-                New-IssueBranchInPlace $branchName $BaseRef
-                $result.workPath = (Get-Location).Path
-            }
-        }
+        $result.workPath = New-IssueWorkspace -repo $repo -issueNum $IssueNum -branchName $branchName `
+                                              -PreferWorktree:$PreferWorktree -Base $Base -BaseCurrent:$BaseCurrent
         if ($result.workPath) {
             Write-SessionRegistryEntry -IssueNum $IssueNum -Branch $branchName -WorkPath $result.workPath -Repo $repo
             Write-Host "  OK  Sesion registrada en .agentic-board/sessions.json" -ForegroundColor Green
@@ -2549,23 +2584,15 @@ if ($Parallel.Count -gt 0) {
 
     $ctx = Resolve-BoardStatus $Owner $ProjectNum
 
-    # Fresh base so each independent worktree branches off the up-to-date default branch.
-    # Shares Resolve-IssueBaseRef with single -Start (#294): this path used to hardcode
-    # origin/main, which silently based every worktree on the wrong branch in a repo whose
-    # default is master.
-    $baseRef = ""
-    if (-not $DryRun) {
-        $baseRef = if ($Base) { $Base } else { Resolve-IssueBaseRef -repo $Repo }
-        if (-not $baseRef) {
-            Write-Host "  WARN no pude resolver la rama por defecto del remoto - los worktrees nacen del HEAD actual." -ForegroundColor DarkYellow
-        }
-    }
-
+    # The base is resolved per issue inside New-IssueWorkspace, which shares one code path
+    # with single -Start (#294). This path used to hardcode origin/main, which silently
+    # based every worktree on the wrong branch in a repo whose default is master - and it
+    # ignored -BaseCurrent entirely, honouring a base the caller had not asked for.
     $results = @()
     foreach ($n in $queue) {
         Write-Host ("--- #{0} ---" -f $n) -ForegroundColor Cyan
         $r = Invoke-IssueStart -IssueNum $n -Ctx $ctx -Owner $Owner -MakeBranch -PreferWorktree `
-                               -BaseRef $baseRef -DryRunStart:$DryRun `
+                               -Base $Base -BaseCurrent:$BaseCurrent -DryRunStart:$DryRun `
                                -IgnoreBlocked:$IgnoreBlocked -TakeOver:$TakeOver
         $results += $r
         Write-Host ""
@@ -2766,26 +2793,8 @@ Write-Host "=== Empezando issue #$Start (board #$ProjectNum de $Owner) ===" -For
 Write-Host ""
 
 $ctx = Resolve-BoardStatus $Owner $ProjectNum
-
-# Resolve the base BEFORE starting: an issue branch starts from the remote default, not
-# from whatever HEAD is (#294). Only needed when we are actually going to branch.
-$startBase = ""
-if ($Branch -and -not $DryRun) {
-    if ($BaseCurrent) {
-        Write-Host "  -BaseCurrent: la rama nace del HEAD actual (trabajo dependiente)." -ForegroundColor DarkGray
-    } elseif ($Base) {
-        $startBase = $Base
-    } else {
-        $startBase = Resolve-IssueBaseRef -repo $Repo
-        if (-not $startBase) {
-            Write-Host "  WARN no pude resolver la rama por defecto del remoto - la rama nace del HEAD actual." -ForegroundColor DarkYellow
-            Write-Host "       Revisa que el PR no arrastre commits ajenos antes de mergear." -ForegroundColor DarkYellow
-        }
-    }
-}
-
 $r = Invoke-IssueStart -IssueNum $Start -Ctx $ctx -Owner $Owner -MakeBranch:$Branch `
-                       -BaseRef $startBase `
+                       -Base $Base -BaseCurrent:$BaseCurrent `
                        -DryRunStart:$DryRun -IgnoreBlocked:$IgnoreBlocked -TakeOver:$TakeOver
 
 if ($r.skipped) {

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -95,6 +95,18 @@
     GitHub fills the Linked pull requests column on the board by itself.
     -Parallel always creates a branch (in a worktree), so -Branch is implied there.
 
+.PARAMETER Base
+    With -Start -Branch / -Parallel: the ref the new issue branch starts from.
+    Defaults to the remote's default branch, freshly fetched (origin/main on this
+    repo) - never the current HEAD, which would drag the commits of whatever branch
+    you happened to be standing on into the issue's PR (#294). Pass an explicit ref
+    only for deliberately dependent work.
+
+.PARAMETER BaseCurrent
+    With -Start -Branch: base the issue branch on the CURRENT HEAD instead of the
+    remote default - the opt-in for work that genuinely builds on the branch you are
+    standing on. Mutually exclusive with -Base.
+
 .PARAMETER TokenVar
     Windows USER env var holding the PAT. Defaults to GITHUB_TOKEN_PERSONAL;
     use GITHUB_TOKEN_BUSINESS for the PAL-Devs account.
@@ -148,6 +160,8 @@ param(
     [int]   $MaxConcurrent = 0,
     [switch]$DryRun,
     [switch]$Branch,
+    [string]$Base          = "",
+    [switch]$BaseCurrent,
     [switch]$IgnoreBlocked,
     [switch]$TakeOver,
     [string]$TokenVar      = "GITHUB_TOKEN_PERSONAL",
@@ -592,10 +606,77 @@ function Get-IssueWorktreePath([string]$repo, [int]$issueNum, [string]$parentDir
     return (Join-Path (Join-Path $parentDir "$repoName--worktrees") "issue-$issueNum")
 }
 
+# The ref a NEW issue branch must start from: the remote's default branch, freshly
+# fetched. Cutting the branch from the current HEAD instead is what let another
+# branch's unmerged commits ride into an issue's PR - a 1-line fix that opened as 56
+# files, +2332/-253, and passed the gate (#294). Basing on the current HEAD is still
+# legitimate for dependent work, so it stays available, but as an OPT-IN (-BaseCurrent).
+#
+# Best-effort by design: every step degrades instead of throwing, because a repo with
+# no reachable origin still has to be able to start an issue - it just cannot promise
+# a clean base, and says so at the call site.
+function Resolve-IssueBaseRef([string]$repo = "", [switch]$NoFetch) {
+    if (-not $NoFetch) { git fetch origin --quiet 2>$null | Out-Null }
+
+    # 1. origin/HEAD - what this clone recorded as the remote's default branch.
+    $head = git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $head) {
+        git rev-parse --verify --quiet $head 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { return $head }
+    }
+
+    # 2. Ask GitHub. origin/HEAD is written at clone time: it is absent in fetch-built
+    #    clones and stale if the remote's default moved since.
+    if ($repo) {
+        $name = gh repo view $repo --json defaultBranchRef -q .defaultBranchRef.name 2>$null
+        if ($LASTEXITCODE -eq 0 -and $name) {
+            git rev-parse --verify --quiet "origin/$name" 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) { return "origin/$name" }
+        }
+    }
+
+    # 3. Convention, verified - never return a ref that does not resolve.
+    foreach ($candidate in @('origin/main', 'origin/master')) {
+        git rev-parse --verify --quiet $candidate 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { return $candidate }
+    }
+    return ""
+}
+
+# Check out the issue branch in the CURRENT working copy (the non-worktree path: the
+# tree is clean and not parked on another issue-*). Same base discipline as the worktree
+# path (#294) - a clean working copy parked on a feature branch is not dirty and does not
+# match issue-*, so it lands HERE, and a bare `checkout -b` off that HEAD drags the
+# feature branch's commits into this issue's PR exactly like the worktree path did.
+# Extracted so the base choice is unit-testable against a real repo without mocking gh.
+# Returns the ref the branch was based on ('' = current HEAD, 'existing' = no new branch).
+function New-IssueBranchInPlace([string]$branchName, [string]$baseRef = "") {
+    git rev-parse --verify --quiet $branchName 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        git checkout $branchName 2>&1 | Out-Null
+        Write-Host "  OK  Rama $branchName ya existia - checkout hecho" -ForegroundColor Green
+        return 'existing'
+    }
+    if ($baseRef) {
+        git checkout -b $branchName $baseRef 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  OK  Rama $branchName creada y activa (desde $baseRef)" -ForegroundColor Green
+            return $baseRef
+        }
+        # An unresolvable base must not silently become "branch off HEAD" - that is the
+        # #294 failure mode wearing a different hat. Say so, then fall back loudly.
+        Write-Host "  WARN no pude basar la rama en '$baseRef' - uso el HEAD actual." -ForegroundColor DarkYellow
+        Write-Host "       Revisa que el PR no arrastre commits ajenos antes de mergear." -ForegroundColor DarkYellow
+    }
+    git checkout -b $branchName 2>&1 | Out-Null
+    Write-Host "  OK  Rama $branchName creada y activa (desde el HEAD actual)" -ForegroundColor Green
+    return ''
+}
+
 # Create an isolated worktree <parent>/<repo>--worktrees/issue-<n> for a branch.
 # Returns the path or $null. $baseRef (e.g. origin/main) is used only when creating a
-# NEW branch: parallel starts each independent issue off a fresh main; single start
-# passes "" to keep branching off the current HEAD.
+# NEW branch; "" falls back to the current HEAD (see Resolve-IssueBaseRef for why that
+# is the fallback and not the default).
 function New-IssueWorktree([string]$repo, [int]$issueNum, [string]$branchName, [string]$baseRef = "") {
     $wtPath   = Get-IssueWorktreePath $repo $issueNum (Split-Path (Get-Location) -Parent)
     # Reuse: is the branch already checked out in some worktree?
@@ -764,14 +845,7 @@ mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!) {
                 }
                 $result.workPath = New-IssueWorktree $repo $IssueNum $branchName $BaseRef
             } else {
-                git rev-parse --verify --quiet $branchName 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) {
-                    git checkout $branchName 2>&1 | Out-Null
-                    Write-Host "  OK  Rama $branchName ya existia - checkout hecho" -ForegroundColor Green
-                } else {
-                    git checkout -b $branchName 2>&1 | Out-Null
-                    Write-Host "  OK  Rama $branchName creada y activa" -ForegroundColor Green
-                }
+                New-IssueBranchInPlace $branchName $BaseRef
                 $result.workPath = (Get-Location).Path
             }
         }
@@ -2164,6 +2238,10 @@ if (-not $env:GH_TOKEN) {
 }
 if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (and GH_TOKEN empty)." }
 
+# -Base and -BaseCurrent contradict each other; silently honouring one would put the
+# branch on a base the caller did not ask for - the exact class of bug #294 was.
+if ($Base -and $BaseCurrent) { throw "-Base and -BaseCurrent are mutually exclusive: pick the ref, or the current HEAD." }
+
 # ==============================================================================
 # LOCK MODE: -Lock <n> / -Unlock <n>  -> in ONE step mark an issue owned-elsewhere
 # (post the [abios-claim] fingerprint, move Status, AND assign the owner) WITHOUT
@@ -2471,12 +2549,16 @@ if ($Parallel.Count -gt 0) {
 
     $ctx = Resolve-BoardStatus $Owner $ProjectNum
 
-    # Fresh base so each independent worktree branches off up-to-date main.
+    # Fresh base so each independent worktree branches off the up-to-date default branch.
+    # Shares Resolve-IssueBaseRef with single -Start (#294): this path used to hardcode
+    # origin/main, which silently based every worktree on the wrong branch in a repo whose
+    # default is master.
     $baseRef = ""
     if (-not $DryRun) {
-        git fetch origin --quiet 2>$null
-        git rev-parse --verify --quiet origin/main 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) { $baseRef = "origin/main" }
+        $baseRef = if ($Base) { $Base } else { Resolve-IssueBaseRef -repo $Repo }
+        if (-not $baseRef) {
+            Write-Host "  WARN no pude resolver la rama por defecto del remoto - los worktrees nacen del HEAD actual." -ForegroundColor DarkYellow
+        }
     }
 
     $results = @()
@@ -2684,7 +2766,26 @@ Write-Host "=== Empezando issue #$Start (board #$ProjectNum de $Owner) ===" -For
 Write-Host ""
 
 $ctx = Resolve-BoardStatus $Owner $ProjectNum
+
+# Resolve the base BEFORE starting: an issue branch starts from the remote default, not
+# from whatever HEAD is (#294). Only needed when we are actually going to branch.
+$startBase = ""
+if ($Branch -and -not $DryRun) {
+    if ($BaseCurrent) {
+        Write-Host "  -BaseCurrent: la rama nace del HEAD actual (trabajo dependiente)." -ForegroundColor DarkGray
+    } elseif ($Base) {
+        $startBase = $Base
+    } else {
+        $startBase = Resolve-IssueBaseRef -repo $Repo
+        if (-not $startBase) {
+            Write-Host "  WARN no pude resolver la rama por defecto del remoto - la rama nace del HEAD actual." -ForegroundColor DarkYellow
+            Write-Host "       Revisa que el PR no arrastre commits ajenos antes de mergear." -ForegroundColor DarkYellow
+        }
+    }
+}
+
 $r = Invoke-IssueStart -IssueNum $Start -Ctx $ctx -Owner $Owner -MakeBranch:$Branch `
+                       -BaseRef $startBase `
                        -DryRunStart:$DryRun -IgnoreBlocked:$IgnoreBlocked -TakeOver:$TakeOver
 
 if ($r.skipped) {

--- a/plugins/agentic-board/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-board/skills/projects-admin/SKILL.md
@@ -213,7 +213,8 @@ them instead of one-by-one (each still finishes through the same step 5):
 
 | Command | What it does |
 |---------|--------------|
-| `Board-Work.ps1 -ProjectNum <n> -Parallel <n1,n2,...>` | Batch-start each issue (In Progress + assign + claim), each in its OWN isolated worktree `../<repo>--issue-<n>` branched off a fresh `origin/main`. Blocked / claimed / closed issues are skipped with a reason — the batch never aborts |
+| `Board-Work.ps1 -ProjectNum <n> -Parallel <n1,n2,...>` | Batch-start each issue (In Progress + assign + claim), each in its OWN isolated worktree, branched off the freshly fetched **default branch** (resolved, not assumed — a `master` repo works). Blocked / claimed / closed issues are skipped with a reason — the batch never aborts |
+| `... -Start <n> -Branch -BaseCurrent` (or `-Base <ref>`) | Opt in to basing the issue branch on the current HEAD (or an explicit ref) instead of the default branch — for work that genuinely builds on the branch you are standing on. Also honoured by `-Parallel`. Without it, the branch always starts from the default branch, so the PR cannot drag another branch's unmerged commits (#294) |
 | `... -Parallel <nums> -Launch` | After starting, spawn ONE visible Claude session per worktree, each briefed to take its issue through step 5. Windows Terminal tab (grouped in one named window) when `wt` is on PATH; otherwise a standalone `pwsh` window per worktree |
 | `... -Parallel <nums> [-Launch] -DryRun` | Plan the whole batch (and, with `-Launch`, preview the exact launch commands) without mutating the board, touching git, or spawning anything |
 | `Board-Work.ps1 -Sessions` | Monitor the LIVE fleet from `sessions.json` (branch, worktree, launch method `via`, and the PR opened per branch). Dead-PID entries pruned on read; needs no `-ProjectNum` |

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -145,8 +145,13 @@ Describe 'Resolve-IssueBaseRef (an issue branch starts from the remote default, 
     It 'falls back to convention when origin/HEAD is absent' {
         # origin/HEAD is written at clone time and is routinely missing (fetch-built
         # clones, older gits). Deleting it must not lose the base.
+        #
+        # -NoFetch is load-bearing, not an optimisation: since git 2.47
+        # remote.origin.followRemoteHEAD defaults to `create`, so the fetch inside
+        # Resolve-IssueBaseRef RECREATES origin/HEAD and step 1 answers again. Without
+        # this switch the test passes with the convention fallback deleted entirely.
         git symbolic-ref -d refs/remotes/origin/HEAD 2>&1 | Out-Null
-        Resolve-IssueBaseRef | Should -Be 'origin/main'
+        Resolve-IssueBaseRef -NoFetch | Should -Be 'origin/main'
     }
 
     It 'returns empty rather than an unresolvable ref when there is no origin at all' {
@@ -161,9 +166,90 @@ Describe 'Resolve-IssueBaseRef (an issue branch starts from the remote default, 
     }
 }
 
-Describe 'New-IssueWorktree bases a NEW branch on the remote default (#294)' {
-    # The regression proper: a 1-line fix opened a PR with 56 files and +2332/-253
-    # because the worktree was cut from whatever HEAD happened to be.
+Describe 'New-IssueWorkspace picks the base itself (the #294 wiring)' {
+    # THE regression test. New-IssueWorktree already honoured a base ref before #294 -
+    # the bug was that nobody passed it one. So a test that hands the base in passes
+    # against the buggy code and proves nothing; this one calls the wiring exactly as
+    # Invoke-IssueStart does, and goes red if the base resolution is removed.
+    BeforeEach {
+        # New-IssueWorkspace refuses to branch unless origin matches the issue's repo, so
+        # the remote has to SPELL owner/name. A Windows path cannot (it separates with \),
+        # hence a real bare repo at .../o/r reached over a file:/// URL: it contains the
+        # literal "o/r", and fetch still works locally without touching the network.
+        $script:Repo4   = 'o/r'
+        $root           = Join-Path $TestDrive ('W' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Origin4 = Join-Path $root 'o\r'
+        New-Item -ItemType Directory -Path $script:Origin4 -Force | Out-Null
+        git init -q --bare -b main $script:Origin4
+        $url = 'file:///' + ($script:Origin4 -replace '\\', '/')
+        $script:Clone4 = Join-Path $root 'clone'
+
+        $seed = Join-Path $root 'seed'
+        git clone -q $url $seed 2>&1 | Out-Null
+        Push-Location $seed
+        'base' | Set-Content (Join-Path $seed 'a.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git push -q origin main 2>&1 | Out-Null
+        Pop-Location
+
+        git clone -q $url $script:Clone4 2>&1 | Out-Null
+        Push-Location $script:Clone4
+        git config user.email t@t
+        git config user.name t
+        # Clean tree, parked on a feature branch with a commit main has never seen.
+        git checkout -q -b feature-z
+        'contamination' | Set-Content (Join-Path $script:Clone4 'foreign.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m 'foreign work nobody reviewed'
+    }
+    AfterEach { Pop-Location }
+
+    It 'the fixture really is a clone of the issue repo (else every test below passes vacuously)' {
+        # Guard on the guard: if the origin check silently stopped matching, New-IssueWorkspace
+        # would return '' and the contamination assertions would "pass" having branched nothing.
+        (git remote get-url origin) | Should -Match 'o/r'
+    }
+
+    It 'does NOT inherit the current branch commits - via the worktree path (dirty tree)' {
+        'uncommitted' | Set-Content (Join-Path $script:Clone4 'dirty.txt')   # forces the worktree path
+        $wp = New-IssueWorkspace -repo $script:Repo4 -issueNum 60 -branchName 'issue-60-fix'
+        $wp | Should -Not -BeNullOrEmpty
+        (Test-Path (Join-Path $wp 'foreign.txt')) | Should -BeFalse
+        Push-Location $wp
+        (git rev-list --count origin/main..HEAD) | Should -Be '0'
+        Pop-Location
+    }
+
+    It 'does NOT inherit the current branch commits - via the in-place path (clean tree)' {
+        $wp = New-IssueWorkspace -repo $script:Repo4 -issueNum 61 -branchName 'issue-61-fix'
+        $wp | Should -Be $script:Clone4
+        (git branch --show-current) | Should -Be 'issue-61-fix'
+        (Test-Path (Join-Path $script:Clone4 'foreign.txt')) | Should -BeFalse
+    }
+
+    It '-BaseCurrent opts back in to the current HEAD' {
+        $wp = New-IssueWorkspace -repo $script:Repo4 -issueNum 62 -branchName 'issue-62-dep' -BaseCurrent
+        (Test-Path (Join-Path $wp 'foreign.txt')) | Should -BeTrue
+    }
+
+    It '-Base pins an explicit ref' {
+        $wp = New-IssueWorkspace -repo $script:Repo4 -issueNum 63 -branchName 'issue-63-dep' -Base 'feature-z'
+        (Test-Path (Join-Path $wp 'foreign.txt')) | Should -BeTrue
+    }
+
+    It 'refuses to branch when the cwd is not a clone of the issue repo' {
+        New-IssueWorkspace -repo 'someone/else' -issueNum 64 -branchName 'issue-64-x' | Should -Be ''
+        (git branch --show-current) | Should -Be 'feature-z'   # nothing was touched
+    }
+
+    It 'returns ONLY the work path - no leaked git/branch output (Invoke-IssueStart reads $r.workPath)' {
+        $wp = New-IssueWorkspace -repo $script:Repo4 -issueNum 65 -branchName 'issue-65-fix'
+        @($wp).Count | Should -Be 1
+    }
+}
+
+Describe 'New-IssueWorktree honours a base ref it is given' {
     BeforeEach {
         $script:Origin2 = Join-Path $TestDrive ('O' + [guid]::NewGuid().ToString('N').Substring(0, 8))
         $script:Clone2  = "$($script:Origin2)-clone"
@@ -186,10 +272,12 @@ Describe 'New-IssueWorktree bases a NEW branch on the remote default (#294)' {
     }
     AfterEach { Pop-Location }
 
-    It 'does NOT carry the current branch commits into the issue worktree' {
-        $wt = New-IssueWorktree 'o/r' 42 'issue-42-fix' (Resolve-IssueBaseRef)
+    # NOTE: this asserts New-IssueWorktree's OWN contract only. It honoured a base ref
+    # before #294 too, so none of these would have caught the bug - the wiring that
+    # chooses the base is tested in the New-IssueWorkspace block above.
+    It 'cuts the branch from the given base, not from the current HEAD' {
+        $wt = New-IssueWorktree 'o/r' 42 'issue-42-fix' 'origin/main'
         $wt | Should -Not -BeNullOrEmpty
-        # The load-bearing assertion: the foreign commit must not be an ancestor.
         Push-Location $wt
         (Test-Path (Join-Path $wt 'foreign.txt')) | Should -BeFalse
         $ahead = git rev-list --count origin/main..HEAD

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -104,6 +104,166 @@ Describe 'Get-IssueWorktreePath (grouped worktree layout)' {
     }
 }
 
+Describe 'Resolve-IssueBaseRef (an issue branch starts from the remote default, #294)' {
+    # Real git repos over a real file-URL "origin" - the resolution order it implements
+    # (origin/HEAD -> gh -> convention) is entirely git state, so mocking git would
+    # only assert that the mock was called.
+    BeforeEach {
+        $script:Origin = Join-Path $TestDrive ('o' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Clone  = "$($script:Origin)-clone"
+        git init -q --bare -b main $script:Origin
+        $seed = "$($script:Origin)-seed"
+        git clone -q $script:Origin $seed 2>&1 | Out-Null
+        Push-Location $seed
+        'base' | Set-Content (Join-Path $seed 'a.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git push -q origin main 2>&1 | Out-Null
+        Pop-Location
+        git clone -q $script:Origin $script:Clone 2>&1 | Out-Null
+        Push-Location $script:Clone
+    }
+    AfterEach { Pop-Location }
+
+    It 'resolves the remote default branch from origin/HEAD' {
+        Resolve-IssueBaseRef | Should -Be 'origin/main'
+    }
+
+    It 'resolves a default branch that is NOT called main' {
+        # A repo on `master` (or `develop`) must not silently fall back to origin/main.
+        Push-Location $script:Origin
+        git symbolic-ref HEAD refs/heads/develop 2>&1 | Out-Null
+        Pop-Location
+        Push-Location $script:Clone
+        git branch -q develop main 2>&1 | Out-Null
+        git push -q origin develop 2>&1 | Out-Null
+        git remote set-head origin -a 2>&1 | Out-Null
+        Resolve-IssueBaseRef | Should -Be 'origin/develop'
+        Pop-Location
+    }
+
+    It 'falls back to convention when origin/HEAD is absent' {
+        # origin/HEAD is written at clone time and is routinely missing (fetch-built
+        # clones, older gits). Deleting it must not lose the base.
+        git symbolic-ref -d refs/remotes/origin/HEAD 2>&1 | Out-Null
+        Resolve-IssueBaseRef | Should -Be 'origin/main'
+    }
+
+    It 'returns empty rather than an unresolvable ref when there is no origin at all' {
+        # A local-only repo still has to start an issue - it just cannot promise a base.
+        $solo = Join-Path $TestDrive ('s' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        New-Item -ItemType Directory -Path $solo | Out-Null
+        Push-Location $solo
+        git init -q -b main
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m base
+        Resolve-IssueBaseRef | Should -BeNullOrEmpty
+        Pop-Location
+    }
+}
+
+Describe 'New-IssueWorktree bases a NEW branch on the remote default (#294)' {
+    # The regression proper: a 1-line fix opened a PR with 56 files and +2332/-253
+    # because the worktree was cut from whatever HEAD happened to be.
+    BeforeEach {
+        $script:Origin2 = Join-Path $TestDrive ('O' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Clone2  = "$($script:Origin2)-clone"
+        git init -q --bare -b main $script:Origin2
+        $seed = "$($script:Origin2)-seed"
+        git clone -q $script:Origin2 $seed 2>&1 | Out-Null
+        Push-Location $seed
+        'base' | Set-Content (Join-Path $seed 'a.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git push -q origin main 2>&1 | Out-Null
+        Pop-Location
+        git clone -q $script:Origin2 $script:Clone2 2>&1 | Out-Null
+        Push-Location $script:Clone2
+        # A local feature branch carrying a commit that main has never seen.
+        git checkout -q -b feature-x
+        'contamination' | Set-Content (Join-Path $script:Clone2 'foreign.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m 'foreign work nobody reviewed'
+    }
+    AfterEach { Pop-Location }
+
+    It 'does NOT carry the current branch commits into the issue worktree' {
+        $wt = New-IssueWorktree 'o/r' 42 'issue-42-fix' (Resolve-IssueBaseRef)
+        $wt | Should -Not -BeNullOrEmpty
+        # The load-bearing assertion: the foreign commit must not be an ancestor.
+        Push-Location $wt
+        (Test-Path (Join-Path $wt 'foreign.txt')) | Should -BeFalse
+        $ahead = git rev-list --count origin/main..HEAD
+        $ahead | Should -Be '0'
+        Pop-Location
+    }
+
+    It 'still honours an explicit base ref (dependent work is opt-in, not the default)' {
+        $wt = New-IssueWorktree 'o/r' 43 'issue-43-dep' 'feature-x'
+        Push-Location $wt
+        (Test-Path (Join-Path $wt 'foreign.txt')) | Should -BeTrue
+        Pop-Location
+    }
+
+    It 'falls back to HEAD when no base can be resolved, rather than failing the start' {
+        $wt = New-IssueWorktree 'o/r' 44 'issue-44-nobase' ''
+        $wt | Should -Not -BeNullOrEmpty
+        (Test-Path (Join-Path $wt 'foreign.txt')) | Should -BeTrue
+    }
+}
+
+Describe 'New-IssueBranchInPlace bases a NEW branch on the remote default (#294)' {
+    # The half of #294 the report did not describe. A CLEAN working copy parked on a
+    # feature branch is not dirty and does not match issue-*, so it never reaches the
+    # worktree path - it lands here, where `checkout -b` had the identical defect.
+    BeforeEach {
+        $script:Origin3 = Join-Path $TestDrive ('i' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Clone3  = "$($script:Origin3)-clone"
+        git init -q --bare -b main $script:Origin3
+        $seed = "$($script:Origin3)-seed"
+        git clone -q $script:Origin3 $seed 2>&1 | Out-Null
+        Push-Location $seed
+        'base' | Set-Content (Join-Path $seed 'a.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git push -q origin main 2>&1 | Out-Null
+        Pop-Location
+        git clone -q $script:Origin3 $script:Clone3 2>&1 | Out-Null
+        Push-Location $script:Clone3
+        # Clean tree, parked on a feature branch with an unmerged commit.
+        git checkout -q -b feature-y
+        'contamination' | Set-Content (Join-Path $script:Clone3 'foreign.txt')
+        git add -A 2>&1 | Out-Null
+        git -c user.email=t@t -c user.name=t commit -q -m 'foreign work nobody reviewed'
+        git config user.email t@t
+        git config user.name t
+    }
+    AfterEach { Pop-Location }
+
+    It 'does NOT inherit the feature branch commits when given the remote default' {
+        New-IssueBranchInPlace 'issue-50-fix' (Resolve-IssueBaseRef) | Should -Be 'origin/main'
+        (git branch --show-current) | Should -Be 'issue-50-fix'
+        (Test-Path (Join-Path $script:Clone3 'foreign.txt')) | Should -BeFalse
+        (git rev-list --count origin/main..HEAD) | Should -Be '0'
+    }
+
+    It 'inherits the current HEAD when no base is given (the pre-fix behaviour, now opt-in)' {
+        New-IssueBranchInPlace 'issue-51-dep' '' | Should -Be ''
+        (Test-Path (Join-Path $script:Clone3 'foreign.txt')) | Should -BeTrue
+    }
+
+    It 'checks out an existing branch instead of recreating it off the base' {
+        git branch issue-52-old main 2>&1 | Out-Null
+        New-IssueBranchInPlace 'issue-52-old' 'origin/main' | Should -Be 'existing'
+        (git branch --show-current) | Should -Be 'issue-52-old'
+    }
+
+    It 'falls back to HEAD - loudly - when the base ref does not resolve' {
+        # Must not fail the start, but must not pretend it used the base either.
+        New-IssueBranchInPlace 'issue-53-badbase' 'origin/does-not-exist' | Should -Be ''
+        (git branch --show-current) | Should -Be 'issue-53-badbase'
+    }
+}
+
 Describe 'Get-SessionBriefing' {
     BeforeAll { $script:Brief = Get-SessionBriefing 42 'owner/repo' 'issue-42-x' 'C:\wt\path' }
     It 'is a single line (safe to pass on a command line)' {


### PR DESCRIPTION
Closes #294.

## What

`-Start -Branch` cut the work branch from whatever HEAD happened to be. Start an issue while parked
on a feature branch and the issue branch was based on it, so the PR carried that branch's unmerged
commits — a 1-line fix that opened as 56 files, +2332/-253 and passed the gate, which said only
"PR grande".

`Resolve-IssueBaseRef` resolves the remote default branch, freshly fetched (`origin/HEAD` → ask
GitHub → verified convention; every step verifies the ref before returning it). `New-IssueWorkspace`
is the single wiring both start paths now share.

## Beyond the report

Two defects the issue did not describe, found while fixing it:

- **The in-place `checkout -b` had the identical defect.** A *clean* working copy parked on a feature
  branch is not dirty and does not match `issue-*`, so it never reaches the worktree path — it lands
  in the in-place path, which branched off HEAD just the same. Fixing only the worktree would have
  left the bug reachable by the more common route.
- **`-Parallel` hardcoded `origin/main`**, so in a repo whose default is `master` it silently based
  every worktree on the wrong branch.

## What the review changed

No external reviewer was available (Copilot out of quota, Codex timed out, Gemini CLI auth is dead),
so this went through an adversarial subagent review instead. It found four real defects — each
confirmed empirically before fixing, and each worth more than the original diff:

| Defect | Why it mattered |
|---|---|
| `Resolve-IssueBaseRef` was passed the script's `-Repo` | That is the `-ListBoards` scope filter — **empty on every `-Start`**. The `gh` fallback was dead code, so a clone with no `origin/HEAD`, of a repo defaulting to `develop` but still carrying a legacy `main`, silently based on `origin/main`. Bug #294 wearing a different hat. The base is now resolved where the issue's real repo slug is known |
| The convention-fallback test was **vacuous** | Since git 2.47 `followRemoteHEAD` defaults to `create`, so the fetch inside the function *recreated* `origin/HEAD` and step 1 answered. Verified on git 2.52 here. It passed with step 3 deleted entirely; now uses `-NoFetch` |
| The worktree test **proved nothing** | `New-IssueWorktree` already honoured a base ref before this fix — nobody passed it one — and the test handed the base in itself. The real wiring sat in top-level code past the dot-source guard, unreachable by the suite |
| `-BaseCurrent` was **silently ignored** by `-Parallel` | Based every worktree on the default branch — the exact "honour a base the caller did not ask for" failure the `-Base`/`-BaseCurrent` guard exists to prevent |

Plus: `New-IssueBranchInPlace`'s return value leaked onto `Invoke-IssueStart`'s output stream, making
`$r` an `Object[]` instead of the documented structured result — harmless today, one `Set-StrictMode`
away from real.

## Validation

733 tests pass (715 on main; **+18**). The new suites use **real git repos over a real `file:///`
origin** — the behaviour under test is entirely git state, so mocking git would only assert that the
mock was called.

**The tests are mutation-verified.** Deleting the base resolution restores bug #294, and exactly the
two regression tests go red:

```
=== BUG #294 REINTRODUCED -> FAILED: 2 ===
  RED: does NOT inherit the current branch commits - via the worktree path (dirty tree)
  RED: does NOT inherit the current branch commits - via the in-place path (clean tree)
```

The opt-in tests stay green under that mutation, which is correct — they do not depend on resolution.
A fixture guard asserts the clone really is a clone of the issue repo, so the origin-match check
cannot silently make the contamination assertions pass having branched nothing (it did exactly that
in the first draft).

## Not in this PR

The issue's "Extra" — a review-gate warning when a PR contains commits that are not the issue's work
— is tracked in #309. It is a different concern (detecting contamination after the fact) with its own
design and tests, and bundling it would make this PR exactly the kind the gate warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
