### PR TITLE
gh hardening: Invoke-Gh - a gh failure is a failure, not an empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- **`Invoke-Gh.ps1` — a shared helper that turns a `gh` failure into a real failure** (#311, part of
+  #303). `gh` signals failure only through its exit code, and a native command that exits non-zero
+  does not throw in PowerShell — not even under `$ErrorActionPreference = 'Stop'`. Unchecked, a 401
+  becomes an empty result, which several scripts read as "the board is empty" and then write from.
+  Covers all three failure modes: non-zero exit, exit 0 with an unparseable body (`-Json`), and exit
+  0 with a graphql `errors[]` body (`-Graphql`). Retries only what retrying can fix (5xx/timeouts,
+  never a 401), and captures stderr instead of leaving `2>$null` to bury it. A genuinely empty result
+  is still returned as empty — that half of the contract is pinned by tests too.
+
 ### Fixed
 - **work: an issue branch starts from the remote default branch, not the current HEAD** (#294).
   `-Start -Branch` cut the branch from whatever HEAD happened to be, so starting an issue from a

--- a/plugins/agentic-board/scripts/Invoke-Gh.ps1
+++ b/plugins/agentic-board/scripts/Invoke-Gh.ps1
@@ -14,14 +14,20 @@
 
     The contract, and both halves matter equally:
       * gh exits non-zero            -> throw, with the operation named and gh's stderr attached.
-      * gh succeeds and returns []   -> return []. A genuinely empty board is NOT an error.
+      * gh succeeds and returns []   -> return it as an empty result, NOT an error. A genuinely
+                                        empty board is not a failure.
     If those two ever collapse into each other the helper has failed at its only job, so the
     test suite pins them as a pair.
+
+    (Precisely: an empty JSON array comes back as $null, because `'[]' | ConvertFrom-Json` emits
+    nothing. That is what every consumer already expects - @($x).Count, foreach and ForEach-Object
+    all see zero either way - but the distinction is written down here rather than papered over.)
 
     Three failure modes, not one:
       1. non-zero exit                        -> -GhArgs alone covers it.
       2. exit 0 with an unparseable/empty body -> -Json (gh --json always emits at least [] or {}).
       3. exit 0 with a graphql errors[] body   -> -Graphql. The request succeeded; the query did not.
+         -Graphql implies -Json: the check needs the parsed body, so the two cannot be separated.
 
     stderr is captured here rather than left to each call site, because the `2>$null` idiom
     that ~30 sites use hides the message AND the exit code goes unread, so the failure leaves
@@ -33,8 +39,12 @@
     Usage:
       $board  = Invoke-Gh -GhArgs @('project','view','13','--owner','x','--format','json') `
                           -What 'leer el board #13' -Json
-      $resp   = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q") -What 'mover el item' -Json -Graphql
+      $resp   = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q") -What 'mover el item' -Graphql
       $null   = Invoke-Gh -GhArgs @('project','item-edit',...) -What 'escribir el campo' -Retries 3
+
+    A body on stdin (`gh api graphql --input -`) travels as -StdIn, NOT as a pipe into this
+    function - see Invoke-GhRaw for why a pipe would hang instead of failing:
+      $resp   = Invoke-Gh -GhArgs @('api','graphql','--input','-') -StdIn $body -What '...' -Graphql
 #>
 
 # The ONE place the gh executable is touched. A seam, so the retry/parse/throw logic above
@@ -42,10 +52,16 @@
 # stdout is kept CLEAN (stderr goes to its own file, never merged with 2>&1, which would
 # splice ErrorRecords into a body about to be parsed as JSON).
 function Invoke-GhRaw {
-    param([string[]]$GhArgs)
+    param([string[]]$GhArgs, [string]$StdIn)
     $errFile = [System.IO.Path]::GetTempFileName()
     try {
-        $out  = & gh @GhArgs 2>$errFile
+        # $StdIn feeds `gh ... --input -`. It must be piped HERE, explicitly: a native
+        # command does NOT inherit the enclosing function's pipeline input, so a caller
+        # writing `$body | Invoke-Gh ...` does not fail - gh blocks reading the console
+        # forever. A hang is worse than the 401 this file exists to stop, so the body
+        # travels as a parameter and the pipe is built where gh can actually see it.
+        if ($PSBoundParameters.ContainsKey('StdIn')) { $out = $StdIn | & gh @GhArgs 2>$errFile }
+        else                                         { $out = & gh @GhArgs 2>$errFile }
         $code = $LASTEXITCODE           # read FIRST: any native call after this clobbers it
         $err  = ''
         if (Test-Path $errFile) {
@@ -67,11 +83,17 @@ function Invoke-GhRaw {
 function Test-GhTransientError {
     param([string]$StdErr)
     if (-not $StdErr) { return $false }
+    # 'secondary rate limit' arrives as a 403, so it has to be matched by TEXT, not status:
+    # a plain permissions 403 must stay non-transient. This is the failure /board work
+    # -Parallel actually produces - N processes hammering the API - so leaving it out made
+    # -Retries useless for the one case it was needed. (Primary rate limiting is NOT here:
+    # it resets on the hour, and a 500ms backoff cannot outwait it.)
     return ($StdErr -match 'HTTP 5\d\d' -or
             $StdErr -match 'i/o timeout' -or
             $StdErr -match 'connection reset' -or
             $StdErr -match 'TLS handshake timeout' -or
-            $StdErr -match 'temporary failure')
+            $StdErr -match 'temporary failure' -or
+            $StdErr -match 'secondary rate limit')
 }
 
 function Invoke-Gh {
@@ -80,13 +102,21 @@ function Invoke-Gh {
         [string]$What = 'la operacion gh',
         [switch]$Json,
         [switch]$Graphql,
+        [string]$StdIn,
         [int]   $Retries = 0,
         [int]   $RetryDelayMs = 500
     )
 
+    # -Graphql IMPLIES -Json. Checking errors[] means parsing the body, and the parse only
+    # happens under -Json - so `-Graphql` alone used to return before the check ever ran,
+    # making the switch a silent no-op at exactly the call sites it was written for. A
+    # caller that asks for the graphql check must GET the graphql check.
+    if ($Graphql) { $Json = $true }
+
     $attempt = 0
     while ($true) {
-        $r = Invoke-GhRaw -GhArgs $GhArgs
+        $r = if ($PSBoundParameters.ContainsKey('StdIn')) { Invoke-GhRaw -GhArgs $GhArgs -StdIn $StdIn }
+             else                                         { Invoke-GhRaw -GhArgs $GhArgs }
         if ($r.ExitCode -eq 0) { break }
 
         # Retry only a transient failure, and only while attempts remain.

--- a/plugins/agentic-board/scripts/Invoke-Gh.ps1
+++ b/plugins/agentic-board/scripts/Invoke-Gh.ps1
@@ -1,0 +1,117 @@
+<#  Invoke-Gh.ps1 - run gh so that a failure is a FAILURE, not an empty result (#303).
+
+    Why this exists. `gh` signals failure ONLY through its exit code, and a native command
+    that exits non-zero does NOT throw in PowerShell - not even under
+    $ErrorActionPreference = 'Stop', which governs cmdlets only. So this:
+
+        $fields = (gh project field-list 13 --owner x --format json | ConvertFrom-Json).fields
+
+    turns a 401 into `$fields = @()`. Nothing errors, nothing warns, and the caller reads it
+    as "the board has no fields" - which is exactly the premise it then WRITES from. That
+    misread already shipped once: Board-Fill reported a healthy "no gaps" board it had never
+    managed to read (issue #86). It was fixed in that one file and never generalised, which
+    is why this is a shared helper and not another hand-written check.
+
+    The contract, and both halves matter equally:
+      * gh exits non-zero            -> throw, with the operation named and gh's stderr attached.
+      * gh succeeds and returns []   -> return []. A genuinely empty board is NOT an error.
+    If those two ever collapse into each other the helper has failed at its only job, so the
+    test suite pins them as a pair.
+
+    Three failure modes, not one:
+      1. non-zero exit                        -> -GhArgs alone covers it.
+      2. exit 0 with an unparseable/empty body -> -Json (gh --json always emits at least [] or {}).
+      3. exit 0 with a graphql errors[] body   -> -Graphql. The request succeeded; the query did not.
+
+    stderr is captured here rather than left to each call site, because the `2>$null` idiom
+    that ~30 sites use hides the message AND the exit code goes unread, so the failure leaves
+    no trace at all.
+
+    Pure at load: dot-source it, it defines functions only (no gh, no output).
+      . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+
+    Usage:
+      $board  = Invoke-Gh -GhArgs @('project','view','13','--owner','x','--format','json') `
+                          -What 'leer el board #13' -Json
+      $resp   = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q") -What 'mover el item' -Json -Graphql
+      $null   = Invoke-Gh -GhArgs @('project','item-edit',...) -What 'escribir el campo' -Retries 3
+#>
+
+# The ONE place the gh executable is touched. A seam, so the retry/parse/throw logic above
+# it is unit-testable by mocking this: no token, no network, any exit code on demand.
+# stdout is kept CLEAN (stderr goes to its own file, never merged with 2>&1, which would
+# splice ErrorRecords into a body about to be parsed as JSON).
+function Invoke-GhRaw {
+    param([string[]]$GhArgs)
+    $errFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $out  = & gh @GhArgs 2>$errFile
+        $code = $LASTEXITCODE           # read FIRST: any native call after this clobbers it
+        $err  = ''
+        if (Test-Path $errFile) {
+            # -Raw on an empty file returns $null, and ([string]$null).Trim() THROWS
+            # ("cannot call a method on a null-valued expression") - so the empty-stderr
+            # case, i.e. every successful call, has to be handled explicitly.
+            $raw = Get-Content $errFile -Raw -ErrorAction SilentlyContinue
+            if ($raw) { $err = $raw.Trim() }
+        }
+        return [pscustomobject]@{ Output = $out; ExitCode = $code; StdErr = $err }
+    } finally {
+        Remove-Item $errFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Is this failure worth retrying? Only what retrying can actually fix: GitHub's transient
+# 5xx and network stalls. A 401 or a 404 is a fact, and retrying it four times just makes
+# the same error arrive later.
+function Test-GhTransientError {
+    param([string]$StdErr)
+    if (-not $StdErr) { return $false }
+    return ($StdErr -match 'HTTP 5\d\d' -or
+            $StdErr -match 'i/o timeout' -or
+            $StdErr -match 'connection reset' -or
+            $StdErr -match 'TLS handshake timeout' -or
+            $StdErr -match 'temporary failure')
+}
+
+function Invoke-Gh {
+    param(
+        [Parameter(Mandatory)][string[]]$GhArgs,
+        [string]$What = 'la operacion gh',
+        [switch]$Json,
+        [switch]$Graphql,
+        [int]   $Retries = 0,
+        [int]   $RetryDelayMs = 500
+    )
+
+    $attempt = 0
+    while ($true) {
+        $r = Invoke-GhRaw -GhArgs $GhArgs
+        if ($r.ExitCode -eq 0) { break }
+
+        # Retry only a transient failure, and only while attempts remain.
+        if ($attempt -lt $Retries -and (Test-GhTransientError -StdErr $r.StdErr)) {
+            $attempt++
+            Start-Sleep -Milliseconds ($RetryDelayMs * $attempt)   # linear backoff
+            continue
+        }
+        $detail = if ($r.StdErr) { ": $($r.StdErr)" } else { '' }
+        throw "No pude $What (gh exit $($r.ExitCode))$detail"
+    }
+
+    if (-not $Json) { return $r.Output }
+
+    # gh --json ALWAYS emits at least [] or {}. Nothing means something went wrong in a way
+    # the exit code did not report - never hand that back as an empty result.
+    $body = ($r.Output -join "`n").Trim()
+    if (-not $body) { throw "No pude $What - gh salio 0 pero sin salida (se esperaba JSON)" }
+
+    try   { $parsed = $body | ConvertFrom-Json }
+    catch { throw "No pude $What - la respuesta de gh no es JSON valido: $($_.Exception.Message)" }
+
+    # graphql's own failure mode: HTTP 200 + exit 0, with the failure inside the body.
+    if ($Graphql -and $parsed.PSObject.Properties.Name -contains 'errors' -and @($parsed.errors).Count -gt 0) {
+        throw "No pude $What - graphql devolvio errores: $(@($parsed.errors)[0].message)"
+    }
+    return $parsed
+}

--- a/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
@@ -1,0 +1,188 @@
+#Requires -Modules Pester
+<#  Tests for scripts/Invoke-Gh.ps1 (#311, part of #303).
+
+    The whole point of the helper is that a gh failure must NOT be readable as an empty
+    result, so almost every test here asserts a THROW. The one that matters most is the
+    pair: gh exiting non-zero must throw, and gh legitimately returning an empty list must
+    NOT - if those two collapse into each other the helper has failed at its only job.
+
+    Invoke-GhRaw is the seam: it is the single place the gh executable is touched, so
+    mocking it simulates any exit code / body with no token and no network. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Invoke-Gh.ps1' | Resolve-Path
+    . $script:Script
+}
+
+Describe 'Invoke-Gh (a non-zero exit is a failure, not an empty result)' {
+
+    It 'returns stdout when gh succeeds' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = 'hello'; ExitCode = 0; StdErr = '' } }
+        Invoke-Gh -GhArgs @('repo', 'view') | Should -Be 'hello'
+    }
+
+    It 'THROWS when gh exits non-zero - the #303 bug in one line' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 401: Bad credentials' } }
+        { Invoke-Gh -GhArgs @('project', 'view', '13') } | Should -Throw
+    }
+
+    It 'names the operation and the exit code in the message' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 4; StdErr = 'HTTP 401: Bad credentials' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -What 'leer el board #13' } |
+            Should -Throw -ExpectedMessage '*leer el board #13*'
+    }
+
+    It 'surfaces gh stderr in the message (2>$null used to bury it)' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 401: Bad credentials' } }
+        { Invoke-Gh -GhArgs @('project', 'view') } | Should -Throw -ExpectedMessage '*Bad credentials*'
+    }
+}
+
+Describe 'Invoke-Gh -Json' {
+
+    It 'parses the body on success' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"name":"board"}'; ExitCode = 0; StdErr = '' } }
+        (Invoke-Gh -GhArgs @('project', 'view') -Json).name | Should -Be 'board'
+    }
+
+    It 'returns an EMPTY list as an empty list - a real empty board is not an error' {
+        # The other half of the contract. If this throws, every caller learns to catch,
+        # and the catch swallows the real failures again.
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '[]'; ExitCode = 0; StdErr = '' } }
+        @(Invoke-Gh -GhArgs @('issue', 'list') -Json).Count | Should -Be 0
+    }
+
+    It 'THROWS on empty stdout - gh --json always emits at least [] or {}' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -Json } | Should -Throw -ExpectedMessage '*sin salida*'
+    }
+
+    It 'THROWS on a body that is not JSON, instead of returning $null' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = 'not json at all'; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -Json } | Should -Throw
+    }
+
+    It 'joins a multi-line body before parsing (gh emits an array of lines)' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = @('{', '"name":"board"', '}'); ExitCode = 0; StdErr = '' } }
+        (Invoke-Gh -GhArgs @('project', 'view') -Json).name | Should -Be 'board'
+    }
+}
+
+Describe 'Invoke-Gh -Graphql (exit 0 WITH an errors[] body)' {
+    # graphql's separate failure mode: the request succeeds, the query does not.
+
+    It 'THROWS when the body carries errors[], despite exit 0' {
+        Mock Invoke-GhRaw {
+            [pscustomobject]@{ Output = '{"data":null,"errors":[{"message":"Could not resolve to a node"}]}'; ExitCode = 0; StdErr = '' }
+        }
+        { Invoke-Gh -GhArgs @('api', 'graphql') -Json -Graphql } |
+            Should -Throw -ExpectedMessage '*Could not resolve to a node*'
+    }
+
+    It 'does NOT throw on a clean graphql body' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"node":{"id":"X"}}}'; ExitCode = 0; StdErr = '' } }
+        (Invoke-Gh -GhArgs @('api', 'graphql') -Json -Graphql).data.node.id | Should -Be 'X'
+    }
+
+    It 'does NOT treat a non-graphql field called errors as a failure unless -Graphql is set' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"errors":["a"]}'; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('api', 'x') -Json } | Should -Not -Throw
+    }
+
+    It 'ignores an EMPTY errors[] (some responses include it empty)' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"x":1},"errors":[]}'; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('api', 'graphql') -Json -Graphql } | Should -Not -Throw
+    }
+}
+
+Describe 'Test-GhTransientError (only retry what retrying can fix)' {
+    It 'treats 5xx as transient' {
+        Test-GhTransientError -StdErr 'HTTP 502: Bad gateway' | Should -BeTrue
+        Test-GhTransientError -StdErr 'HTTP 503' | Should -BeTrue
+    }
+    It 'treats timeouts and connection resets as transient' {
+        Test-GhTransientError -StdErr 'error connecting: i/o timeout' | Should -BeTrue
+    }
+    It 'does NOT treat auth failure as transient - retrying a 401 is just slower' {
+        Test-GhTransientError -StdErr 'HTTP 401: Bad credentials' | Should -BeFalse
+    }
+    It 'does NOT treat a 404 as transient' {
+        Test-GhTransientError -StdErr 'HTTP 404: Not Found' | Should -BeFalse
+    }
+    It 'is false for empty stderr' {
+        Test-GhTransientError -StdErr '' | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-Gh -Retries' {
+    It 'retries a transient failure and succeeds' {
+        $script:calls = 0
+        Mock Invoke-GhRaw {
+            $script:calls++
+            if ($script:calls -lt 3) { [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 502: Bad gateway' } }
+            else                     { [pscustomobject]@{ Output = 'ok'; ExitCode = 0; StdErr = '' } }
+        }
+        Invoke-Gh -GhArgs @('project', 'view') -Retries 3 -RetryDelayMs 1 | Should -Be 'ok'
+        $script:calls | Should -Be 3
+    }
+
+    It 'does NOT retry a 401 - it fails on the first attempt' {
+        $script:calls = 0
+        Mock Invoke-GhRaw { $script:calls++; [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 401: Bad credentials' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -Retries 3 -RetryDelayMs 1 } | Should -Throw
+        $script:calls | Should -Be 1
+    }
+
+    It 'gives up after the last retry and still THROWS (never returns empty)' {
+        $script:calls = 0
+        Mock Invoke-GhRaw { $script:calls++; [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 502' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -Retries 2 -RetryDelayMs 1 } | Should -Throw
+        $script:calls | Should -Be 3      # first attempt + 2 retries
+    }
+}
+
+Describe 'Invoke-GhRaw against the REAL gh (the seam every other test mocks away)' {
+    # These exist because the mocked suite above passed 22/22 while Invoke-GhRaw was
+    # broken for EVERY successful call: -Raw on the empty stderr file returns $null, and
+    # ([string]$null).Trim() throws. Mocking the seam proves the logic on top of it and
+    # nothing about the seam itself, so the seam gets real calls.
+    #
+    # `gh --version` needs no token and no network, so this is CI-safe.
+    #
+    # The probe sits in the Describe BODY, not in BeforeAll: -Skip is evaluated at
+    # DISCOVERY, so a BeforeAll variable is still $null when Pester reads it and every
+    # test below would silently skip - passing while testing nothing.
+    $hasGh = [bool](Get-Command gh -ErrorAction SilentlyContinue)
+
+    It 'reports exit 0 and clean stdout on success, with EMPTY stderr (the null-Trim bug)' -Skip:(-not $hasGh) {
+        $r = Invoke-GhRaw -GhArgs @('--version')
+        $r.ExitCode | Should -Be 0
+        $r.StdErr   | Should -Be ''            # would THROW before, not return ''
+        ($r.Output -join ' ') | Should -Match 'gh version'
+    }
+
+    It 'reports a non-zero exit and captures stderr on failure' -Skip:(-not $hasGh) {
+        $r = Invoke-GhRaw -GhArgs @('this-subcommand-does-not-exist')
+        $r.ExitCode | Should -Not -Be 0
+        $r.StdErr   | Should -Not -BeNullOrEmpty
+    }
+
+    It 'end-to-end: a real failing gh call THROWS through Invoke-Gh' -Skip:(-not $hasGh) {
+        { Invoke-Gh -GhArgs @('this-subcommand-does-not-exist') -What 'probar el seam' } |
+            Should -Throw -ExpectedMessage '*probar el seam*'
+    }
+
+    It 'end-to-end: a real succeeding gh call returns its output' -Skip:(-not $hasGh) {
+        (Invoke-Gh -GhArgs @('--version') -What 'leer la version') -join ' ' | Should -Match 'gh version'
+    }
+}
+
+Describe 'Dot-sourcing Invoke-Gh.ps1 is side-effect free' {
+    It 'defines the functions without invoking gh or writing output' {
+        # Every consumer dot-sources it at load; a script that ran anything here would
+        # fire on import, including inside the ABIOS_*_DOTSOURCE test guards.
+        $out = . $script:Script
+        $out | Should -BeNullOrEmpty
+        (Get-Command Invoke-Gh -ErrorAction SilentlyContinue) | Should -Not -BeNullOrEmpty
+    }
+}

--- a/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
@@ -93,6 +93,22 @@ Describe 'Invoke-Gh -Graphql (exit 0 WITH an errors[] body)' {
         Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"x":1},"errors":[]}'; ExitCode = 0; StdErr = '' } }
         { Invoke-Gh -GhArgs @('api', 'graphql') -Json -Graphql } | Should -Not -Throw
     }
+
+    It 'THROWS on errors[] even WITHOUT -Json - the switch must never be a silent no-op' {
+        # -Graphql alone used to return the raw body before the errors[] check ran, so a
+        # caller that asked for the check silently got none: bug #303 restored at exactly
+        # the call sites this switch exists for. -Graphql now implies -Json.
+        Mock Invoke-GhRaw {
+            [pscustomobject]@{ Output = '{"data":null,"errors":[{"message":"Could not resolve to a node"}]}'; ExitCode = 0; StdErr = '' }
+        }
+        { Invoke-Gh -GhArgs @('api', 'graphql') -What 'mover el item' -Graphql } |
+            Should -Throw -ExpectedMessage '*Could not resolve to a node*'
+    }
+
+    It 'parses the body under -Graphql alone (it implies -Json)' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"node":{"id":"X"}}}'; ExitCode = 0; StdErr = '' } }
+        (Invoke-Gh -GhArgs @('api', 'graphql') -Graphql).data.node.id | Should -Be 'X'
+    }
 }
 
 Describe 'Test-GhTransientError (only retry what retrying can fix)' {
@@ -111,6 +127,16 @@ Describe 'Test-GhTransientError (only retry what retrying can fix)' {
     }
     It 'is false for empty stderr' {
         Test-GhTransientError -StdErr '' | Should -BeFalse
+    }
+    It 'treats a SECONDARY rate limit as transient - what -Parallel actually produces' {
+        Test-GhTransientError -StdErr 'HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes.' |
+            Should -BeTrue
+    }
+    It 'does NOT treat a plain permissions 403 as transient (matched by text, not status)' {
+        Test-GhTransientError -StdErr 'HTTP 403: Resource not accessible by integration' | Should -BeFalse
+    }
+    It 'matches case-insensitively (gh has changed the casing of these strings before)' {
+        Test-GhTransientError -StdErr 'http 502: bad gateway' | Should -BeTrue
     }
 }
 
@@ -174,6 +200,45 @@ Describe 'Invoke-GhRaw against the REAL gh (the seam every other test mocks away
 
     It 'end-to-end: a real succeeding gh call returns its output' -Skip:(-not $hasGh) {
         (Invoke-Gh -GhArgs @('--version') -What 'leer la version') -join ' ' | Should -Match 'gh version'
+    }
+}
+
+Describe 'Invoke-Gh -StdIn (the `gh api graphql --input -` sites)' {
+    # Apply-FieldPreset.ps1 feeds graphql over stdin. The obvious conversion,
+    # `$body | Invoke-Gh -GhArgs @('api','graphql','--input','-')`, does NOT work and does
+    # NOT fail: a native command inside a function never sees the function's pipeline
+    # input, so gh blocks on the console forever. Under a headless -Launch fleet session a
+    # silent hang is worse than the 401 this whole file exists to stop - hence -StdIn.
+
+    It 'the in-function pipe idiom Invoke-GhRaw relies on really reaches a native stdin' {
+        # Pins the IDIOM (`$var | & <native>` built INSIDE the function), not Invoke-GhRaw's
+        # own line - that one hardcodes gh, and `gh api graphql --input -` would need a token
+        # and the network. git is in this repo's toolchain and reads stdin, so it stands in.
+        # Mocking would prove nothing here: the hang IS the seam.
+        #
+        # Run in a job with a timeout so that a REGRESSION (gh blocking on the console) fails
+        # this test instead of wedging the whole suite forever - which is what the bug does.
+        $sha = ''
+        $job = Start-Job { $body = 'hello'; $body | & git hash-object --stdin 2>$null }
+        if (Wait-Job $job -Timeout 20) { $sha = (Receive-Job $job) -join '' }
+        Remove-Job $job -Force -ErrorAction SilentlyContinue
+        # Asserting a NON-empty sha, not a literal one: the exact hash depends on the line
+        # ending PowerShell's pipe appends (CRLF here -> ef0493b..., not the "hello\n"
+        # value every reference would tell you). What is under test is that the bytes
+        # arrived at all; pinning the platform's newline would only make this brittle.
+        $sha | Should -Match '^[0-9a-f]{40}$'
+    }
+
+    It 'passes -StdIn through Invoke-Gh to Invoke-GhRaw' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"ok":1}}'; ExitCode = 0; StdErr = '' } } -ParameterFilter { $StdIn -eq 'BODY' }
+        (Invoke-Gh -GhArgs @('api', 'graphql', '--input', '-') -StdIn 'BODY' -Graphql).data.ok | Should -Be 1
+        Should -Invoke Invoke-GhRaw -Times 1 -Exactly -ParameterFilter { $StdIn -eq 'BODY' }
+    }
+
+    It 'does not pass -StdIn when the caller did not ask for it' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = 'ok'; ExitCode = 0; StdErr = '' } }
+        Invoke-Gh -GhArgs @('repo', 'view') | Out-Null
+        Should -Invoke Invoke-GhRaw -Times 1 -Exactly -ParameterFilter { -not $PSBoundParameters.ContainsKey('StdIn') }
     }
 }
 


### PR DESCRIPTION
Closes #311. Part of #303.

## What

`gh` signals failure **only** through its exit code, and a native command that exits non-zero does
not throw in PowerShell — not even under `$ErrorActionPreference = 'Stop'`, which governs cmdlets.
So the idiom used across 79 call sites:

```powershell
$fields = (gh project field-list 13 --owner x --format json | ConvertFrom-Json).fields
```

turns a 401 into `$fields = @()` — which the caller reads as *"the board has no fields"*, the premise
it then **writes** from. This adds the shared helper the rest of #303 will convert those sites to.

It is deliberately **not wired into any caller yet**: this PR is the foundation plus its tests, so
the conversions land reviewable on top.

## Not one failure mode, three

| Mode | Covered by |
|---|---|
| non-zero exit | `-GhArgs` alone |
| exit 0, empty/unparseable body | `-Json` (gh `--json` always emits at least `[]` or `{}`) |
| exit 0 **with** a graphql `errors[]` body | `-Graphql` — the request succeeded, the query did not |

Both halves of the contract are pinned by tests: a failure must throw, **and** a genuinely empty list
must still come back empty. If those collapse into each other, callers learn to `catch`, and the
catch swallows the real failures all over again.

`-Retries` retries only what retrying can fix (5xx, timeouts, secondary rate limits) — a 401 fails on
the first attempt instead of four times slower. stderr is captured here rather than left to the
`2>$null` idiom, which hides the message *and* lets the exit code go unread.

## This nearly shipped broken twice

Worth recording, because both escapes were caused by the same thing — trusting a green suite.

**1. The mocks hid the seam.** 22/22 tests passed while `Invoke-GhRaw` threw on **every successful
call**: `Get-Content -Raw` on the empty stderr file returns `$null`, and `([string]$null).Trim()`
throws. Every test mocked the seam, so nothing exercised the one function that touches reality.
Found by running it against real `gh`. Now covered by 4 tests that call `gh` for real via
`gh --version` (no token, CI-safe) — and CI confirms they run: `Tests Passed: 768, Skipped: 0`.

**2. An adversarial review found three more.** Each confirmed by running it before fixing:

| Defect | Why it mattered |
|---|---|
| **`-Graphql` without `-Json` did nothing** | `if (-not $Json) { return $r.Output }` returned before the `errors[]` check. A caller that explicitly asked for the graphql check silently got none — bug #303 restored at the exact ~27 sites the switch exists for. Every test passed both switches together, so none caught it. `-Graphql` now implies `-Json` |
| **No stdin, and the obvious conversion HANGS** | `Apply-FieldPreset` feeds graphql over stdin. A native command inside a function never sees the function's pipeline input, so `$body \| Invoke-Gh ...` does not fail — gh blocks on the console forever. Under a headless `-Launch` session a silent hang is worse than the 401 this file exists to stop. Added `-StdIn` |
| **`secondary rate limit` was not transient** | It arrives as a 403, so it must be matched by *text* (a plain permissions 403 must stay non-transient). It is the failure `-Parallel` actually produces — N processes on one API — so `-Retries` was useless for the one case it was needed |

## Validation

768 tests pass (760 before this PR's review round; 715 on main).

**Mutation-tested** — reverting each fix turns exactly the matching tests red, so none of them are
decorative:

```
=== -Graphql no longer implies -Json      -> RED: 3
=== secondary rate limit dropped          -> RED: 1
=== -StdIn never forwarded to the seam    -> RED: 1
=== exit-code check removed (the #303 bug)-> RED: 5
```

Verified end-to-end against the live API, all three modes:

```
1. REAL success (valid token)     -> OK  board title: agentic-board — Roadmap (items: 178)
2. REAL failure (invalid token)   -> OK  THREW: No pude leer el board #13 (gh exit 1): unknown owner type
3. REAL graphql error             -> OK  THREW: ... Could not resolve to a node with the global id of 'NOT_A_REAL_ID'
```

One honesty fix from the review: the header claimed `[]` comes back as `[]`, when it is really `$null`
(`'[]' | ConvertFrom-Json` emits nothing). Identical for every consumer, but the contract should not
say something the code does not do.

## Reviewer note

No external reviewer was available (Copilot out of quota, Codex timed out, Gemini CLI auth is dead),
so this went through an adversarial subagent review instead — that is where defects 2–4 came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
