### PR TITLE
feat(release): pin the marketplace at the release channel (#323)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,22 @@
   "plugins": [
     {
       "name": "agentic-board",
-      "source": "./plugins/agentic-board",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CSalcedoDataBI/agentic-board",
+        "path": "plugins/agentic-board",
+        "ref": "release"
+      },
       "description": "Run coding agents off your real GitHub Projects board — a quota-aware, review-gated coordinator, not another local Kanban. Cross-account board & issue governance, parallel /board work sessions (one worktree + agent per issue), a multi-CLI fleet, session handoff (save/resume context), a skills-ops lifecycle module, a sanitized improvement-feedback flow, and a private-content guard. BI GitOps is a future module."
     },
     {
       "name": "agentic-bi-ops",
-      "source": "./plugins/agentic-board",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CSalcedoDataBI/agentic-board",
+        "path": "plugins/agentic-board",
+        "ref": "release"
+      },
       "description": "DEPRECATED alias — renamed to agentic-board. Points to the same plugin so existing `agentic-bi-ops` installs keep updating. Install the new name: agentic-board."
     }
   ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,17 @@ jobs:
             --notes-file release-notes.md \
             --target "$SHA"
           echo "::notice::Released $TAG at $SHA"
+
+      - name: Advance the release channel to the released commit
+        if: steps.v.outputs.release == 'true'
+        env:
+          SHA: ${{ steps.v.outputs.sha }}
+        run: |
+          # Installs pin the plugin at ref `release` (marketplace.json git-subdir source, #323), so
+          # that branch — NOT main HEAD — is what a fresh install or `plugin update` fetches. It must
+          # advance to each released commit; this push is the ONLY thing that moves pinned installs.
+          # A normal push creates the branch (first release) or fast-forwards it (the released commit
+          # is a descendant of the prior release). A non-fast-forward is rejected loudly rather than
+          # rewriting the channel. Pushes made with GITHUB_TOKEN do not retrigger workflows.
+          git push origin "$SHA:refs/heads/release"
+          echo "::notice::release channel -> $SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,28 @@ plugins/agentic-board/scripts/New-Release.ps1 -Bump patch     # bump plugin.json
 It bumps the version (targeted, so the rest of `plugin.json` is byte-preserved), folds the board's
 Done issues into `CHANGELOG.md` under the new version (via `Board-Changelog.ps1`), and validates
 that `marketplace.json` hasn't drifted from `plugin.json` (`-SyncManifest` rewrites it from the
-source of truth). Then review `git diff` and commit `chore(release): X.Y.Z` yourself — tagging and
-pushing stay manual. `-Check` is exit-code clean (0 ok / 1 drift) so a CI gate can call it.
+source of truth). Then review `git diff` and commit `chore(release): X.Y.Z` yourself. `-Check` is
+exit-code clean (0 ok / 1 drift) so a CI gate can call it.
+
+### What happens after the version-bump lands on `main`
+
+Two channels, so users never install whatever `main` HEAD happens to be:
+
+- **`main`** is the development channel — every merged PR lands here.
+- **`release`** is the branch installs actually fetch. `marketplace.json`'s plugin `source` is a
+  `git-subdir` pinned at `ref: release` (#323), so a fresh install or `plugin update` gets the
+  `release` commit, not `main` HEAD.
+
+When a `chore(release): X.Y.Z` commit changes `plugin.json`'s version on `main`, the **Release**
+workflow (`.github/workflows/release.yml`, #322) fires automatically and:
+
+1. creates the git tag `vX.Y.Z` + a GitHub Release, notes taken from that version's `CHANGELOG.md`
+   block (`scripts/Get-ReleaseNotes.ps1`), on the exact commit that set the version, and
+2. fast-forwards the `release` branch to that commit — the one push that moves pinned installs.
+
+So tagging and the release channel are **no longer manual**: land the version bump on `main` and CI
+does the rest. `plugin.json`'s `version` is still what drives `plugin update` detection for users, so
+it must change on every release (the bump commit is exactly that).
 
 ## Good first issues
 


### PR DESCRIPTION
Closes #323 — Layer 2 of #321, closing the epic.

## What
Installs stop tracking `main` HEAD. Both marketplace entries' `source` become a **git-subdir pinned at `ref: release`**:
```json
{ "source": "git-subdir", "url": "https://github.com/CSalcedoDataBI/agentic-board", "path": "plugins/agentic-board", "ref": "release" }
```
A relative path can't carry a ref (per the marketplace docs), hence git-subdir. The marketplace ref and the plugin `source.ref` are **independent**: `plugin update` re-reads marketplace.json from main, then fetches the plugin from the `release` branch — so installs move only when `release` moves, never on a main push.

## Automation
`release.yml` gains a final step that **fast-forwards `release` to each released commit** (`git push origin $SHA:refs/heads/release`) — the one push that advances pinned installs. Plain push (create or FF; non-FF rejected loudly). No loop (ci/release trigger on main only; GITHUB_TOKEN pushes don't retrigger).

## Notes
- The `release` branch already exists at current tested main HEAD (9efff25, includes #322/#329/#339), so there's **no broken-ref window** on merge — installs resolve immediately.
- `release` is currently ahead of the `v0.21.0` tag (both labeled 0.21.0); this self-corrects when **0.22.0** is cut next (release FFs to the exact bump commit). Kept at current code deliberately so pinned installs get the #329 pagination fix rather than the pre-#329 0.21.0 tag.
- CONTRIBUTING documents the two-channel model and that tagging + the channel are now automated.

Suite 845/0; marketplace↔plugin.json consistency intact (`New-Release -Check`). Adversarial review (opus subagent): schema-correct, repo public so git-subdir resolves the subpath, no install-breakage window, FF loop-free — ship it.