### PR TITLE
M6 — Compaction-survival for long /board work runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- **Compaction-survival for long single-session `/board work` runs** (#348). A queue of issues
+  worked in ONE session eventually auto-compacts, and Claude Code's generic summary drops the
+  thread. A new `Board-RunLedger.ps1` (`-Start`/`-Update`/`-Close`) keeps a durable run-ledger as
+  an `[abios-run-ledger]` comment on the epic plus a lockfile-sized local `.agentic-board/active-run.json`
+  marker (#349). The `SessionStart` hook now handles `source: "compact"` — reading only the local
+  marker (offline), it re-injects a pointer to the epic ledger so the session re-grounds and resumes
+  the queue unattended; a strict no-op outside an active run (#350). A `PreCompact` hook snapshots the
+  transcript into `.agentic-board/compact-snapshots/` as a safety net, never blocking (#351). Works
+  around three Claude Code limits (no programmatic `/compact`, no auto-compact instructions, no cheap
+  compaction model — [anthropics/claude-code#14160](https://github.com/anthropics/claude-code/issues/14160));
+  see `skills/projects-admin/references/compact-survival.md` (#352, #353).
+
 ## [0.22.0] - 2026-07-17
 ### Added
 - **release L1: CI tags + a GitHub Release when `plugin.json`'s version changes on `main`** (#322).

--- a/plugins/agentic-board/hooks/hooks.json
+++ b/plugins/agentic-board/hooks/hooks.json
@@ -9,6 +9,26 @@
             "command": "pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/scripts/Welcome-SessionStartHook.ps1\""
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/scripts/Handoff-SessionStartHook.ps1\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/scripts/Compact-PreCompactHook.ps1\""
+          }
+        ]
       }
     ]
   }

--- a/plugins/agentic-board/scripts/Board-RunLedger.ps1
+++ b/plugins/agentic-board/scripts/Board-RunLedger.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+    Maintain a durable "run-ledger" for a long /board work run so it SURVIVES
+    auto-compaction (epic #348).
+
+.DESCRIPTION
+    A single-session /board work run that works a queue of issues X->Z fills the
+    context window and eventually auto-compacts. The generic summary drops the thread
+    (which issues are done, which pending, the key decisions). This script keeps a
+    durable ledger of that run in TWO places, mirroring the /board handoff model:
+
+      * DURABLE source of truth: an upserted `<!-- abios-run-ledger -->` comment on the
+        EPIC issue (cross-machine, visible, reuses the fail-closed upsert from #316).
+      * LOCAL breadcrumb: `.agentic-board/active-run.json` ({epic, board, repo, status,
+        ...}). A lockfile-sized marker the OFFLINE SessionStart(compact) hook reads to
+        know a run is active and which epic to point back at. The hook never hits the
+        network; the reawakened agent re-reads the epic comment in-session.
+
+    Three actions:
+      -Start  -Epic <n> [-Board <b>] [-Queue <n,...>]   begin a run
+      -Update -Epic <n> -Issue <i> [-Note <s>] [-Next <s>]   record progress on an issue
+      -Close  -Epic <n>                                 end the run (marker -> closed)
+
+    Dot-source guard: set $env:ABIOS_RUNLEDGER_DOTSOURCE=1 before dot-sourcing to load
+    the pure helpers for Pester WITHOUT the token check or any gh/git side effect.
+
+.PARAMETER TokenVar
+    Windows USER env var holding the PAT. Default GITHUB_TOKEN_PERSONAL.
+
+.PARAMETER DryRun
+    Print the marker + intended comment without writing or posting.
+
+.EXAMPLE
+    .\Board-RunLedger.ps1 -Start  -Epic 348 -Board 13 -Queue 349,350,351
+    .\Board-RunLedger.ps1 -Update -Epic 348 -Issue 349 -Note "reused Invoke-Gh upsert" -Next "wire the hook"
+    .\Board-RunLedger.ps1 -Close  -Epic 348
+#>
+[CmdletBinding()]
+param(
+    [switch]  $Start,
+    [switch]  $Update,
+    [switch]  $Close,
+    [int]     $Epic = 0,
+    [int]     $Board = 0,
+    [int[]]   $Queue = @(),
+    [int]     $Issue = 0,
+    [string]  $Note = "",
+    [string]  $Next = "",
+    [string]  $Repo = "",
+    [string]  $TokenVar = "GITHUB_TOKEN_PERSONAL",
+    [switch]  $DryRun
+)
+
+# ==============================================================================
+# Pure helpers (unit-testable; no gh/git/network, no side effects)
+# ==============================================================================
+
+# The comment marker that identifies OUR run-ledger comment on the epic, so update
+# can find-and-edit it instead of piling up new comments (same idea as the handoff
+# marker in Board-Handoff.ps1).
+$script:RunLedgerMarker = "<!-- abios-run-ledger -->"
+
+# RFC3339 UTC (always Z). Takes a DateTime so tests are deterministic.
+function Get-RunLedgerStamp([datetime]$when) {
+    return $when.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+}
+
+# Build a fresh run-state object. Pure: the caller passes the clock.
+function New-RunState {
+    param(
+        [int]     $Epic,
+        [int]     $Board,
+        [string]  $Repo,
+        [int[]]   $Queue = @(),
+        [datetime]$When
+    )
+    return [pscustomobject]@{
+        epic    = $Epic
+        board   = $Board
+        repo    = $Repo
+        status  = 'active'
+        started = Get-RunLedgerStamp $When
+        updated = Get-RunLedgerStamp $When
+        queue   = @($Queue)
+        entries = @()
+    }
+}
+
+# Append one progress entry to a run-state and bump `updated`. Returns a NEW object
+# (does not mutate the input) so tests can assert on both. Idempotent-friendly:
+# re-recording the same issue appends a new row (the ledger is a log, not a set).
+function Add-RunEntry {
+    param(
+        [Parameter(Mandatory)]$State,
+        [int]     $Issue,
+        [string]  $Note = "",
+        [string]  $Next = "",
+        [datetime]$When
+    )
+    $entry = [pscustomobject]@{
+        issue = $Issue
+        note  = ([string]$Note).Trim()
+        next  = ([string]$Next).Trim()
+        at    = Get-RunLedgerStamp $When
+    }
+    $entries = @($State.entries) + $entry
+    return [pscustomobject]@{
+        epic    = $State.epic
+        board   = $State.board
+        repo    = $State.repo
+        status  = $State.status
+        started = $State.started
+        updated = Get-RunLedgerStamp $When
+        queue   = @($State.queue)
+        entries = @($entries)
+    }
+}
+
+# Render the durable epic comment body from a run-state. Pure. Carries the hidden
+# marker (for exact find) and a visible [abios-run-ledger] tag (discovery), then a
+# one-row-per-update table of what the board does NOT hold (decision / next step).
+function Format-RunLedgerComment {
+    param([Parameter(Mandatory)]$State)
+    $queue = if (@($State.queue).Count) { (@($State.queue) | ForEach-Object { "#$_" }) -join ', ' } else { '(none listed)' }
+    $lines = @(
+        $script:RunLedgerMarker
+        "**[abios-run-ledger]** live ``/board work`` run — epic #$($State.epic). Board #$($State.board)."
+        ""
+        "- **Queue:** $queue"
+        "- **Status:** $($State.status)"
+        ""
+    )
+    $entries = @($State.entries)
+    if ($entries.Count) {
+        $lines += "| issue | note | next |"
+        $lines += "| --- | --- | --- |"
+        foreach ($e in $entries) {
+            $note = if ($e.note) { $e.note } else { '—' }
+            $next = if ($e.next) { $e.next } else { '—' }
+            $lines += "| #$($e.issue) | $note | $next |"
+        }
+        $lines += ""
+    }
+    $lines += "_Updated $($State.updated)._"
+    return ($lines -join "`n")
+}
+
+# ==============================================================================
+# Main entry. Dot-source guard: the test harness sets ABIOS_RUNLEDGER_DOTSOURCE to
+# load the helpers above without running any of the side-effecting code below.
+# ==============================================================================
+if ($env:ABIOS_RUNLEDGER_DOTSOURCE) { return }
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot 'Get-RepoFromOrigin.ps1')
+. (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')
+. (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+
+$actions = @($Start, $Update, $Close) | Where-Object { $_ }
+if ($actions.Count -ne 1) { throw "Pass exactly one action: -Start, -Update, or -Close." }
+if ($Epic -le 0) { throw "Pass -Epic <n> (the epic issue that owns this run's queue)." }
+
+if (-not $env:GH_TOKEN) { $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, "User") }
+if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (and GH_TOKEN empty)." }
+
+# -- Resolve repo --------------------------------------------------------------
+if (-not $Repo) {
+    $originUrl = git remote get-url origin 2>$null
+    $Repo = Get-RepoFromOriginUrl $originUrl
+}
+if (-not $Repo) { throw "Could not derive the repo from origin - pass -Repo owner/name." }
+
+# -- Marker path (shared state dir; one per main clone, all worktrees share it) --
+$stateDir = Get-AbiosStateDir
+if (-not $stateDir) { throw "Not inside a git working tree - cannot resolve the state dir." }
+$markerPath = Join-Path $stateDir 'active-run.json'
+
+function Read-RunMarker {
+    if (-not (Test-Path $markerPath)) { return $null }
+    try { return (Get-Content $markerPath -Raw | ConvertFrom-Json) } catch { return $null }
+}
+function Write-RunMarker([Parameter(Mandatory)]$State) {
+    Set-Content -Path $markerPath -Value ($State | ConvertTo-Json -Depth 6) -Encoding UTF8
+}
+
+# -- Durable upsert of the ledger comment on the epic (fail-closed, #316) --------
+function Update-RunLedgerComment {
+    param([Parameter(Mandatory)][string]$Body)
+    # A FAILED read of existing comments must NOT read as "no marker" - that posts a
+    # DUPLICATE instead of editing. On a read failure, skip the post (the local marker
+    # is already written) rather than risk the duplicate.
+    $existingId = $null
+    try {
+        $comments = Invoke-Gh -GhArgs @('api','--paginate',"repos/$Repo/issues/$Epic/comments?per_page=100") `
+                              -What "read the comments of $Repo#$Epic" -Json
+        $existingId = (@($comments | Where-Object { $_.body -like "*$script:RunLedgerMarker*" }) | Select-Object -Last 1).id
+    } catch {
+        Write-Host "  WARN could not read existing comments ($($_.Exception.Message)) - NOT posting to avoid a duplicate. Local marker is saved." -ForegroundColor DarkYellow
+        return
+    }
+    try {
+        if ($existingId) {
+            $null = Invoke-Gh -GhArgs @('api','--method','PATCH',"repos/$Repo/issues/comments/$existingId",'-F','body=@-') `
+                              -StdIn $Body -What "update the run-ledger comment on $Repo#$Epic"
+            Write-Host "  OK  Run-ledger comment updated on $Repo#$Epic" -ForegroundColor Green
+        } else {
+            $null = Invoke-Gh -GhArgs @('issue','comment',"$Epic",'--repo',$Repo,'--body-file','-') `
+                              -StdIn $Body -What "post the run-ledger comment on $Repo#$Epic"
+            Write-Host "  OK  Run-ledger comment posted on $Repo#$Epic" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "  WARN could not upsert the run-ledger comment ($($_.Exception.Message)) - the local marker is still written." -ForegroundColor DarkYellow
+    }
+}
+
+$now = Get-Date
+
+# ------------------------------------------------------------------- START -----
+if ($Start) {
+    if ($Board -le 0) {
+        try {
+            $owner = ($Repo -split '/')[0]
+            $resolved = & (Join-Path $PSScriptRoot "Resolve-Board.ps1") -Owner $owner -Repo $Repo -CreateIfMissing:$false 2>$null
+            if ($resolved) { $Board = [int]($resolved | Select-Object -Last 1) }
+        } catch { $Board = 0 }
+    }
+    $state = New-RunState -Epic $Epic -Board $Board -Repo $Repo -Queue $Queue -When $now
+    $body  = Format-RunLedgerComment $state
+    Write-Host "=== /board run-ledger start  ($Repo)  epic #$Epic ===" -ForegroundColor Cyan
+    if ($DryRun) {
+        Write-Host "DRY-RUN - would write $markerPath and upsert:" -ForegroundColor Yellow
+        Write-Host ""; Write-Host $body; return
+    }
+    Write-RunMarker $state
+    Write-Host "  OK  active-run.json written (epic #$Epic, board #$Board, $(@($Queue).Count) queued)" -ForegroundColor Green
+    Update-RunLedgerComment -Body $body
+    return
+}
+
+# ------------------------------------------------------------------ UPDATE -----
+if ($Update) {
+    $state = Read-RunMarker
+    if (-not $state) { throw "No active-run.json marker found - run -Start first." }
+    if ([int]$state.epic -ne $Epic) { throw "Marker epic (#$($state.epic)) != -Epic #$Epic. Refusing to cross runs." }
+    $state = Add-RunEntry -State $state -Issue $Issue -Note $Note -Next $Next -When $now
+    $body  = Format-RunLedgerComment $state
+    Write-Host "=== /board run-ledger update  ($Repo)  epic #$Epic  issue #$Issue ===" -ForegroundColor Cyan
+    if ($DryRun) {
+        Write-Host "DRY-RUN - would append the entry and upsert:" -ForegroundColor Yellow
+        Write-Host ""; Write-Host $body; return
+    }
+    Write-RunMarker $state
+    Write-Host "  OK  active-run.json updated ($(@($state.entries).Count) entries)" -ForegroundColor Green
+    Update-RunLedgerComment -Body $body
+    return
+}
+
+# ------------------------------------------------------------------- CLOSE -----
+if ($Close) {
+    $state = Read-RunMarker
+    if (-not $state) { throw "No active-run.json marker found - nothing to close." }
+    if ([int]$state.epic -ne $Epic) { throw "Marker epic (#$($state.epic)) != -Epic #$Epic. Refusing to cross runs." }
+    $state.status  = 'closed'
+    $state.updated = Get-RunLedgerStamp $now
+    $body = Format-RunLedgerComment $state
+    Write-Host "=== /board run-ledger close  ($Repo)  epic #$Epic ===" -ForegroundColor Cyan
+    if ($DryRun) {
+        Write-Host "DRY-RUN - would mark closed and upsert:" -ForegroundColor Yellow
+        Write-Host ""; Write-Host $body; return
+    }
+    Write-RunMarker $state
+    Write-Host "  OK  active-run.json marked closed" -ForegroundColor Green
+    Update-RunLedgerComment -Body $body
+    return
+}

--- a/plugins/agentic-board/scripts/Compact-PreCompactHook.ps1
+++ b/plugins/agentic-board/scripts/Compact-PreCompactHook.ps1
@@ -1,0 +1,59 @@
+<#  Compact-PreCompactHook.ps1 - snapshot the transcript before a compaction (epic #348).
+
+    Wired as a Claude Code PreCompact hook. It is the belt-and-suspenders half of the
+    compaction-survival feature: the run-ledger (Board-RunLedger.ps1) is the primary
+    recovery path, but if it ever has a gap, the raw transcript is preserved here so
+    nothing is truly lost.
+
+    Contract (all three matter):
+      * NEVER blocks the compaction - it emits no `decision`, so compaction proceeds.
+      * NEVER throws - a failing PreCompact hook would disrupt the session, so
+        everything is wrapped and the script always exits 0.
+      * OFFLINE + cheap - it only copies a local file (the transcript) into the repo's
+        `.agentic-board/compact-snapshots/`; no network, no gh.
+
+    Dot-source guard: set $env:ABIOS_PRECOMPACT_DOTSOURCE=1 to load the pure helper for
+    Pester without reading stdin or touching the filesystem.
+#>
+[CmdletBinding()]
+param()
+
+# Colon-free basic-format ISO-8601 UTC stamp + trigger, for a snapshot filename
+# (':' is invalid on Windows). Pure: the caller passes the clock and the trigger.
+function New-CompactSnapshotName([datetime]$when, [string]$trigger) {
+    $t = if ($trigger -match '^[A-Za-z]+$') { $trigger.ToLower() } else { 'unknown' }
+    return ($when.ToUniversalTime().ToString("yyyyMMddTHHmmssZ") + "-$t.jsonl")
+}
+
+# ==============================================================================
+# Main. Dot-source guard for tests.
+# ==============================================================================
+if ($env:ABIOS_PRECOMPACT_DOTSOURCE) { return }
+
+try {
+    if (-not [Console]::IsInputRedirected) { exit 0 }
+
+    $raw = ""
+    try { $raw = [Console]::In.ReadToEnd() } catch { $raw = "" }
+    $in = $null
+    if ($raw) { try { $in = $raw | ConvertFrom-Json } catch { $in = $null } }
+    if (-not $in) { exit 0 }
+
+    $transcript = if ($in.transcript_path) { [string]$in.transcript_path } else { "" }
+    if (-not $transcript -or -not (Test-Path -LiteralPath $transcript)) { exit 0 }
+
+    $cwd = if ($in.cwd) { [string]$in.cwd } else { (Get-Location).Path }
+    $root = git -C $cwd rev-parse --show-toplevel 2>$null
+    if (-not $root) { $root = $cwd }
+
+    $snapDir = Join-Path (Join-Path $root '.agentic-board') 'compact-snapshots'
+    if (-not (Test-Path $snapDir)) { New-Item -ItemType Directory -Force $snapDir | Out-Null }
+
+    $trigger = if ($in.trigger) { [string]$in.trigger } else { 'unknown' }
+    $name = New-CompactSnapshotName (Get-Date) $trigger
+    Copy-Item -LiteralPath $transcript -Destination (Join-Path $snapDir $name) -Force
+}
+catch {
+    # A PreCompact hook must never fail the session - swallow everything.
+}
+exit 0

--- a/plugins/agentic-board/scripts/Handoff-SessionStartHook.ps1
+++ b/plugins/agentic-board/scripts/Handoff-SessionStartHook.ps1
@@ -45,6 +45,34 @@ function Get-HandoffSessionContext([string]$body) {
     return $ctx
 }
 
+# Build the SessionStart context line AFTER an auto-compaction (source == "compact"),
+# from the local active-run marker object (.agentic-board/active-run.json). Pure +
+# testable. Returns "" unless a run is genuinely active - so the compact case is a
+# strict no-op on any session that is not mid-run (safe to ship always-on). It only
+# re-injects a POINTER: the durable ledger lives in the epic comment, which the
+# reawakened agent re-reads in-session (the hook itself never hits the network).
+function Get-CompactSessionContext($marker) {
+    if (-not $marker) { return "" }
+    $status = if ($marker.PSObject.Properties.Name -contains 'status') { [string]$marker.status } else { "" }
+    if ($status -ne 'active') { return "" }
+    $epic = if ($marker.PSObject.Properties.Name -contains 'epic') { [int]$marker.epic } else { 0 }
+    if ($epic -le 0) { return "" }
+    $board = if ($marker.PSObject.Properties.Name -contains 'board') { [int]$marker.board } else { 0 }
+    $repo  = if ($marker.PSObject.Properties.Name -contains 'repo')  { [string]$marker.repo } else { "" }
+    $queue = @()
+    if ($marker.PSObject.Properties.Name -contains 'queue' -and $marker.queue) {
+        $queue = @($marker.queue | ForEach-Object { "#$_" })
+    }
+    $ctx = "You just auto-compacted mid-run of a /board work queue (epic #$epic"
+    if ($board -gt 0) { $ctx += ", board #$board" }
+    $ctx += "). The durable run-ledger lives in the '[abios-run-ledger]' comment on epic #$epic"
+    if ($repo) { $ctx += " ($repo)" }
+    $ctx += " - re-read it with 'gh issue view $epic --comments' to recover decisions and the next step."
+    if ($queue.Count) { $ctx += " Queue: $($queue -join ', ')." }
+    $ctx += " Re-read each issue's live status from the board before resuming."
+    return $ctx
+}
+
 # ==============================================================================
 # Main. Dot-source guard for tests.
 # ==============================================================================
@@ -61,19 +89,38 @@ try {
     if ($raw) { try { $in = $raw | ConvertFrom-Json } catch { $in = $null } }
 
     $source = if ($in -and $in.source) { [string]$in.source } else { "" }
-    # Surface ONLY when resuming a prior session (source == "resume"). A fresh
-    # startup is covered by the self-cleaning MEMORY.md pointer (see #141), and
-    # gating to resume avoids re-announcing a stale HANDOFF.md on every new session.
-    if ($source -ne 'resume') { exit 0 }
+    # Two cases surface context; everything else (a fresh startup, a clear) is a no-op:
+    #   resume  -> a stale HANDOFF.md exists to resume (self-cleaning MEMORY.md pointer
+    #              covers a plain new session, see #141).
+    #   compact -> an auto-compaction just happened MID-RUN of a /board work queue; the
+    #              generic summary drops the thread, so re-inject a pointer to the durable
+    #              run-ledger (epic #348). Strict no-op unless a run is active.
+    if ($source -ne 'resume' -and $source -ne 'compact') { exit 0 }
 
     $cwd = if ($in -and $in.cwd) { [string]$in.cwd } else { (Get-Location).Path }
     $root = git -C $cwd rev-parse --show-toplevel 2>$null
     if (-not $root) { $root = $cwd }
-    $handoffPath = Join-Path $root 'HANDOFF.md'
-    if (-not (Test-Path $handoffPath)) { exit 0 }
 
-    $body = Get-Content $handoffPath -Raw
-    $ctx = Get-HandoffSessionContext $body
+    $ctx = ""
+    if ($source -eq 'compact') {
+        # OFFLINE by design: read only the local marker (never the network). The state
+        # dir is shared across worktrees via the main clone's .git-common-dir; here we
+        # only need the per-repo `.agentic-board/active-run.json` under the repo root.
+        $markerPath = Join-Path (Join-Path $root '.agentic-board') 'active-run.json'
+        if (-not (Test-Path $markerPath)) {
+            # Fall back to the pre-rebrand dir name so a mid-migration repo still works.
+            $markerPath = Join-Path (Join-Path $root '.agentic-bi-ops') 'active-run.json'
+        }
+        if (-not (Test-Path $markerPath)) { exit 0 }
+        $marker = $null
+        try { $marker = Get-Content $markerPath -Raw | ConvertFrom-Json } catch { $marker = $null }
+        $ctx = Get-CompactSessionContext $marker
+    } else {
+        $handoffPath = Join-Path $root 'HANDOFF.md'
+        if (-not (Test-Path $handoffPath)) { exit 0 }
+        $body = Get-Content $handoffPath -Raw
+        $ctx = Get-HandoffSessionContext $body
+    }
     if (-not $ctx) { exit 0 }
 
     $out = @{ hookSpecificOutput = @{ hookEventName = 'SessionStart'; additionalContext = $ctx } } | ConvertTo-Json -Compress

--- a/plugins/agentic-board/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-board/skills/projects-admin/SKILL.md
@@ -198,6 +198,19 @@ Notes:
   host, started}` in `.agentic-board/sessions.json` next to the MAIN clone (shared across
   worktrees, gitignored). The pending list shows live local sessions; entries with dead PIDs are
   pruned automatically on read.
+- **Compaction-survival (long single-session queues)**: when you work a queue of issues tied to an
+  **epic** in ONE session, keep a durable run-ledger so the run survives auto-compaction. Three
+  touch-points (see [references/compact-survival.md](references/compact-survival.md)):
+  - When you begin the queue: `Board-RunLedger.ps1 -Start -Epic <n> [-Board <b>] [-Queue <n,...>]`
+  - After each issue's PR merges: `Board-RunLedger.ps1 -Update -Epic <n> -Issue <i> -Note "<decision/gotcha>" -Next "<next step>"`
+  - When the queue is done: `Board-RunLedger.ps1 -Close -Epic <n>`
+
+  The ledger lives as an `[abios-run-ledger]` comment on the epic (durable) plus a local
+  `.agentic-board/active-run.json` marker (a lockfile-sized breadcrumb). If the context
+  auto-compacts mid-run, the `SessionStart(compact)` hook re-injects a pointer to that ledger so
+  the session re-grounds and resumes the queue unattended. Opt-in per run and a **strict no-op**
+  otherwise — no marker means the hook stays silent. Keep entries lightweight (a decision, a
+  gotcha, the next step); the board remains the source of truth for per-issue **status**.
 - **Worktree mode**: when the working copy is busy (dirty tree or another `issue-*` branch),
   `-Branch` creates/reuses an isolated worktree `../<repo>--issue-<n>` instead of switching —
   the agent must continue the work in the printed path and `git worktree remove` it after the

--- a/plugins/agentic-board/skills/projects-admin/references/compact-survival.md
+++ b/plugins/agentic-board/skills/projects-admin/references/compact-survival.md
@@ -1,0 +1,81 @@
+# Compaction-survival for long /board work runs
+
+A single-session `/board work` run that works a queue of issues X→Z fills the context
+window and eventually **auto-compacts**. Claude Code's generic summary drops the thread —
+which issues are done, which are pending, the key decisions — and the unattended run loses
+its way. This feature re-grounds the session automatically after any compaction, so the
+queue keeps moving without a human typing `/compact`.
+
+## Three things Claude Code cannot do (so we don't rely on them)
+
+Verified 2026-07-17:
+
+- **No programmatic `/compact`.** Slash commands are not callable from hooks.
+- **No instructions for auto-compact.** `/compact <text>` works manually, but the `auto`
+  trigger receives an empty `custom_instructions`
+  ([anthropics/claude-code#14160](https://github.com/anthropics/claude-code/issues/14160)).
+- **No cheap model for compaction.** Compaction uses the session model; there is no setting.
+
+The reliable lever is the **`SessionStart` hook with `source: "compact"`**, which fires
+*after* compaction and can inject `additionalContext`. So we don't shape the summary — we
+make it irrelevant by re-injecting ground truth.
+
+## Persistence model (mirrors /board handoff)
+
+Two places, like the handoff:
+
+| Where | What | Who reads it |
+| --- | --- | --- |
+| **Durable:** an upserted `<!-- abios-run-ledger -->` comment on the **epic** issue | queue header + a one-row-per-update table of decisions / next-steps (what the board does *not* hold) | the reawakened agent, in-session, via `gh` |
+| **Local breadcrumb:** `.agentic-board/active-run.json` (`{epic, board, repo, status, ...}`) | a lockfile-sized marker | the **offline** `SessionStart(compact)` hook |
+
+The board itself remains the always-fresh per-issue **status** — re-read via `gh`, never
+mirrored. The ledger only carries what the board cannot.
+
+## The hook contract
+
+`Handoff-SessionStartHook.ps1` (matcher `compact` in `hooks/hooks.json`):
+
+- Reads **only** the local `active-run.json` marker — **never** the network (a SessionStart
+  hook runs on every session and must stay fast).
+- If a run is `active`, emits a **pointer**: "you auto-compacted mid-run of epic #N; re-read
+  the `[abios-run-ledger]` comment with `gh issue view N --comments`, and re-read each
+  issue's live status from the board before resuming."
+- **Strict no-op** when there is no marker or the run is `closed` — so it is safe shipped
+  always-on for every session, not just board runs.
+- Read-only, offline, never blocks, never throws, always exits 0 (same guarantees as the
+  `resume` path it sits beside).
+
+`Compact-PreCompactHook.ps1` (matcher `*` under `PreCompact`) is a **safety net**: it copies
+the transcript into `.agentic-board/compact-snapshots/` before compaction so nothing is
+truly lost if the ledger has a gap. It **never blocks** (blocking risks hitting the hard
+context limit mid-issue) and always exits 0. Snapshots are gitignored (`.agentic-board/`).
+
+## Maintaining the ledger — `Board-RunLedger.ps1`
+
+The `/board work` loop keeps the ledger current at three touch-points:
+
+```powershell
+# When you begin working a queue tied to an epic:
+Board-RunLedger.ps1 -Start  -Epic <n> [-Board <b>] [-Queue <n,...>]
+
+# After each issue closes (its PR merged), record what the board doesn't hold:
+Board-RunLedger.ps1 -Update -Epic <n> -Issue <i> -Note "<decision/gotcha>" -Next "<next step>"
+
+# When the whole queue is done:
+Board-RunLedger.ps1 -Close  -Epic <n>
+```
+
+Keep entries lightweight — a decision, a gotcha, the next step — not a transcript. The
+comment upsert is **fail-closed** (a failed read of existing comments skips the post rather
+than risk a duplicate, per #316); a gh failure never corrupts the local marker.
+
+## Enable / disable
+
+The `compact` re-injection and the PreCompact snapshot ship enabled in the plugin
+`hooks/hooks.json`. Both are strict no-ops outside an active run, so there is nothing to
+disable for normal sessions. To turn them off entirely, remove the `compact` `SessionStart`
+entry and the `PreCompact` entry from `hooks/hooks.json`.
+
+The `resume`-source handoff surfacing remains **opt-in** via your own `settings.json` (see
+[handoff-hook.md](handoff-hook.md)) — this feature does not change that.

--- a/plugins/agentic-board/tests/Board-RunLedger.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-RunLedger.Tests.ps1
@@ -1,0 +1,97 @@
+#Requires -Modules Pester
+<#  Pester tests for Board-RunLedger.ps1 - the run-ledger writer (epic #348).
+
+    The script touches gh + the filesystem, so it exposes a dot-source guard: with
+    $env:ABIOS_RUNLEDGER_DOTSOURCE set it returns after defining the pure helpers,
+    without the token check or any side effect. These tests exercise only those
+    helpers, with a FIXED clock so the stamps are deterministic. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Board-RunLedger.ps1' | Resolve-Path
+    $env:ABIOS_RUNLEDGER_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_RUNLEDGER_DOTSOURCE = ''
+
+    $script:T0 = [datetime]'2026-07-17T10:00:00Z'
+    $script:T1 = [datetime]'2026-07-17T11:30:00Z'
+}
+
+Describe 'Get-RunLedgerStamp' {
+    It 'emits RFC3339 UTC with a trailing Z' {
+        Get-RunLedgerStamp $script:T0 | Should -BeExactly '2026-07-17T10:00:00Z'
+    }
+    It 'converts a local time to UTC' {
+        $local = [datetime]::new(2026, 7, 17, 10, 0, 0, [System.DateTimeKind]::Local)
+        Get-RunLedgerStamp $local | Should -Match 'Z$'
+    }
+}
+
+Describe 'New-RunState' {
+    It 'starts active with the queue and both timestamps set' {
+        $s = New-RunState -Epic 348 -Board 13 -Repo 'o/r' -Queue 349,350 -When $script:T0
+        $s.epic    | Should -Be 348
+        $s.board   | Should -Be 13
+        $s.repo    | Should -BeExactly 'o/r'
+        $s.status  | Should -BeExactly 'active'
+        $s.started | Should -BeExactly '2026-07-17T10:00:00Z'
+        $s.updated | Should -BeExactly '2026-07-17T10:00:00Z'
+        @($s.queue).Count | Should -Be 2
+        @($s.entries).Count | Should -Be 0
+    }
+    It 'tolerates an empty queue' {
+        $s = New-RunState -Epic 1 -Board 0 -Repo 'o/r' -When $script:T0
+        @($s.queue).Count | Should -Be 0
+    }
+}
+
+Describe 'Add-RunEntry' {
+    It 'appends an entry, bumps updated, and does not mutate the input' {
+        $s0 = New-RunState -Epic 348 -Board 13 -Repo 'o/r' -Queue 349 -When $script:T0
+        $s1 = Add-RunEntry -State $s0 -Issue 349 -Note 'reused Invoke-Gh' -Next 'wire the hook' -When $script:T1
+        @($s0.entries).Count | Should -Be 0            # input untouched
+        @($s1.entries).Count | Should -Be 1
+        $s1.entries[0].issue | Should -Be 349
+        $s1.entries[0].note  | Should -BeExactly 'reused Invoke-Gh'
+        $s1.entries[0].next  | Should -BeExactly 'wire the hook'
+        $s1.entries[0].at    | Should -BeExactly '2026-07-17T11:30:00Z'
+        $s1.updated          | Should -BeExactly '2026-07-17T11:30:00Z'
+        $s1.started          | Should -BeExactly '2026-07-17T10:00:00Z'   # preserved
+    }
+    It 'is a log, not a set - the same issue can appear twice' {
+        $s = New-RunState -Epic 1 -Board 0 -Repo 'o/r' -When $script:T0
+        $s = Add-RunEntry -State $s -Issue 5 -Note 'a' -When $script:T0
+        $s = Add-RunEntry -State $s -Issue 5 -Note 'b' -When $script:T1
+        @($s.entries).Count | Should -Be 2
+    }
+}
+
+Describe 'Format-RunLedgerComment' {
+    It 'carries the hidden marker and the visible tag' {
+        $s = New-RunState -Epic 348 -Board 13 -Repo 'o/r' -Queue 349,350 -When $script:T0
+        $body = Format-RunLedgerComment $s
+        $body | Should -Match '<!-- abios-run-ledger -->'
+        $body | Should -Match '\[abios-run-ledger\]'
+        $body | Should -Match 'epic #348'
+        $body | Should -Match 'Board #13'
+    }
+    It 'lists the queue as #-prefixed numbers' {
+        $s = New-RunState -Epic 1 -Board 2 -Repo 'o/r' -Queue 349,350,351 -When $script:T0
+        Format-RunLedgerComment $s | Should -Match '#349, #350, #351'
+    }
+    It 'renders a table row per entry once entries exist' {
+        $s = New-RunState -Epic 1 -Board 2 -Repo 'o/r' -Queue 349 -When $script:T0
+        $s = Add-RunEntry -State $s -Issue 349 -Note 'did X' -Next 'do Y' -When $script:T1
+        $body = Format-RunLedgerComment $s
+        $body | Should -Match '\| issue \| note \| next \|'
+        $body | Should -Match '\| #349 \| did X \| do Y \|'
+    }
+    It 'omits the table when there are no entries yet' {
+        $s = New-RunState -Epic 1 -Board 2 -Repo 'o/r' -When $script:T0
+        Format-RunLedgerComment $s | Should -Not -Match '\| issue \| note \| next \|'
+    }
+    It 'reflects the closed status' {
+        $s = New-RunState -Epic 1 -Board 2 -Repo 'o/r' -When $script:T0
+        $s.status = 'closed'
+        Format-RunLedgerComment $s | Should -Match 'Status:\*\* closed'
+    }
+}

--- a/plugins/agentic-board/tests/Compact-PreCompactHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Compact-PreCompactHook.Tests.ps1
@@ -1,0 +1,33 @@
+#Requires -Modules Pester
+<#  Pester tests for Compact-PreCompactHook.ps1 - the transcript-snapshot safety net
+    (epic #348).
+
+    The hook reads stdin and copies a file, so it exposes a dot-source guard: with
+    $env:ABIOS_PRECOMPACT_DOTSOURCE set it returns after defining the pure
+    New-CompactSnapshotName helper. These tests exercise only that helper, with a
+    FIXED clock so the name is deterministic. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Compact-PreCompactHook.ps1' | Resolve-Path
+    $env:ABIOS_PRECOMPACT_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_PRECOMPACT_DOTSOURCE = ''
+
+    $script:T0 = [datetime]'2026-07-17T10:05:09Z'
+}
+
+Describe 'New-CompactSnapshotName' {
+    It 'is a colon-free UTC stamp with the trigger and .jsonl extension' {
+        New-CompactSnapshotName $script:T0 'auto' | Should -BeExactly '20260717T100509Z-auto.jsonl'
+    }
+    It 'lowercases the trigger' {
+        New-CompactSnapshotName $script:T0 'MANUAL' | Should -BeExactly '20260717T100509Z-manual.jsonl'
+    }
+    It 'falls back to "unknown" for a junk trigger' {
+        New-CompactSnapshotName $script:T0 '' | Should -BeExactly '20260717T100509Z-unknown.jsonl'
+        New-CompactSnapshotName $script:T0 'a b' | Should -BeExactly '20260717T100509Z-unknown.jsonl'
+    }
+    It 'never contains a colon (invalid on Windows)' {
+        New-CompactSnapshotName $script:T0 'auto' | Should -Not -Match ':'
+    }
+}

--- a/plugins/agentic-board/tests/Handoff-SessionStartHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Handoff-SessionStartHook.Tests.ps1
@@ -65,3 +65,36 @@ Describe 'Get-HandoffSessionContext' {
         $c | Should -Match 'issue #9'
     }
 }
+
+Describe 'Get-CompactSessionContext' {
+    It 'returns empty for a null marker' {
+        Get-CompactSessionContext $null | Should -BeExactly ''
+    }
+    It 'returns empty when the run is not active (strict no-op off-run)' {
+        $m = [pscustomobject]@{ epic = 348; board = 13; repo = 'o/r'; status = 'closed' }
+        Get-CompactSessionContext $m | Should -BeExactly ''
+    }
+    It 'returns empty when there is no epic' {
+        $m = [pscustomobject]@{ board = 13; repo = 'o/r'; status = 'active' }
+        Get-CompactSessionContext $m | Should -BeExactly ''
+    }
+    It 'names the epic and points at the [abios-run-ledger] comment' {
+        $m = [pscustomobject]@{ epic = 348; board = 13; repo = 'o/r'; status = 'active'; queue = @(349, 350) }
+        $c = Get-CompactSessionContext $m
+        $c | Should -Match 'epic #348'
+        $c | Should -Match 'board #13'
+        $c | Should -Match 'abios-run-ledger'
+        $c | Should -Match 'gh issue view 348 --comments'
+        $c | Should -Match '#349, #350'
+    }
+    It 'omits the board clause when the board is unknown' {
+        $m = [pscustomobject]@{ epic = 5; board = 0; repo = 'o/r'; status = 'active' }
+        $c = Get-CompactSessionContext $m
+        $c | Should -Match 'epic #5'
+        $c | Should -Not -Match 'board #0'
+    }
+    It 'tells the agent to re-read live status from the board' {
+        $m = [pscustomobject]@{ epic = 1; board = 2; repo = 'o/r'; status = 'active' }
+        Get-CompactSessionContext $m | Should -Match 'status from the board'
+    }
+}


### PR DESCRIPTION
Closes #348

Implements the compaction-survival epic. Full design and rationale in #348.

Also closes the sub-issues delivered together in this PR:
Closes #349
Closes #350
Closes #351
Closes #352
Closes #353

**Verification**: 28 new Pester tests; full suite 884/884 green. Both hooks smoke-tested end-to-end (compact re-injection active/closed/absent; PreCompact snapshot written + missing-transcript no-throw). `hooks.json` validates.