### PR TITLE
gh hardening: a failed backup must not write a plausible empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   is still returned as empty — that half of the contract is pinned by tests too.
 
 ### Fixed
+- **A failed backup no longer writes a plausible empty file** (#312, part of #303). `Backup-Board.ps1`
+  and `Export-BoardSnapshot.ps1` ran `gh` unchecked, so a 401 produced three empty JSON files and
+  printed `Backup OK:` — a failure only ever discovered on restore day. Both now go through
+  `Invoke-Gh`; the backup reads everything BEFORE it writes anything (so a late failure cannot leave
+  a half-backup nobody labelled as one), persists gh's bytes verbatim via `-RawJson`, and verifies
+  the files it actually wrote rather than the ones it meant to. `Export-BoardSnapshot` no longer
+  publishes `0 of 0 tracked items done.` when it simply could not read the board.
 - **work: an issue branch starts from the remote default branch, not the current HEAD** (#294).
   `-Start -Branch` cut the branch from whatever HEAD happened to be, so starting an issue from a
   feature branch dragged its unmerged commits into the issue's PR — a 1-line fix opened as 56

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@
 - **A failed backup no longer writes a plausible empty file** (#312, part of #303). `Backup-Board.ps1`
   and `Export-BoardSnapshot.ps1` ran `gh` unchecked, so a 401 produced three empty JSON files and
   printed `Backup OK:` — a failure only ever discovered on restore day. Both now go through
-  `Invoke-Gh`; the backup reads everything BEFORE it writes anything (so a late failure cannot leave
-  a half-backup nobody labelled as one), persists gh's bytes verbatim via `-RawJson`, and verifies
-  the files it actually wrote rather than the ones it meant to. `Export-BoardSnapshot` no longer
-  publishes `0 of 0 tracked items done.` when it simply could not read the board.
+  `Invoke-Gh`, which is what makes a failed read fail. The snapshot is written via `-RawJson`, so it
+  is not re-serialised (no reshaping, no silent `-Depth` truncation), and without a BOM, so the same
+  backup no longer differs between Windows PowerShell 5.1 and pwsh 7. Each written file is read back
+  and parsed before the run reports success. If only the live clone fails, the run still fails but
+  now *names* the JSON snapshot it did leave on disk, instead of dying silently over three valid
+  files the caller believes do not exist. `Export-BoardSnapshot` no longer publishes a report when it
+  could not read the board — including the case where `gh` exits 0 with valid JSON of the wrong
+  shape, where `@($resp.items)` on a missing property would otherwise invent a phantom item and
+  render `0 of 1 tracked items done.` above an empty table.
 - **work: an issue branch starts from the remote default branch, not the current HEAD** (#294).
   `-Start -Branch` cut the branch from whatever HEAD happened to be, so starting an issue from a
   feature branch dragged its unmerged commits into the issue's PR — a 1-line fix opened as 56

--- a/plugins/agentic-board/scripts/Backup-Board.ps1
+++ b/plugins/agentic-board/scripts/Backup-Board.ps1
@@ -24,11 +24,14 @@ New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
 
 $stamp  = Get-Date -Format 'yyyyMMdd-HHmmss'
 
-# READ EVERYTHING FIRST, and only then write. -RawJson validates the body as JSON but hands
-# back gh's original text: a backup is persisted verbatim, so round-tripping it through
-# ConvertTo-Json would reshape it (and -Depth would quietly truncate it).
-# Read-then-write also means a failure on the third read cannot leave two files behind that
-# look like a partial backup nobody labelled as one.
+# Read everything first, and only then write, so a failure on the third read cannot leave
+# two files behind that look like a partial backup nobody labelled as one.
+#
+# -RawJson validates the body as JSON but hands back gh's text instead of a parsed object:
+# the snapshot must not be re-serialised, because ConvertTo-Json would reshape it and -Depth
+# would quietly truncate it. It is NOT byte-for-byte gh output - PowerShell has already split
+# stdout into lines and dropped the terminators before any of this runs - but it is
+# unreshaped and untruncated, which is what a restorable backup actually needs.
 $meta   = Invoke-Gh -GhArgs @('project', 'view',       "$Number", '--owner', $Owner, '--format', 'json') `
                     -What "leer el board #$Number de $Owner" -RawJson -Retries 2
 $fields = Invoke-Gh -GhArgs @('project', 'field-list', "$Number", '--owner', $Owner, '--format', 'json') `
@@ -41,22 +44,38 @@ if (-not $title) { throw "El board #$Number no devolvio un titulo - no hago un b
 $safe   = ($title -replace '[^\w\-]+', '_').Trim('_')
 $base   = Join-Path $BackupDir ("{0}_{1}" -f $safe, $stamp)
 
-$meta   | Out-File ("$base.project.json") -Encoding UTF8
-$fields | Out-File ("$base.fields.json")  -Encoding UTF8
-$items  | Out-File ("$base.items.json")   -Encoding UTF8
+# WriteAllText, not Out-File: Out-File -Encoding UTF8 writes a BOM on Windows PowerShell 5.1
+# (which this script supports - see the header) and none on pwsh 7, so the same backup came
+# out different depending on the host. A snapshot's encoding should not depend on who ran it.
+$snapshotFiles = @{ "$base.project.json" = $meta; "$base.fields.json" = $fields; "$base.items.json" = $items }
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+foreach ($f in $snapshotFiles.Keys) { [System.IO.File]::WriteAllText($f, $snapshotFiles[$f], $utf8NoBom) }
 
-# Verify what was WRITTEN, not what we meant to write. The point of this script is that the
-# file is there on the day someone needs it, and an empty file that reports "Backup OK" is
-# the one failure that is only ever discovered when it is already too late.
-foreach ($f in @("$base.project.json", "$base.fields.json", "$base.items.json")) {
-    if (-not (Test-Path $f))            { throw "El backup no se escribio: $f" }
-    if ((Get-Item $f).Length -eq 0)     { throw "El backup quedo VACIO: $f" }
+# Verify what was WRITTEN, not what we meant to write - by READING IT BACK and parsing it.
+# A size check would be theatre: Invoke-Gh -RawJson already refused an empty body, so a
+# zero-byte file was never reachable. What this catches is the write itself going wrong
+# (truncation, a mangled encoding) - the failure a backup can only reveal on restore day.
+foreach ($f in $snapshotFiles.Keys) {
+    if (-not (Test-Path $f)) { throw "El backup no se escribio: $f" }
+    try   { $null = (Get-Content $f -Raw) | ConvertFrom-Json }
+    catch { throw "El backup quedo ilegible (no parsea como JSON): $f" }
 }
 
 # restorable live clone (fields/views + draft issues)
 $cloneTitle = "$title $dash backup $stamp"
-Invoke-Gh -GhArgs @('project', 'copy', "$Number", '--source-owner', $Owner, '--target-owner', $Owner, '--drafts', '--title', $cloneTitle) `
-          -What "clonar el board #$Number" -Retries 2 | Out-Null
+try {
+    Invoke-Gh -GhArgs @('project', 'copy', "$Number", '--source-owner', $Owner, '--target-owner', $Owner, '--drafts', '--title', $cloneTitle) `
+              -What "clonar el board #$Number" -Retries 2 | Out-Null
+} catch {
+    # The snapshot is already on disk and is perfectly good. Dying here without saying so
+    # would leave three valid files the caller believes do not exist - so they either re-run
+    # and pile up duplicate snapshots, or assume they have no backup at all. Report what
+    # exists, report what failed, and still fail: the header promises BOTH halves.
+    Write-Host "Backup PARCIAL:" -ForegroundColor Yellow
+    Write-Host ("  JSON snapshot OK : {0}.project.json (+ .fields.json, .items.json)" -f $base) -ForegroundColor Yellow
+    Write-Host  "  Live clone FALLO : el snapshot JSON sirve para restaurar; el clon vivo no se creo." -ForegroundColor Yellow
+    throw
+}
 
 Write-Host "Backup OK:"
 Write-Host ("  JSON snapshot: {0}.project.json (+ .fields.json, .items.json)" -f $base)

--- a/plugins/agentic-board/scripts/Backup-Board.ps1
+++ b/plugins/agentic-board/scripts/Backup-Board.ps1
@@ -13,17 +13,31 @@ $ErrorActionPreference = 'Stop'
 $dash = [char]0x2014
 # The single resolver for the internal state dir (new name + migration + fallback).
 . (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')
+# gh fails by exit code only, and a native command exiting non-zero does not throw (#303).
+# This script is the LAST line of defence before a delete, so it must never mistake a 401
+# for an empty board and write a plausible-looking empty snapshot.
+. (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
 if (-not $BackupDir) {
   $BackupDir = if ($env:ABIOS_BACKUP_DIR) { $env:ABIOS_BACKUP_DIR } else { Join-Path (Get-AbiosStateDir -Root $HOME) 'backups' }
 }
 New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
 
 $stamp  = Get-Date -Format 'yyyyMMdd-HHmmss'
-$meta   = gh project view      $Number --owner $Owner --format json
-$fields = gh project field-list $Number --owner $Owner --format json
-$items  = gh project item-list $Number --owner $Owner --format json --limit 1000
+
+# READ EVERYTHING FIRST, and only then write. -RawJson validates the body as JSON but hands
+# back gh's original text: a backup is persisted verbatim, so round-tripping it through
+# ConvertTo-Json would reshape it (and -Depth would quietly truncate it).
+# Read-then-write also means a failure on the third read cannot leave two files behind that
+# look like a partial backup nobody labelled as one.
+$meta   = Invoke-Gh -GhArgs @('project', 'view',       "$Number", '--owner', $Owner, '--format', 'json') `
+                    -What "leer el board #$Number de $Owner" -RawJson -Retries 2
+$fields = Invoke-Gh -GhArgs @('project', 'field-list', "$Number", '--owner', $Owner, '--format', 'json') `
+                    -What "leer los campos del board #$Number" -RawJson -Retries 2
+$items  = Invoke-Gh -GhArgs @('project', 'item-list',  "$Number", '--owner', $Owner, '--format', 'json', '--limit', '1000') `
+                    -What "leer los items del board #$Number" -RawJson -Retries 2
 
 $title  = ($meta | ConvertFrom-Json).title
+if (-not $title) { throw "El board #$Number no devolvio un titulo - no hago un backup de algo que no pude leer." }
 $safe   = ($title -replace '[^\w\-]+', '_').Trim('_')
 $base   = Join-Path $BackupDir ("{0}_{1}" -f $safe, $stamp)
 
@@ -31,9 +45,18 @@ $meta   | Out-File ("$base.project.json") -Encoding UTF8
 $fields | Out-File ("$base.fields.json")  -Encoding UTF8
 $items  | Out-File ("$base.items.json")   -Encoding UTF8
 
+# Verify what was WRITTEN, not what we meant to write. The point of this script is that the
+# file is there on the day someone needs it, and an empty file that reports "Backup OK" is
+# the one failure that is only ever discovered when it is already too late.
+foreach ($f in @("$base.project.json", "$base.fields.json", "$base.items.json")) {
+    if (-not (Test-Path $f))            { throw "El backup no se escribio: $f" }
+    if ((Get-Item $f).Length -eq 0)     { throw "El backup quedo VACIO: $f" }
+}
+
 # restorable live clone (fields/views + draft issues)
 $cloneTitle = "$title $dash backup $stamp"
-gh project copy $Number --source-owner $Owner --target-owner $Owner --drafts --title $cloneTitle | Out-Null
+Invoke-Gh -GhArgs @('project', 'copy', "$Number", '--source-owner', $Owner, '--target-owner', $Owner, '--drafts', '--title', $cloneTitle) `
+          -What "clonar el board #$Number" -Retries 2 | Out-Null
 
 Write-Host "Backup OK:"
 Write-Host ("  JSON snapshot: {0}.project.json (+ .fields.json, .items.json)" -f $base)

--- a/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
+++ b/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
@@ -15,7 +15,16 @@ $ErrorActionPreference = 'Stop'
 
 $resp  = Invoke-Gh -GhArgs @('project', 'item-list', "$Number", '--owner', $Owner, '--format', 'json', '--limit', '500') `
                    -What "leer los items del board #$Number de $Owner" -Json -Retries 2
-$items = @($resp.items)
+
+# -Json covers a non-zero exit, an empty body and an unparseable body - but NOT "parsed
+# fine, wrong shape" (an error object like {"message":"Not Found"}, or a gh schema change).
+# That case must fail here, because @($null).Count is 1, not 0: `@($resp.items)` on a
+# missing property yields a one-element array holding $null, and the report would claim
+# "0 of 1 tracked items done" over an empty table - a document that contradicts itself.
+if (-not $resp.PSObject.Properties['items']) {
+    throw "No pude leer los items del board #$Number - gh devolvio JSON sin 'items'."
+}
+$items = @($resp.items | Where-Object { $null -ne $_ })
 
 $rank  = @{ 'Backlog' = 0; 'In Progress' = 1; 'In Review' = 2; 'Done' = 3 }
 $sorted = $items | Sort-Object `

--- a/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
+++ b/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
@@ -8,7 +8,14 @@ param(
   [string]$OutFile
 )
 $ErrorActionPreference = 'Stop'
-$items = (gh project item-list $Number --owner $Owner --format json --limit 500 | ConvertFrom-Json).items
+# gh fails by exit code only, and a native command exiting non-zero does not throw (#303).
+# Unchecked, a 401 made this publish a snapshot reading "0 of 0 tracked items done." - a
+# document that looks like a finished board rather than a failed read.
+. (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+
+$resp  = Invoke-Gh -GhArgs @('project', 'item-list', "$Number", '--owner', $Owner, '--format', 'json', '--limit', '500') `
+                   -What "leer los items del board #$Number de $Owner" -Json -Retries 2
+$items = @($resp.items)
 
 $rank  = @{ 'Backlog' = 0; 'In Progress' = 1; 'In Review' = 2; 'Done' = 3 }
 $sorted = $items | Sort-Object `

--- a/plugins/agentic-board/scripts/Invoke-Gh.ps1
+++ b/plugins/agentic-board/scripts/Invoke-Gh.ps1
@@ -108,10 +108,15 @@ function Invoke-Gh {
         [int]   $RetryDelayMs = 500
     )
 
-    # -RawJson: validate the body as JSON but hand back the ORIGINAL text. For callers that
-    # persist what gh sent (Backup-Board writes the snapshot verbatim) - round-tripping
-    # through ConvertFrom/ConvertTo-Json would silently reshape a backup, and -Depth would
-    # quietly truncate it. Validation without mutation.
+    # -RawJson: validate the body as JSON but hand back the TEXT rather than a parsed object.
+    # For callers that persist what gh sent (Backup-Board writes the snapshot to disk) -
+    # round-tripping through ConvertFrom/ConvertTo-Json would silently reshape a backup, and
+    # -Depth would quietly truncate it.
+    #
+    # NOT byte-for-byte gh output, and it must not be sold as such: `& gh` hands stdout back
+    # already split into lines with the terminators stripped, so CRLF, the trailing newline
+    # and any surrounding whitespace are gone before this function ever sees the body. What
+    # -RawJson guarantees is narrower and is the part that matters: unreshaped and untruncated.
     if ($RawJson) { $Json = $true }
 
     # -Graphql IMPLIES -Json. Checking errors[] means parsing the body, and the parse only

--- a/plugins/agentic-board/scripts/Invoke-Gh.ps1
+++ b/plugins/agentic-board/scripts/Invoke-Gh.ps1
@@ -101,11 +101,18 @@ function Invoke-Gh {
         [Parameter(Mandatory)][string[]]$GhArgs,
         [string]$What = 'la operacion gh',
         [switch]$Json,
+        [switch]$RawJson,
         [switch]$Graphql,
         [string]$StdIn,
         [int]   $Retries = 0,
         [int]   $RetryDelayMs = 500
     )
+
+    # -RawJson: validate the body as JSON but hand back the ORIGINAL text. For callers that
+    # persist what gh sent (Backup-Board writes the snapshot verbatim) - round-tripping
+    # through ConvertFrom/ConvertTo-Json would silently reshape a backup, and -Depth would
+    # quietly truncate it. Validation without mutation.
+    if ($RawJson) { $Json = $true }
 
     # -Graphql IMPLIES -Json. Checking errors[] means parsing the body, and the parse only
     # happens under -Json - so `-Graphql` alone used to return before the check ever ran,
@@ -143,5 +150,6 @@ function Invoke-Gh {
     if ($Graphql -and $parsed.PSObject.Properties.Name -contains 'errors' -and @($parsed.errors).Count -gt 0) {
         throw "No pude $What - graphql devolvio errores: $(@($parsed.errors)[0].message)"
     }
+    if ($RawJson) { return $body }
     return $parsed
 }

--- a/plugins/agentic-board/tests/Backup-Board.Tests.ps1
+++ b/plugins/agentic-board/tests/Backup-Board.Tests.ps1
@@ -12,7 +12,11 @@
 
     So the seam is a fake `gh.cmd` placed first on PATH. It is more faithful than any mock:
     the real script, the real Invoke-Gh, the real Invoke-GhRaw and its real 2>$errFile
-    redirection all run - only the binary at the end is ours. #>
+    redirection all run - only the binary at the end is ours.
+
+    A .cmd is Windows-only. CI runs Pester on windows-latest, so it always executes there;
+    the guard below is for a contributor on macOS/Linux, where these would otherwise hard-fail
+    for a reason that has nothing to do with the code under test. #>
 
 BeforeAll {
     $script:Backup   = (Join-Path $PSScriptRoot '..' 'scripts' 'Backup-Board.ps1'         | Resolve-Path).Path
@@ -58,7 +62,11 @@ exit /b 0
 
 AfterAll { Remove-Item $script:FakeDir -Recurse -Force -ErrorAction SilentlyContinue }
 
-Describe 'Backup-Board: a failed read must not become an empty backup' {
+# NOT named $isWindows: that collides (case-insensitively) with PowerShell 7's read-only
+# automatic $IsWindows, and the clash silently skipped this entire file.
+$onWindows = [System.Environment]::OSVersion.Platform -eq 'Win32NT'
+
+Describe 'Backup-Board: a failed read must not become an empty backup' -Skip:(-not $onWindows) {
     BeforeEach {
         $script:Dir   = Join-Path ([System.IO.Path]::GetTempPath()) ('bkp' + [guid]::NewGuid().ToString('N').Substring(0, 8))
         $script:Count = Join-Path ([System.IO.Path]::GetTempPath()) ('cnt' + [guid]::NewGuid().ToString('N').Substring(0, 8) + '.txt')
@@ -117,12 +125,37 @@ Describe 'Backup-Board: a failed read must not become an empty backup' {
         $files = @(Get-ChildItem $script:Dir -File)
         $files.Count | Should -Be 3
         @($files | Where-Object { $_.Length -eq 0 }).Count | Should -Be 0
-        # -RawJson, not a re-serialisation: a backup is persisted verbatim.
+        # -RawJson, not a re-serialisation: the snapshot is unreshaped.
         (Get-Content $files[0].FullName -Raw).Trim() | Should -Be '{"title":"My Board"}'
+    }
+
+    It 'writes the snapshot WITHOUT a BOM, whatever host ran it' {
+        # Out-File -Encoding UTF8 emits a BOM on Windows PowerShell 5.1 and none on pwsh 7,
+        # so the same backup used to differ by host. A snapshot's bytes should not depend on
+        # who ran the script.
+        Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                          -Env @{ FAKE_GH_OUT = '{"title":"My Board"}' } | Out-Null
+        $f = @(Get-ChildItem $script:Dir -File)[0].FullName
+        $bytes = [System.IO.File]::ReadAllBytes($f)
+        # EF BB BF is the UTF-8 BOM.
+        ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+    }
+
+    It 'reports the snapshot it DID write when only the live clone fails' {
+        # The clone is call 4, after the three files are on disk. Dying silently would leave
+        # three valid files the caller believes do not exist - so they re-run and pile up
+        # duplicates, or assume they have no backup. It must still FAIL (the script promises
+        # snapshot AND clone), but it must say what survived.
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_OUT = '{"title":"My Board"}'; FAKE_GH_COUNT = $script:Count; FAKE_GH_FAIL_ON = '4' }
+        $out | Should -Not -Match 'Backup OK'
+        $out | Should -Match 'Backup PARCIAL'
+        $out | Should -Match 'JSON snapshot OK'
+        @(Get-ChildItem $script:Dir -File).Count | Should -Be 3   # they exist, and they are named
     }
 }
 
-Describe 'Export-BoardSnapshot: a failed read must not become a "0 of 0 done" report' {
+Describe 'Export-BoardSnapshot: a failed read must not become a "0 of 0 done" report' -Skip:(-not $onWindows) {
     BeforeEach { $script:OutFile = Join-Path ([System.IO.Path]::GetTempPath()) ('snap' + [guid]::NewGuid().ToString('N').Substring(0, 8) + '.md') }
     AfterEach  { Remove-Item $script:OutFile -Force -ErrorAction SilentlyContinue }
 
@@ -133,6 +166,28 @@ Describe 'Export-BoardSnapshot: a failed read must not become a "0 of 0 done" re
                                  -Env @{ FAKE_GH_EXIT = '1'; FAKE_GH_ERR = 'HTTP 401: Bad credentials' }
         Test-Path $script:OutFile | Should -BeFalse
         $out | Should -Not -Match 'Snapshot written'
+    }
+
+    It 'writes no file when gh exits 0 with valid JSON of the WRONG SHAPE' {
+        # -Json catches a bad exit, an empty body and unparseable text - but not "parsed
+        # fine, no items property" (an error object, a gh schema change). This case is why
+        # the script asserts the property instead of trusting @($resp.items): @($null).Count
+        # is 1, so the first version of this fix rendered "_0 of 1 tracked items done._"
+        # above an empty table - a self-contradicting report, published with a success
+        # message, and strictly WORSE than the "0 of 0" it replaced.
+        $out = Invoke-WithFakeGh -Path $script:Snapshot -Params @{ Number = 13; Owner = 'o'; OutFile = $script:OutFile } `
+                                 -Env @{ FAKE_GH_OUT = '{"message":"Not Found"}' }
+        Test-Path $script:OutFile | Should -BeFalse
+        $out | Should -Not -Match 'Snapshot written'
+        $out | Should -Match "sin 'items'"
+    }
+
+    It 'renders an EMPTY board as empty - a board with no items is not an error' {
+        # The other half of the contract: fail on unreadable, not on genuinely empty.
+        $out = Invoke-WithFakeGh -Path $script:Snapshot -Params @{ Number = 13; Owner = 'o'; OutFile = $script:OutFile } `
+                                 -Env @{ FAKE_GH_OUT = '{"items":[]}' }
+        Test-Path $script:OutFile | Should -BeTrue
+        (Get-Content $script:OutFile -Raw) | Should -Match '0 of 0 tracked items done'
     }
 
     It 'renders the board on success' {

--- a/plugins/agentic-board/tests/Backup-Board.Tests.ps1
+++ b/plugins/agentic-board/tests/Backup-Board.Tests.ps1
@@ -1,0 +1,146 @@
+#Requires -Modules Pester
+<#  Tests for Backup-Board.ps1 and Export-BoardSnapshot.ps1 (#312, part of #303).
+
+    These two are the ugliest instance of the silent-gh bug. Every other victim misreports
+    something you can see; a backup misreports on the one day you cannot afford it. Before
+    this, a 401 produced three empty files and printed "Backup OK:".
+
+    HOW THESE RUN. Both scripts are top-level commands with mandatory params, so they cannot
+    be dot-sourced for mocking, and stubbing Invoke-GhRaw from the outside does not work
+    either: the script dot-sources Invoke-Gh.ps1 into its OWN scope afterwards, which shadows
+    the stub (the first draft of this file did exactly that and silently called the real API).
+
+    So the seam is a fake `gh.cmd` placed first on PATH. It is more faithful than any mock:
+    the real script, the real Invoke-Gh, the real Invoke-GhRaw and its real 2>$errFile
+    redirection all run - only the binary at the end is ours. #>
+
+BeforeAll {
+    $script:Backup   = (Join-Path $PSScriptRoot '..' 'scripts' 'Backup-Board.ps1'         | Resolve-Path).Path
+    $script:Snapshot = (Join-Path $PSScriptRoot '..' 'scripts' 'Export-BoardSnapshot.ps1' | Resolve-Path).Path
+
+    # A fake gh: exits with %FAKE_GH_EXIT%, prints %FAKE_GH_OUT% on stdout and %FAKE_GH_ERR%
+    # on stderr. With %FAKE_GH_FAIL_ON% set it counts calls in %FAKE_GH_COUNT% and fails only
+    # on the Nth - which is how the read-then-write ordering gets pinned.
+    $script:FakeDir = Join-Path ([System.IO.Path]::GetTempPath()) ('fakegh' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path $script:FakeDir -Force | Out-Null
+    @'
+@echo off
+setlocal EnableDelayedExpansion
+set N=0
+if defined FAKE_GH_COUNT (
+  if exist "%FAKE_GH_COUNT%" set /p N=<"%FAKE_GH_COUNT%"
+  set /a N=!N!+1
+  echo !N!>"%FAKE_GH_COUNT%"
+)
+if defined FAKE_GH_FAIL_ON if "!N!"=="%FAKE_GH_FAIL_ON%" (
+  if defined FAKE_GH_FAIL_ERR (echo %FAKE_GH_FAIL_ERR% 1>&2) else (echo HTTP 401: Bad credentials 1>&2)
+  exit /b 1
+)
+if defined FAKE_GH_ERR echo %FAKE_GH_ERR% 1>&2
+if defined FAKE_GH_OUT echo %FAKE_GH_OUT%
+if defined FAKE_GH_EXIT (exit /b %FAKE_GH_EXIT%)
+exit /b 0
+'@ | Set-Content (Join-Path $script:FakeDir 'gh.cmd') -Encoding ASCII
+
+    # Run a script with the fake gh first on PATH, in a CHILD pwsh so PATH/env never leak.
+    # $Params are NAMED script parameters: only the VALUE is quoted, because quoting the
+    # name too makes PowerShell bind '-Number' as a positional value ("cannot convert
+    # '-Number' to Int32") - which fails the script before gh is ever reached, and makes
+    # every "must not write a file" test pass for the wrong reason.
+    function Invoke-WithFakeGh {
+        param([string]$Path, [hashtable]$Params, [hashtable]$Env = @{})
+        $envSet = ($Env.GetEnumerator() | ForEach-Object { "`$env:$($_.Key)='$($_.Value)'" }) -join '; '
+        $argStr = ($Params.GetEnumerator() | ForEach-Object { "-$($_.Key) '$($_.Value)'" }) -join ' '
+        $cmd = "`$env:PATH='$($script:FakeDir);' + `$env:PATH; $envSet; & '$Path' $argStr"
+        return (& pwsh -NoProfile -Command $cmd 2>&1 | Out-String)
+    }
+}
+
+AfterAll { Remove-Item $script:FakeDir -Recurse -Force -ErrorAction SilentlyContinue }
+
+Describe 'Backup-Board: a failed read must not become an empty backup' {
+    BeforeEach {
+        $script:Dir   = Join-Path ([System.IO.Path]::GetTempPath()) ('bkp' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $script:Count = Join-Path ([System.IO.Path]::GetTempPath()) ('cnt' + [guid]::NewGuid().ToString('N').Substring(0, 8) + '.txt')
+        New-Item -ItemType Directory -Path $script:Dir -Force | Out-Null
+    }
+    AfterEach {
+        Remove-Item $script:Dir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $script:Count -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'writes NOTHING and fails when gh returns 401' {
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_EXIT = '1'; FAKE_GH_ERR = 'HTTP 401: Bad credentials' }
+        # THE assertion: no plausible-looking file survived the failure.
+        @(Get-ChildItem $script:Dir -File).Count | Should -Be 0
+        $out | Should -Not -Match 'Backup OK'
+        $out | Should -Match 'Bad credentials'      # and the buried stderr is surfaced
+    }
+
+    It 'fails when gh exits 0 with an EMPTY body (the exit code cannot catch this one)' {
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_EXIT = '0' }
+        @(Get-ChildItem $script:Dir -File).Count | Should -Be 0
+        $out | Should -Not -Match 'Backup OK'
+    }
+
+    It 'writes NOTHING when the THIRD read fails - no half-backup left behind' {
+        # Why every read happens before any write. A partial backup is the worst artefact of
+        # all: it exists, so nobody re-runs it.
+        #
+        # The injected failure is a 401 ON PURPOSE. With a 502 the helper retries and the
+        # backup legitimately SUCCEEDS - which is what the first version of this test hit,
+        # asserting 0 files against a run that had correctly recovered. See the retry test
+        # below: same injection point, transient error, opposite (and also correct) outcome.
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_OUT = '{"title":"My Board"}'; FAKE_GH_COUNT = $script:Count; FAKE_GH_FAIL_ON = '3' }
+        @(Get-ChildItem $script:Dir -File).Count | Should -Be 0
+        $out | Should -Not -Match 'Backup OK'
+    }
+
+    It 'RECOVERS from a transient 502 on the third read and still writes the backup' {
+        # The other half of -Retries: a 5xx must not cost you the backup.
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_OUT     = '{"title":"My Board"}'
+                                         FAKE_GH_COUNT   = $script:Count
+                                         FAKE_GH_FAIL_ON = '3'
+                                         FAKE_GH_FAIL_ERR = 'HTTP 502: Bad gateway' }
+        $out | Should -Match 'Backup OK'
+        @(Get-ChildItem $script:Dir -File).Count | Should -Be 3
+    }
+
+    It 'writes three NON-EMPTY files and reports OK on success' {
+        $out = Invoke-WithFakeGh -Path $script:Backup -Params @{ Number = 13; Owner = 'o'; BackupDir = $script:Dir } `
+                                 -Env @{ FAKE_GH_OUT = '{"title":"My Board"}' }
+        $out | Should -Match 'Backup OK'
+        $files = @(Get-ChildItem $script:Dir -File)
+        $files.Count | Should -Be 3
+        @($files | Where-Object { $_.Length -eq 0 }).Count | Should -Be 0
+        # -RawJson, not a re-serialisation: a backup is persisted verbatim.
+        (Get-Content $files[0].FullName -Raw).Trim() | Should -Be '{"title":"My Board"}'
+    }
+}
+
+Describe 'Export-BoardSnapshot: a failed read must not become a "0 of 0 done" report' {
+    BeforeEach { $script:OutFile = Join-Path ([System.IO.Path]::GetTempPath()) ('snap' + [guid]::NewGuid().ToString('N').Substring(0, 8) + '.md') }
+    AfterEach  { Remove-Item $script:OutFile -Force -ErrorAction SilentlyContinue }
+
+    It 'writes no file and fails when gh returns 401' {
+        # The pre-fix behaviour published "_0 of 0 tracked items done._" - a document that
+        # reads like a finished board rather than a failed read.
+        $out = Invoke-WithFakeGh -Path $script:Snapshot -Params @{ Number = 13; Owner = 'o'; OutFile = $script:OutFile } `
+                                 -Env @{ FAKE_GH_EXIT = '1'; FAKE_GH_ERR = 'HTTP 401: Bad credentials' }
+        Test-Path $script:OutFile | Should -BeFalse
+        $out | Should -Not -Match 'Snapshot written'
+    }
+
+    It 'renders the board on success' {
+        $out = Invoke-WithFakeGh -Path $script:Snapshot -Params @{ Number = 13; Owner = 'o'; OutFile = $script:OutFile } `
+                                 -Env @{ FAKE_GH_OUT = '{"items":[{"title":"a thing","status":"Done","content":{"number":7,"url":"u"}}]}' }
+        Test-Path $script:OutFile | Should -BeTrue
+        $md = Get-Content $script:OutFile -Raw
+        $md | Should -Match '1 of 1 tracked items done'
+        $md | Should -Match '#7'
+    }
+}

--- a/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
@@ -68,6 +68,46 @@ Describe 'Invoke-Gh -Json' {
     }
 }
 
+Describe 'Invoke-Gh -RawJson (validate as JSON, hand back the text)' {
+    # For callers that PERSIST what gh sent (Backup-Board). Re-serialising a backup would
+    # reshape it and -Depth would truncate it, so the text has to survive - but validated,
+    # or the snapshot is worthless.
+
+    It 'returns a STRING, not a parsed object' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"title":"My Board"}'; ExitCode = 0; StdErr = '' } }
+        $r = Invoke-Gh -GhArgs @('project', 'view') -RawJson
+        $r | Should -BeOfType [string]
+        $r | Should -Be '{"title":"My Board"}'
+    }
+
+    It 'still THROWS on an unparseable body - text, but validated text' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = 'not json'; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -RawJson } | Should -Throw
+    }
+
+    It 'still THROWS on an empty body (it implies -Json)' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -RawJson } | Should -Throw -ExpectedMessage '*sin salida*'
+    }
+
+    It 'still THROWS on a non-zero exit' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = ''; ExitCode = 1; StdErr = 'HTTP 401: Bad credentials' } }
+        { Invoke-Gh -GhArgs @('project', 'view') -RawJson } | Should -Throw
+    }
+
+    It 'still honours the graphql errors[] check when combined with -Graphql' {
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"errors":[{"message":"nope"}]}'; ExitCode = 0; StdErr = '' } }
+        { Invoke-Gh -GhArgs @('api', 'graphql') -RawJson -Graphql } | Should -Throw -ExpectedMessage '*nope*'
+    }
+
+    It 'does not reshape the body it was given' {
+        # The whole point: a parsed round-trip would reorder/retype this; the text does not.
+        $body = '{"z":1,"a":{"deep":{"deeper":[1,2,3]}}}'
+        Mock Invoke-GhRaw { [pscustomobject]@{ Output = $body; ExitCode = 0; StdErr = '' } }.GetNewClosure()
+        Invoke-Gh -GhArgs @('x') -RawJson | Should -Be $body
+    }
+}
+
 Describe 'Invoke-Gh -Graphql (exit 0 WITH an errors[] body)' {
     # graphql's separate failure mode: the request succeeds, the query does not.
 


### PR DESCRIPTION
Closes #312. Part of #303.

## What

`Backup-Board.ps1` and `Export-BoardSnapshot.ps1` ran `gh` unchecked (#303). Of every victim of that
bug these two are the worst: the others misreport something you can see, while a backup misreports on
the single day you cannot afford it. Reproduced against `main` with a fake gh returning 401 —
**three 0-byte files and `Backup OK:`**; the snapshot published `_0 of 0 tracked items done._` and
`Snapshot written`.

Both now go through the shared `Invoke-Gh`, which is what makes a failed read actually fail.

## What the review changed

An adversarial review found **five real defects**, each reproduced before fixing. Two are worth
calling out because they are not "polish":

**My first fix made the snapshot worse than `main`.** `@($resp.items)` fabricated an item —
`@($null).Count` is **1**, not 0. So gh exiting 0 with valid JSON of the *wrong shape*
(`{"message":"Not Found"}`, a schema change) rendered:

```
_0 of 1 tracked items done._
| Status | Item | Issue |
|--------|------|-------|      <- ...and nothing else
```

A self-contradicting document, published with a success message, where `main` at least said `0 of 0`.
`-Json` catches a bad exit, an empty body and unparseable text — but *not* "parsed fine, wrong
shape". The property is now asserted.

**The CHANGELOG claimed credit for something already true.** It said the backup now "reads everything
BEFORE it writes anything". That was already the order on `main` (verified: last read line 24, first
write line 30). The genuinely new protection is `Invoke-Gh` throwing on the read. Claim corrected.

The other three:

| Defect | Fix |
|---|---|
| A failed `gh project copy` left three valid JSON files while telling the user the backup failed — so they re-run and pile up duplicates, or assume they have nothing | Still fails (the script promises snapshot **and** clone), but now *names* the snapshot that survived |
| `-RawJson` was sold as byte-for-byte. It is not: `& gh` returns stdout already split into lines with terminators stripped, so CRLF and the trailing newline are gone before the helper sees it | Claim narrowed — in the helper, the script and the CHANGELOG — to what is true and is still the point: **unreshaped and untruncated** |
| `Out-File -Encoding UTF8` writes a BOM on Windows PowerShell 5.1 (which this script supports) and none on pwsh 7 — the same backup differed by host | `WriteAllText` with explicit BOM-less UTF8 |

Plus: the file check asserted `Length -eq 0`, which `-RawJson` had already made unreachable — theatre.
It now reads each file back and **parses** it, which catches the failure that is reachable: the write
itself going wrong.

## Validation

785 tests pass (775 before the review round; 715 on main).

Restoring each bug turns the matching test red:

```
PRE-FIX Backup-Board (unchecked gh)   -> RED: 3
phantom-item bug restored             -> RED: 1  (wrong-shape JSON)
```

**The tests use a fake `gh.cmd` first on PATH, not a mock.** These scripts are top-level commands that
cannot be dot-sourced, and stubbing `Invoke-GhRaw` from outside does *not* work — the script
dot-sources `Invoke-Gh.ps1` into its own scope afterwards and shadows the stub. The first draft did
exactly that and **silently called the real API**. The fake binary is also more faithful: the real
script, real `Invoke-Gh`, real `Invoke-GhRaw` and its real `2>$errFile` redirection all run.

Two traps hit while writing them, both fixed and both worth knowing:

- Quoting the parameter *names* made PowerShell bind `-Number` as a positional value, so the script
  died before gh was reached — and every "must not write a file" test passed **for the wrong reason**.
- The Windows guard was named `$isWindows`, which collides (case-insensitively) with PowerShell 7's
  read-only automatic `$IsWindows` and **silently skipped the entire file** (`TOTAL: 0`).

`-RawJson` also shipped in #311 with no unit tests; 6 added.

## Reviewer note

No external reviewer was available (Copilot out of quota, Codex timed out, Gemini CLI auth is dead),
so this went through an adversarial subagent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
