### PR TITLE
fix(release): clear $LASTEXITCODE after the release-existence probe (#339)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
             gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
             $exists = ($LASTEXITCODE -eq 0)
           } catch { $exists = $false }
+          # A missing Release makes `gh release view` exit 1. GitHub's pwsh shell appends
+          # `exit $LASTEXITCODE` to every step, so that 1 would fail this step even though the probe
+          # is doing its job. Clear it — the probe's exit code is captured in $exists already (#339).
+          $global:LASTEXITCODE = 0
           if ($exists) {
             "release=false" | Out-File $env:GITHUB_OUTPUT -Append
             Write-Host "Release $tag already exists — nothing to do."


### PR DESCRIPTION
Closes #339 (follow-up to #322).

The idempotency probe `gh release view $tag` exits 1 when the Release is absent — the intended path — leaving `$LASTEXITCODE=1`. GitHub Actions' `shell: pwsh` appends `exit $LASTEXITCODE` to every step, so the decision step failed with exit 1 even though it correctly logged `No release v0.21.0 yet — will create it at 74cd539…`. The first `workflow_dispatch` failed exactly here, **before** the create step, so no tag/Release was created (no half-state).

Fix: reset `$global:LASTEXITCODE = 0` after the probe (`$exists` already carries the result). Verified under a local replica of GitHub's pwsh wrapper (`$ErrorActionPreference='stop'` + trailing `exit $LASTEXITCODE`): the step now exits 0 with `release=true`, tag `v0.21.0`, target = the real bump commit.