### PR TITLE
fix(board): paginated reads pass the cursor as a GraphQL variable, not quoted into the query (#329)

### DIFF
--- a/plugins/agentic-board/scripts/Board-Changelog.ps1
+++ b/plugins/agentic-board/scripts/Board-Changelog.ps1
@@ -129,13 +129,15 @@ if (-not $Version) {
 #    on boards >100 items, so the changelog silently missed recent entries) ───────
 $nodes = @(); $cursor = $null
 do {
-    $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+    # Cursor as a GraphQL variable (-f cursor=), never interpolated as after: "$cursor": embedded
+    # double-quotes in a native gh.exe arg are not escaped, so gh saw the base64 cursor unquoted and
+    # its `==` padding parsed as bare tokens -> parse error on every board >100 items (#329).
     $q = @"
-query(`$owner:String!, `$num:Int!) {
+query(`$owner:String!, `$num:Int!, `$cursor:String) {
   user(login:`$owner) {
     projectV2(number:`$num) {
       id
-      items(first:100 $after) {
+      items(first:100, after:`$cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           fieldValues(first:20) {
@@ -159,8 +161,9 @@ query(`$owner:String!, `$num:Int!) {
   }
 }
 "@
-    $data = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q",'-F',"owner=$Owner",'-F',"num=$ProjectNum") `
-                      -What "leer los items del board #$ProjectNum de $Owner" -Graphql
+    $ghArgs = @('api','graphql','-f',"query=$q",'-F',"owner=$Owner",'-F',"num=$ProjectNum")
+    if ($cursor) { $ghArgs += @('-f',"cursor=$cursor") }
+    $data = Invoke-Gh -GhArgs $ghArgs -What "leer los items del board #$ProjectNum de $Owner" -Graphql
     $pv = $data.data.user.projectV2
     if (-not $pv.id) {
         throw "No pude resolver el board #$ProjectNum de $Owner (revisa cuenta / scope 'project')."

--- a/plugins/agentic-board/scripts/Board-Fill.ps1
+++ b/plugins/agentic-board/scripts/Board-Fill.ps1
@@ -177,12 +177,14 @@ function Get-AllPages {
 function Get-BoardItems($projId) {
     return Get-AllPages {
         param($cursor)
-        $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+        # Cursor as a GraphQL variable (-f cursor=), not interpolated as after: "$cursor": embedded
+        # double-quotes in a native gh.exe arg are not escaped, so gh saw the base64 cursor unquoted
+        # and its `==` padding parsed as bare tokens -> parse error on every board >100 items (#329).
         $q = @"
-query(`$proj:ID!) {
+query(`$proj:ID!, `$cursor:String) {
   node(id:`$proj) {
     ... on ProjectV2 {
-      items(first:100 $after) {
+      items(first:100, after:`$cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -217,8 +219,9 @@ query(`$proj:ID!) {
   }
 }
 "@
-        $resp  = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q",'-F',"proj=$projId") `
-                           -What "leer los items del board" -Graphql
+        $ghArgs = @('api','graphql','-f',"query=$q",'-F',"proj=$projId")
+        if ($cursor) { $ghArgs += @('-f',"cursor=$cursor") }
+        $resp  = Invoke-Gh -GhArgs $ghArgs -What "leer los items del board" -Graphql
         $items = $resp.data.node.items
         return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
     }

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -468,12 +468,16 @@ function Get-BoardItem([string]$projectId, [int]$issueNum) {
     foreach ($attempt in 1..2) {
         $nodes = Get-AllPages {
             param($cursor)
-            $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+            # The cursor rides as a GraphQL VARIABLE (-f cursor=), NOT interpolated into the query
+            # as after: "$cursor". Embedded double-quotes in a native gh.exe argument are not escaped
+            # by PowerShell, so gh saw the base64 cursor unquoted and its `==` padding parsed as bare
+            # tokens -> "Expected NAME, actual EQUALS" on every board >100 items (#329). `$cursor is
+            # backtick-escaped so the query carries the literal variable ref, not the value.
             $q = @"
-query(`$proj:ID!) {
+query(`$proj:ID!, `$cursor:String) {
   node(id:`$proj) {
     ... on ProjectV2 {
-      items(first:100 $after) {
+      items(first:100, after:`$cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -501,8 +505,9 @@ query(`$proj:ID!) {
 "@
             # -Graphql + retries: a transient failure retries, a hard failure (or errors[]) THROWS
             # instead of silently truncating pagination -> a target issue falsely "not on board" (#314).
-            $resp  = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q",'-F',"proj=$projectId") `
-                               -What "leer los items del board" -Graphql -Retries 2
+            $ghArgs = @('api','graphql','-f',"query=$q",'-F',"proj=$projectId")
+            if ($cursor) { $ghArgs += @('-f',"cursor=$cursor") }
+            $resp  = Invoke-Gh -GhArgs $ghArgs -What "leer los items del board" -Graphql -Retries 2
             $items = $resp.data.node.items
             return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
         }

--- a/plugins/agentic-board/scripts/Fleet-Plan.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Plan.ps1
@@ -163,12 +163,14 @@ function Get-PendingBoardIssues {
     param([string]$Owner, [int]$ProjectNum)
     $nodes = Get-AllPages {
         param($cursor)
-        $after = if ($cursor) { 'after: "' + $cursor + '"' } else { '' }
+        # Cursor as a GraphQL variable (-f cursor=), not interpolated as after: "$cursor": embedded
+        # double-quotes in a native gh.exe arg are not escaped, so gh saw the base64 cursor unquoted
+        # and its `==` padding parsed as bare tokens -> parse error on every board >100 items (#329).
         $q = @"
-query(`$o:String!, `$n:Int!) {
+query(`$o:String!, `$n:Int!, `$cursor:String) {
   user(login:`$o) {
     projectV2(number:`$n) {
-      items(first:100 $after) {
+      items(first:100, after:`$cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           fieldValues(first:20) {
@@ -188,8 +190,9 @@ query(`$o:String!, `$n:Int!) {
   }
 }
 "@
-        $resp  = Invoke-Gh -GhArgs @('api','graphql','-f',"query=$q",'-F',"o=$Owner",'-F',"n=$ProjectNum") `
-                           -What "leer los items del board #$ProjectNum" -Graphql
+        $ghArgs = @('api','graphql','-f',"query=$q",'-F',"o=$Owner",'-F',"n=$ProjectNum")
+        if ($cursor) { $ghArgs += @('-f',"cursor=$cursor") }
+        $resp  = Invoke-Gh -GhArgs $ghArgs -What "leer los items del board #$ProjectNum" -Graphql
         $items = $resp.data.user.projectV2.items
         return @{ nodes = $items.nodes; hasNext = $items.pageInfo.hasNextPage; endCursor = $items.pageInfo.endCursor }
     }

--- a/plugins/agentic-board/tests/Board-Fill.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Fill.Tests.ps1
@@ -45,6 +45,31 @@ Describe 'Get-BoardItems fails closed on a gh failure (#313, part of #303)' {
         Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"i1"},{"id":"i2"}]}}}}'; ExitCode = 0; StdErr = '' } }
         @(Get-BoardItems 'PVT_x').Count | Should -Be 2
     }
+    It 'passes the page-2 cursor as a -f variable, never spliced into the query as after: "..." (#329)' {
+        # A board >100 items needs a 2nd page. Interpolating after: "$cursor" put embedded quotes
+        # into a native gh.exe arg, which PowerShell drops, so gh saw the base64 cursor unquoted
+        # and its `==` padding broke the query. The cursor now rides as a GraphQL variable instead.
+        # Page chosen by CALL COUNT, not arg content, so a regression that still paginates
+        # terminates and fails on the assertions rather than looping forever.
+        $script:pgCalls = @(); $script:pgN = 0
+        Mock Invoke-GhRaw {
+            $script:pgCalls += ,@($GhArgs); $script:pgN++
+            if ($script:pgN -ge 2) {
+                [pscustomobject]@{ Output = '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"i2"}]}}}}'; ExitCode = 0; StdErr = '' }
+            } else {
+                [pscustomobject]@{ Output = '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":true,"endCursor":"CUR=="},"nodes":[{"id":"i1"}]}}}}'; ExitCode = 0; StdErr = '' }
+            }
+        }
+        $nodes = @(Get-BoardItems 'PVT_x')
+        $nodes.Count         | Should -Be 2             # both pages accumulated
+        $script:pgCalls.Count | Should -Be 2
+        (@($script:pgCalls[1]) -contains 'cursor=CUR==') | Should -BeTrue
+        foreach ($c in $script:pgCalls) {
+            $qArg = @($c) | Where-Object { $_ -like 'query=*' }
+            $qArg | Should -Not -Match 'after:\s*"'
+            $qArg | Should -Match 'after:\$cursor'
+        }
+    }
 }
 
 Describe 'Convert-DraftToIssue fails closed on a graphql errors[] body (#315)' {

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -59,6 +59,33 @@ Describe 'Board-Work graphql reads fail closed (#314, part of #303)' {
             Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":null,"errors":[{"message":"boom"}]}'; ExitCode = 0; StdErr = '' } }
             { Get-BoardItem 'PVT_x' 5 } | Should -Throw
         }
+        It 'passes the page-2 cursor as a -f variable, never spliced into the query as after: "..." (#329)' {
+            # A board >100 items needs a 2nd page. The cursor must ride as a GraphQL variable
+            # (-f cursor=), NOT be interpolated into the query text as after: "$cursor": PowerShell
+            # does not escape embedded double-quotes in a native gh.exe argument, so gh saw the
+            # base64 cursor UNQUOTED and its `==` padding parsed as bare tokens -> the board-wide
+            # "Expected NAME, actual EQUALS" that broke every read once the board crossed 100 items.
+            # Page is chosen by CALL COUNT, not arg content, so a regression that still paginates
+            # (via query interpolation) terminates and fails on the assertions instead of looping.
+            $script:pgCalls = @(); $script:pgN = 0
+            Mock Invoke-GhRaw {
+                $script:pgCalls += ,@($GhArgs); $script:pgN++
+                if ($script:pgN -ge 2) {
+                    [pscustomobject]@{ Output = '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I2","content":{"__typename":"Issue","number":5}}]}}}}'; ExitCode = 0; StdErr = '' }
+                } else {
+                    [pscustomobject]@{ Output = '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":true,"endCursor":"CUR=="},"nodes":[{"id":"I1","content":{"__typename":"Issue","number":99}}]}}}}'; ExitCode = 0; StdErr = '' }
+                }
+            }
+            $item = Get-BoardItem 'PVT_x' 5
+            $item.content.number  | Should -Be 5            # found on the 2nd page
+            $script:pgCalls.Count | Should -Be 2            # both pages fetched
+            (@($script:pgCalls[1]) -contains 'cursor=CUR==') | Should -BeTrue   # cursor as a -f value
+            foreach ($c in $script:pgCalls) {
+                $qArg = @($c) | Where-Object { $_ -like 'query=*' }
+                $qArg | Should -Not -Match 'after:\s*"'     # the #329 anti-pattern (embedded quotes)
+                $qArg | Should -Match 'after:\$cursor'      # cursor referenced as a variable
+            }
+        }
     }
 
     Context 'Resolve-BoardStatus (board id + Status field that every start writes against)' {

--- a/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
@@ -34,6 +34,31 @@ Describe 'Get-PendingBoardIssues fails closed on the board read (#316, part of #
         Mock Invoke-GhRaw { [pscustomobject]@{ Output = '{"data":{"user":{"projectV2":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"fieldValues":{"nodes":[]},"content":{"__typename":"Issue","number":9,"state":"CLOSED","title":"done","repository":{"nameWithOwner":"o/r"},"labels":{"nodes":[]}}}]}}}}}'; ExitCode = 0; StdErr = '' } }
         @(Get-PendingBoardIssues 'owner' 13).Count | Should -Be 0
     }
+    It 'passes the page-2 cursor as a -f variable, never spliced into the query as after: "..." (#329)' {
+        # A board >100 items needs a 2nd page. Interpolating after: "$cursor" put embedded quotes into
+        # a native gh.exe arg, which PowerShell drops, so gh saw the base64 cursor unquoted and its
+        # `==` broke the query. Both pages use CLOSED issues so the blocked_by REST path never runs.
+        # Page chosen by CALL COUNT, not arg content, so a regression that still paginates
+        # terminates and fails on the assertions rather than looping forever.
+        $script:pgCalls = @(); $script:pgN = 0
+        Mock Invoke-GhRaw {
+            $script:pgCalls += ,@($GhArgs); $script:pgN++
+            $closed = '{"fieldValues":{"nodes":[]},"content":{"__typename":"Issue","number":9,"state":"CLOSED","title":"done","repository":{"nameWithOwner":"o/r"},"labels":{"nodes":[]}}}'
+            if ($script:pgN -ge 2) {
+                [pscustomobject]@{ Output = "{`"data`":{`"user`":{`"projectV2`":{`"items`":{`"pageInfo`":{`"hasNextPage`":false,`"endCursor`":null},`"nodes`":[$closed]}}}}}"; ExitCode = 0; StdErr = '' }
+            } else {
+                [pscustomobject]@{ Output = "{`"data`":{`"user`":{`"projectV2`":{`"items`":{`"pageInfo`":{`"hasNextPage`":true,`"endCursor`":`"CUR==`"},`"nodes`":[$closed]}}}}}"; ExitCode = 0; StdErr = '' }
+            }
+        }
+        $null = Get-PendingBoardIssues 'owner' 13
+        $script:pgCalls.Count | Should -Be 2
+        (@($script:pgCalls[1]) -contains 'cursor=CUR==') | Should -BeTrue
+        foreach ($c in $script:pgCalls) {
+            $qArg = @($c) | Where-Object { $_ -like 'query=*' }
+            $qArg | Should -Not -Match 'after:\s*"'
+            $qArg | Should -Match 'after:\$cursor'
+        }
+    }
 }
 
 Describe 'Select-CliForIssue (capability routing with availability fallback)' {

--- a/plugins/agentic-board/tests/Pagination-CursorQuoting.Tests.ps1
+++ b/plugins/agentic-board/tests/Pagination-CursorQuoting.Tests.ps1
@@ -1,0 +1,44 @@
+#Requires -Modules Pester
+<#  Source-level regression lock for #329 across ALL paginated board reads.
+
+    Every Projects-v2 read that paginates once built its page-2 cursor argument by splicing it
+    into the query text as  after: "$cursor"  — embedded double-quotes and all. PowerShell does
+    not escape embedded double-quotes in a native gh.exe argument, so gh received the base64
+    cursor UNQUOTED and its `==` padding parsed as bare GraphQL tokens ("Expected NAME, actual
+    EQUALS"). Latent until the board crossed 100 items and a second page (hence a cursor) existed;
+    then it broke -Start / -ToReview / -Parallel / -Fleet, the changelog, the gap-filler and the
+    fleet planner all at once.
+
+    The fix is uniform: declare `$cursor:String`, reference `after:$cursor`, and pass the value as
+    a GraphQL variable via `-f cursor=<value>`. Three of the four sites are exercised behaviourally
+    at the Invoke-GhRaw seam (Board-Work Get-BoardItem, Board-Fill Get-BoardItems, Fleet-Plan
+    Get-PendingBoardIssues). The fourth — Board-Changelog's top-level read loop — is not function-
+    extracted, so this source scan is its regression coverage, and a uniform backstop for the rest.
+
+    Full-line `#` comments are stripped before matching: the notes above and beside each fix
+    deliberately name the anti-pattern to warn future editors, and must not trip their own guard. #>
+
+Describe 'Paginated board reads thread the cursor as a GraphQL variable, never quoted into the query (#329)' {
+    # -ForEach is evaluated at Discovery, so the file list is an inline literal (a $script: var set
+    # in BeforeAll would still be $null here).
+    $paginated = 'Board-Work.ps1', 'Board-Changelog.ps1', 'Board-Fill.ps1', 'Fleet-Plan.ps1'
+
+    BeforeAll {
+        function Get-CodeOnly([string]$fileName) {
+            $path = Join-Path $PSScriptRoot '..' 'scripts' $fileName | Resolve-Path
+            # Drop whole-line comments so we assert on CODE, not the explanatory prose.
+            (Get-Content $path) | Where-Object { $_ -notmatch '^\s*#' } | Out-String
+        }
+    }
+
+    It '<_> never splices the cursor into the query as an after:"..." clause' -ForEach $paginated {
+        $code = Get-CodeOnly $_
+        # The exact #329 hazard: a double-quote immediately after the `after:` GraphQL argument.
+        $code | Should -Not -Match 'after:\s*"'
+    }
+
+    It '<_> threads the pagination cursor as a -f variable value' -ForEach $paginated {
+        $code = Get-CodeOnly $_
+        $code | Should -Match 'cursor=\$cursor'
+    }
+}


### PR DESCRIPTION
Closes #329

## The bug
Every paginated Projects-v2 read built its page-2 cursor argument by splicing it into the query text as `after: "$cursor"`. PowerShell does not escape the embedded double-quotes in a native `gh.exe` argument, so gh received the base64 cursor **unquoted** and its `==` padding parsed as bare GraphQL tokens → `gh: Expected NAME, actual EQUALS`. Latent until the board crossed 100 items (a second page, hence a cursor exists); at 182 items it broke `-Start`, `-ToReview`, `-Parallel`, `-Fleet`, the changelog, the gap-filler and the fleet planner all at once.

## The fix (uniform, 4 sites)
Board-Work `Get-BoardItem`, Board-Changelog, Board-Fill `Get-BoardItems`, Fleet-Plan `Get-PendingBoardIssues`: declare a nullable `$cursor:String`, reference `after:$cursor` (backtick-escaped so the value is never re-interpolated), and pass it as `-f cursor=<value>` only when a cursor exists (page 1 omits it → GraphQL null → first page). No embedded double-quotes reach the native `gh.exe` invocation. Verified live against the 182-item board: page 1 = 100 nodes, page 2 = 82, no error.

## Tests
- Page-2 cursor tests at the `Invoke-GhRaw` seam for the three extractable functions (counter-based paging, so a still-paginating regression fails on assertions instead of hanging).
- A source-invariant scan over all four scripts — the only coverage for Board-Changelog's un-extracted read loop, and a uniform backstop for the rest.
- Each is **mutation-verified**: reverting a site to the embedded-quote form turns its tests red. Full suite **809 → 820**, all green.

Adversarial review (opus subagent): no blockers/majors/minors.