### PR TITLE
feat(release): tag + GitHub Release when plugin.json version changes on main (#322)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+# Release L1 (#322, part of #321): the tool tags nobody's repos but its own — it installs rulesets,
+# templates and add-to-project CI into OTHER repos while its own repo had zero tags and zero
+# releases, so installs (relative marketplace `source`, no pinned ref) track main HEAD and two users
+# can run different code under one version string (#295). This closes the provenance half: when
+# plugin.json's version changes on main, cut a git tag v<version> and a GitHub Release whose body is
+# that version's CHANGELOG block. CI-driven, not a documented manual step — "tagging stays manual"
+# scored 0 tags for months; a backstop that fires on the change itself does not degrade (#305).
+#
+# Layer 2 (#323 — pin the marketplace at a release ref so installs stop following HEAD) is separate.
+
+on:
+  push:
+    branches: [main]
+    # Only a plugin.json change can bump the version. The release-existence check below makes the
+    # job idempotent, so a non-version edit (e.g. description) to this file is a harmless no-op.
+    paths:
+      - 'plugins/agentic-board/.claude-plugin/plugin.json'
+  workflow_dispatch:   # manual re-run / backfill
+
+permissions:
+  contents: write   # push the tag + create the release
+
+# Serialise releases: a rapid double-push, or a push racing a manual dispatch, must not both reach
+# `gh release create` and turn one run red on "release already exists".
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags, and `git log -- plugin.json` needs the history
+
+      - name: Read version and decide whether to release
+        id: v
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $pjPath = 'plugins/agentic-board/.claude-plugin/plugin.json'
+          $ver = (Get-Content $pjPath -Raw | ConvertFrom-Json).version
+          if (-not $ver) { throw 'plugin.json has no version.' }
+          $tag = "v$ver"
+          "version=$ver" | Out-File $env:GITHUB_OUTPUT -Append
+          "tag=$tag"     | Out-File $env:GITHUB_OUTPUT -Append
+
+          # Tag the commit that actually SET this version (the last change to plugin.json), not the
+          # push tip: a batched push, or a workflow_dispatch long after the bump, would otherwise
+          # tag the wrong commit and defeat the point (provenance). Falls back to the event sha.
+          $sha = (git log -1 --format=%H -- $pjPath 2>$null | Out-String).Trim()
+          if (-not $sha) { $sha = $env:GITHUB_SHA }
+          "sha=$sha" | Out-File $env:GITHUB_OUTPUT -Append
+
+          # Idempotency keys on the RELEASE, not the tag. A tag can exist without a Release — a
+          # human backfilling with `git tag`/`git push --tags` (exactly the #321 scenario), or a
+          # half-failed prior run — and that Release must still get created; an existing Release must
+          # never be recreated. GitHub's pwsh runs with $ErrorActionPreference='stop', so a missing
+          # release (gh exit 1) would THROW; the try/catch + $LASTEXITCODE reads it as "absent".
+          $exists = $false
+          try {
+            gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
+            $exists = ($LASTEXITCODE -eq 0)
+          } catch { $exists = $false }
+          if ($exists) {
+            "release=false" | Out-File $env:GITHUB_OUTPUT -Append
+            Write-Host "Release $tag already exists — nothing to do."
+          } else {
+            "release=true"  | Out-File $env:GITHUB_OUTPUT -Append
+            Write-Host "No release $tag yet — will create it at $sha."
+          }
+
+      - name: Extract release notes from the CHANGELOG
+        if: steps.v.outputs.release == 'true'
+        shell: pwsh
+        # The version is a controlled semver string, but it still travels as an env var (never
+        # spliced into the script via ${{ }}) to match this repo's injection-safe convention.
+        env:
+          VER: ${{ steps.v.outputs.version }}
+        run: |
+          ./scripts/Get-ReleaseNotes.ps1 -Version "$env:VER" -ChangelogPath CHANGELOG.md > release-notes.md
+          Write-Host "----- release notes -----"
+          Get-Content release-notes.md
+
+      - name: Create the tag and GitHub Release
+        if: steps.v.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.v.outputs.tag }}
+          SHA: ${{ steps.v.outputs.sha }}
+        run: |
+          # gh release create makes the tag at $SHA when it does not exist (--target is ignored if
+          # the tag already exists), so the tag and the release are created together — and when a
+          # tag was pre-created by hand, this still attaches the missing Release to it.
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            --target "$SHA"
+          echo "::notice::Released $TAG at $SHA"

--- a/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
@@ -78,7 +78,10 @@ Describe 'Get-ChangelogSection (release-notes extraction, #322)' {
         $notes | Should -Not -Match '\s$'
     }
     It 'handles CRLF line endings' {
-        $crlf = $script:Sample -replace "`n", "`r`n"
+        # Normalise to LF first, THEN to CRLF, so the sample is genuinely \r\n regardless of how
+        # this test file was checked out. A naive -replace "`n","`r`n" would double-convert an
+        # already-CRLF checkout (Windows CI) into \r\r\n — a malformed ending real files never have.
+        $crlf = ($script:Sample -replace "`r`n", "`n") -replace "`n", "`r`n"
         $notes = Get-ChangelogSection -Text $crlf -Version '0.20.0'
         $notes | Should -Match 'Older thing \(#3\)'
         $notes | Should -Not -Match 'Unreleased'

--- a/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
@@ -1,0 +1,86 @@
+#Requires -Modules Pester
+<#  Pester tests for scripts/Get-ReleaseNotes.ps1 (release L1, #322).
+
+    Get-ReleaseNotes.ps1 reads CHANGELOG.md and prints one version's block for the release workflow
+    to feed `gh release create --notes-file`. The extraction is a pure function (Get-ChangelogSection)
+    behind a dot-source guard ($env:ABIOS_RELEASENOTES_DOTSOURCE), so these tests exercise it with no
+    files and no gh. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' '..' '..' 'scripts' 'Get-ReleaseNotes.ps1' | Resolve-Path
+    $env:ABIOS_RELEASENOTES_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_RELEASENOTES_DOTSOURCE = ''
+
+    # A sample shaped exactly like this repo's CHANGELOG, including the stray empty [Unreleased]
+    # block (#324) between two releases, and an older 0.2.0 to catch a 0.2.0-vs-0.21.0 mismatch.
+    $script:Sample = @"
+# Changelog
+
+## [0.21.0] - 2026-07-17
+### Added
+- Thing A (#1)
+### Fixed
+- Thing B (#2)
+
+## [0.20.0] - 2026-07-16
+### Added
+- Older thing (#3)
+
+## [Unreleased]
+
+## [0.2.0] - 2026-01-01
+### Added
+- Ancient thing (#4)
+"@
+}
+
+Describe 'Get-ChangelogSection (release-notes extraction, #322)' {
+    It 'returns the block body for a version, without the header line' {
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.21.0'
+        $notes | Should -Match '### Added'
+        $notes | Should -Match 'Thing A \(#1\)'
+        $notes | Should -Match '### Fixed'
+        $notes | Should -Match 'Thing B \(#2\)'
+        $notes | Should -Not -Match '\[0\.21\.0\]'      # header line dropped (title carries it)
+    }
+    It 'stops at the next version header — no bleed into older releases' {
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.21.0'
+        $notes | Should -Not -Match '0\.20\.0'
+        $notes | Should -Not -Match 'Older thing'
+        $notes | Should -Not -Match '(?m)^\#\# \['              # never contains another header
+    }
+    It 'stops before an [Unreleased] header too' {
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.20.0'
+        $notes | Should -Match 'Older thing \(#3\)'
+        $notes | Should -Not -Match 'Unreleased'
+        $notes | Should -Not -Match 'Ancient'
+    }
+    It 'extracts the LAST block, running to end-of-file' {
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.2.0'
+        $notes | Should -Match 'Ancient thing \(#4\)'
+    }
+    It 'does not confuse 0.2.0 with 0.21.0 (escaped dots + closing-bracket boundary)' {
+        # 0.2.0 must resolve to the ancient block, NOT partially match inside [0.21.0].
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.2.0'
+        $notes | Should -Match 'Ancient thing \(#4\)'
+        $notes | Should -Not -Match 'Thing A'
+    }
+    It 'returns $null for a version that has no section' {
+        Get-ChangelogSection -Text $script:Sample -Version '9.9.9' | Should -BeNullOrEmpty
+    }
+    It 'returns $null for a header with an empty body (e.g. [Unreleased])' {
+        Get-ChangelogSection -Text $script:Sample -Version 'Unreleased' | Should -BeNullOrEmpty
+    }
+    It 'trims surrounding whitespace' {
+        $notes = Get-ChangelogSection -Text $script:Sample -Version '0.21.0'
+        $notes | Should -Not -Match '^\s'
+        $notes | Should -Not -Match '\s$'
+    }
+    It 'handles CRLF line endings' {
+        $crlf = $script:Sample -replace "`n", "`r`n"
+        $notes = Get-ChangelogSection -Text $crlf -Version '0.20.0'
+        $notes | Should -Match 'Older thing \(#3\)'
+        $notes | Should -Not -Match 'Unreleased'
+    }
+}

--- a/scripts/Get-ReleaseNotes.ps1
+++ b/scripts/Get-ReleaseNotes.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Extract one version's notes from a Keep-a-Changelog CHANGELOG (release L1, #322).
+
+.DESCRIPTION
+    The release workflow (.github/workflows/release.yml) turns a version bump on main into a
+    git tag + a GitHub Release. The release body is that version's block from CHANGELOG.md — the
+    same text a human reads under `## [X.Y.Z] - DATE`, minus the header line itself (the release
+    title already carries the version).
+
+    The parser is a pure function (Get-ChangelogSection) so it is unit-tested with no files and no
+    gh. The script body reads CHANGELOG.md, extracts the requested version, and prints the notes to
+    stdout for the workflow to capture with `--notes-file`. A version with no section is NOT fatal:
+    the tag is the point (provenance / rollback), so it emits a GitHub Actions ::warning:: and falls
+    back to a pointer body rather than blocking the release.
+
+.PARAMETER Version
+    X.Y.Z to extract. Default: the version in plugins/agentic-board/.claude-plugin/plugin.json.
+
+.PARAMETER ChangelogPath
+    Path to the changelog. Default: CHANGELOG.md in the cwd.
+
+.EXAMPLE
+    ./scripts/Get-ReleaseNotes.ps1 -Version 0.21.0
+    ./scripts/Get-ReleaseNotes.ps1 -Version 0.21.0 -ChangelogPath CHANGELOG.md > notes.md
+#>
+[CmdletBinding()]
+param(
+    [string]$Version       = '',
+    [string]$ChangelogPath = 'CHANGELOG.md'
+)
+
+# ------------------------------------------------------------------ pure helper
+# Return the notes for exactly $Version: the text between that version's header
+# (## [X.Y.Z] ...) and the next `## [` header (any version, including
+# [Unreleased]) or end-of-file, trimmed, with the header line itself dropped.
+# Returns $null when the version has no section. Pure -> unit-testable.
+function Get-ChangelogSection {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Version
+    )
+    # Match `## [<version>]` with any trailing text on the line (e.g. ` - 2026-07-17`), then
+    # capture everything up to the next `## [` header or the end of the document. The version is
+    # regex-escaped so its dots are literal and 0.2.0 can never match 0.21.0.
+    $rx = '(?ms)^\#\#[ \t]+\[' + [regex]::Escape($Version) + '\][^\r\n]*\r?\n(.*?)(?=^\#\#[ \t]+\[|\z)'
+    $m  = [regex]::Match($Text, $rx)
+    if (-not $m.Success) { return $null }
+    $body = $m.Groups[1].Value.Trim()
+    if (-not $body) { return $null }
+    return $body
+}
+
+# Dot-source guard: with $env:ABIOS_RELEASENOTES_DOTSOURCE set, return after defining the pure
+# helper WITHOUT touching disk — lets the tests exercise Get-ChangelogSection directly.
+if ($env:ABIOS_RELEASENOTES_DOTSOURCE) { return }
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Version) {
+    # Single source of truth for the version (same file the workflow reads). Explicit path, not a
+    # recursive search: that search picks up a stale gitignored worktree copy of plugin.json (#319).
+    $pluginJson = Join-Path $PSScriptRoot '..' 'plugins' 'agentic-board' '.claude-plugin' 'plugin.json'
+    if (-not (Test-Path $pluginJson)) { throw "No encuentro plugin.json en $pluginJson (pasa -Version)." }
+    $Version = ([System.IO.File]::ReadAllText((Resolve-Path $pluginJson)) | ConvertFrom-Json).version
+    if (-not $Version) { throw "plugin.json no tiene 'version' (pasa -Version)." }
+}
+
+if (-not (Test-Path $ChangelogPath)) { throw "No existe $ChangelogPath." }
+$text  = [System.IO.File]::ReadAllText((Resolve-Path $ChangelogPath))
+$notes = Get-ChangelogSection -Text $text -Version $Version
+
+if (-not $notes) {
+    # Not fatal: the tag/release is worth creating for provenance even without notes. Surface the
+    # gap as an Actions warning and fall back to a pointer body.
+    Write-Warning "CHANGELOG.md has no section for [$Version] — releasing with a pointer body."
+    Write-Host "::warning::No CHANGELOG.md section for [$Version]; release notes fall back to a pointer."
+    $notes = "See [CHANGELOG.md](CHANGELOG.md) for the changes in this release."
+}
+
+# stdout = the notes, for `gh release create --notes-file`.
+Write-Output $notes


### PR DESCRIPTION
Closes #322 (release L1 of #321).

## What
When `plugins/agentic-board/.claude-plugin/plugin.json`'s `version` changes on `main` (or on manual dispatch), CI cuts a git tag `v<version>` and a GitHub Release whose body is that version's CHANGELOG block. This closes the **provenance** half of #321 — the tool tags every repo but its own, and with a relative marketplace `source` (no pinned ref) installs track main HEAD, so two users can run different code under one version string (#295). Layer 2 (#323, pin the marketplace at a release ref) is separate.

## Design (hardened after adversarial review)
- **Idempotency keys on the RELEASE, not the tag** (`gh release view`): a tag created by hand — exactly the #321 backfill path — or a half-failed run still gets its Release; an existing Release is never recreated. `gh release create` attaches to a pre-existing tag (`--target` ignored), so both paths converge.
- **Tags the commit that set the version** (`git log -1 -- plugin.json`), not the push tip, so a batched push or a delayed dispatch tags the right commit (verified: resolves to the real `chore(release)` commit, not HEAD).
- **`concurrency: group release, cancel-in-progress: false`** serialises runs so a double-push never turns one red on "release already exists".
- `contents: write` only; the version travels as an env var, never a `${{ }}` splice.

## `scripts/Get-ReleaseNotes.ps1`
Pure `Get-ChangelogSection` extracts one version's block — escaped dots (`0.2.0` != `0.21.0`), stops at the next `## [` (incl. `[Unreleased]`), CRLF-safe, last-block-to-EOF. A missing section is **not fatal** (the tag is the point): emits a `::warning::` and falls back to a pointer body. `Write-Host`/`Write-Warning` go to non-stdout streams, so `> notes.md` stays clean (verified).

## Tests
9 pure-function cases for the extractor; the key workflow snippets (release-existence check under Actions' pwsh `stop` defaults, and the `git log` target) validated live. Full suite **820 → 829**.

Adversarial review (opus subagent, two rounds): a MAJOR (idempotency on the tag) + two minors found and fixed; final verdict clean.