### PR TITLE
feat(skills): diagram-authoring — Mermaid over ASCII + Diagrams knowledge domain (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- **`diagram-authoring` skill — Mermaid over ASCII in plugin artifacts** (#375, #376–#379). When the
+  agent puts a diagram into a plugin-produced markdown artifact (`/board plan` docs, epic/issue bodies,
+  handoffs, status updates, `KNOWLEDGE.md`, README, blog), it now emits a Mermaid fenced block instead
+  of hand-drawn ASCII art — GitHub and Claude render it natively, zero build step. A new INTERNAL
+  support skill (`user-invocable: false`, never a typed command per the Command Surface Contract) is
+  the single source of truth: core rule, diagram-type→syntax decision table, an anti-invention rule,
+  a pre-save validation checklist, and an escalation path to D2/Graphviz rendered via Kroki when a
+  graph is too dense for Mermaid (#376). `projects-admin` and `knowledge-registry` carry a one-line
+  DRY pointer to it (#377). A new **Diagrams** knowledge domain catalogues Mermaid/D2/Graphviz/Kroki,
+  and **Graphify** (multi-modal knowledge-graph peer of CodeGraph) is catalogued in `Claude-Code`
+  with a sanitization note — referenced, not built (#378). Pester coverage for the skill contract and
+  the registry entries (#379).
+
 ## [0.23.2] - 2026-07-20
 ### Added
 - **`/board complete` and `/board bi-checklist` sub-actions** (#371). Two capabilities from 0.23.x had

--- a/knowledge/KNOWLEDGE.md
+++ b/knowledge/KNOWLEDGE.md
@@ -6,7 +6,17 @@
 | Title | Type | Ref | Note |
 |-------|------|-----|------|
 | awesome-claude-code — curated Claude Code ecosystem | repo | [https://github.com/hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | 49.7K stars. Coleccion curada de skills, subagentes, status lines, plugins y tooling de Claude Code. Fuente para descubrir patrones y herramientas del ecosistema. |
+| Graphify (Graphify-Labs/graphify) — multi-modal knowledge graph | repo | [https://github.com/Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) | MIT, ~93K stars. Multi-modal knowledge-graph skill (code + docs + PDFs + SQL schemas); peer of CodeGraph, its graph.html is an auto-generated architecture visual. Sanitization: code parse is local but doc/PDF extraction uses an LLM backend and graph.json/html may embed secrets — never commit them, trusted backend only in private repos. |
 | wshobson/agents — multi-harness agentic plugin marketplace | repo | [https://github.com/wshobson/agents](https://github.com/wshobson/agents) | 37.8K stars, MIT. Marketplace de plugins/subagentes multi-harness (Claude Code, Codex, Cursor, Copilot, Gemini). Peer directo de agentic-board; referente de como estructurar subagentes y coordinacion. |
+
+## Diagrams
+
+| Title | Type | Ref | Note |
+|-------|------|-----|------|
+| D2 (Terrastruct) | repo | [https://github.com/terrastruct/d2](https://github.com/terrastruct/d2) | Cleaner architecture diagrams than Mermaid for dense graphs; needs external render (not inline on GitHub) — escalation target via Kroki. |
+| Graphviz (DOT) | url | [https://graphviz.org/](https://graphviz.org/) | DOT language for large/dense dependency graphs; render via Kroki or the graphviz CLI. Escalation target when Mermaid gets illegible. |
+| Kroki — universal diagram render | url | [https://kroki.io/](https://kroki.io/) | Renders Mermaid/D2/Graphviz/PlantUML to SVG/PNG via a URL — the render path when a diagram is not inline-native and must be embedded as an image. |
+| Mermaid — diagram-as-code | repo | [https://github.com/mermaid-js/mermaid](https://github.com/mermaid-js/mermaid) | Diagram-as-code. GitHub and Claude render fenced mermaid blocks natively — the plugin default, zero build step. |
 
 ## Multi-Agent-Orchestration
 

--- a/knowledge/registry.json
+++ b/knowledge/registry.json
@@ -10,7 +10,8 @@
     "Vega",
     "Claude-Code",
     "Research",
-    "Multi-Agent-Orchestration"
+    "Multi-Agent-Orchestration",
+    "Diagrams"
   ],
   "references": [
     {
@@ -57,6 +58,51 @@
       "ref": "https://github.com/microsoft/autogen",
       "note": "59.6K stars, CC-BY-4.0. Framework de Microsoft para AI agentica multi-agente (conversaciones entre agentes, group chat). Referente de arquitectura de coordinacion.",
       "added": "2026-07-10"
+    },
+    {
+      "id": "kn_006",
+      "domain": "Diagrams",
+      "type": "repo",
+      "title": "Mermaid — diagram-as-code",
+      "ref": "https://github.com/mermaid-js/mermaid",
+      "note": "Diagram-as-code. GitHub and Claude render fenced mermaid blocks natively — the plugin default, zero build step.",
+      "added": "2026-07-21"
+    },
+    {
+      "id": "kn_007",
+      "domain": "Diagrams",
+      "type": "repo",
+      "title": "D2 (Terrastruct)",
+      "ref": "https://github.com/terrastruct/d2",
+      "note": "Cleaner architecture diagrams than Mermaid for dense graphs; needs external render (not inline on GitHub) — escalation target via Kroki.",
+      "added": "2026-07-21"
+    },
+    {
+      "id": "kn_008",
+      "domain": "Diagrams",
+      "type": "url",
+      "title": "Graphviz (DOT)",
+      "ref": "https://graphviz.org/",
+      "note": "DOT language for large/dense dependency graphs; render via Kroki or the graphviz CLI. Escalation target when Mermaid gets illegible.",
+      "added": "2026-07-21"
+    },
+    {
+      "id": "kn_009",
+      "domain": "Diagrams",
+      "type": "url",
+      "title": "Kroki — universal diagram render",
+      "ref": "https://kroki.io/",
+      "note": "Renders Mermaid/D2/Graphviz/PlantUML to SVG/PNG via a URL — the render path when a diagram is not inline-native and must be embedded as an image.",
+      "added": "2026-07-21"
+    },
+    {
+      "id": "kn_010",
+      "domain": "Claude-Code",
+      "type": "repo",
+      "title": "Graphify (Graphify-Labs/graphify) — multi-modal knowledge graph",
+      "ref": "https://github.com/Graphify-Labs/graphify",
+      "note": "MIT, ~93K stars. Multi-modal knowledge-graph skill (code + docs + PDFs + SQL schemas); peer of CodeGraph, its graph.html is an auto-generated architecture visual. Sanitization: code parse is local but doc/PDF extraction uses an LLM backend and graph.json/html may embed secrets — never commit them, trusted backend only in private repos.",
+      "added": "2026-07-21"
     }
   ]
 }

--- a/plugins/agentic-board/skills/diagram-authoring/SKILL.md
+++ b/plugins/agentic-board/skills/diagram-authoring/SKILL.md
@@ -72,7 +72,7 @@ Vega field rules). If you are unsure a relationship exists, leave it out or ask.
 ```mermaid
 flowchart TD
   A[About to write a diagram into a plugin artifact] --> B{Destination}
-  B -->|GitHub md / Claude artifact| C[Emit ```mermaid fenced block]
+  B -->|GitHub md / Claude artifact| C["Emit a mermaid fenced block"]
   B -->|Graph too dense for Mermaid| D[D2 / Graphviz]
   D --> E[Render via Kroki] --> F[Embed image]
 ```

--- a/plugins/agentic-board/skills/diagram-authoring/SKILL.md
+++ b/plugins/agentic-board/skills/diagram-authoring/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: diagram-authoring
+description: Use whenever a diagram goes into a plugin-produced markdown artifact — a /board plan or epic/issue body, a handoff, a status update, KNOWLEDGE.md, the README, or a blog entry. Emit diagram-as-code (Mermaid by default), NEVER hand-drawn ASCII art. Covers flowcharts, architecture, sequence, state, ER and gantt diagrams; escalate to D2/Graphviz (rendered via Kroki) only when a graph is too dense for Mermaid. Triggers — "draw a diagram", "add a flowchart/architecture/sequence/state diagram", "diagrama", "haz un diagrama", "visualiza este flujo", "add a diagram to the plan/issue/handoff/README".
+user-invocable: false
+---
+
+# diagram-authoring — Mermaid over ASCII
+
+The single source of truth for **how this plugin draws diagrams**. The plugin writes markdown
+artifacts (`/board plan` docs, epic/issue bodies, handoffs, status updates, `KNOWLEDGE.md`,
+README, blog entries). Their destinations — GitHub markdown and Claude Code / claude.ai
+artifacts — render **Mermaid** natively, so a proper diagram-as-code block costs nothing extra
+and reads far better than ASCII.
+
+## Core rule
+
+When you are about to put a diagram into any plugin-produced markdown artifact, emit a fenced
+**Mermaid** block. **Never hand-draw ASCII art for a graph** (boxes of `+--+`, `│`, `└──▶`).
+ASCII diagrams wrap badly, don't diff, and don't scale.
+
+````
+```mermaid
+flowchart LR
+  A[Issue picked] --> B[Work branch]
+  B --> C[PR + review gate]
+  C --> D[Merge → Done]
+```
+````
+
+## Decision table — diagram type → Mermaid syntax
+
+| You are showing… | Use | Header keyword |
+|---|---|---|
+| A flow / pipeline / decision path | flowchart | `flowchart TD` / `LR` |
+| Messages between actors over time | sequence | `sequenceDiagram` |
+| States and transitions | state machine | `stateDiagram-v2` |
+| Entities and their relations | ER model | `erDiagram` |
+| A schedule / timeline | gantt | `gantt` |
+| A tree / hierarchy | flowchart (top-down) | `flowchart TD` |
+
+Pick the type that matches the thing being documented — a flow is not a sequence, a hierarchy
+is not an ER model.
+
+## Escalation — when Mermaid is not enough
+
+Reach for **D2 (Terrastruct)** or **Graphviz/DOT** only when a graph is too dense for Mermaid to
+stay legible (large dependency graphs, many crossing edges). These need an **external render** —
+they do not display inline on GitHub. Render via **Kroki** (`https://kroki.io/`) to an SVG/PNG and
+embed the image, rather than pasting source no destination will draw. If no render path is
+available, fall back to a simpler Mermaid approximation — never ship ASCII art as the fallback.
+
+## Anti-invention rule
+
+A diagram documents the **real system**. Do not invent nodes, edges, states, or actors to make a
+picture look complete. Every box and arrow must correspond to something that actually exists in
+the code, flow, or data being described — read the source first (same discipline as the global
+Vega field rules). If you are unsure a relationship exists, leave it out or ask.
+
+## Validation checklist (before saving)
+
+- [ ] The fenced block is opened with ` ```mermaid ` and **closed** with ` ``` `.
+- [ ] Node IDs have **no spaces** (`workBranch`, not `work branch`) — quote labels instead:
+      `A["work branch"]`.
+- [ ] Arrows use valid syntax for the chosen diagram (`-->`, `-.->`, `==>`; `->>` / `-->>` in
+      sequence diagrams).
+- [ ] `subgraph` / `end` and every `[`, `(`, `{`, `"` are balanced.
+- [ ] The diagram reflects the real system (anti-invention rule) — no placeholder nodes.
+- [ ] When in doubt it parses, render once (a Claude artifact or Kroki) to confirm before saving.
+
+## Data flow
+
+```mermaid
+flowchart TD
+  A[About to write a diagram into a plugin artifact] --> B{Destination}
+  B -->|GitHub md / Claude artifact| C[Emit ```mermaid fenced block]
+  B -->|Graph too dense for Mermaid| D[D2 / Graphviz]
+  D --> E[Render via Kroki] --> F[Embed image]
+```
+
+## Relation to other skills
+
+- Artifact-producing skills (`projects-admin` for `/board plan` + handoff, `knowledge-registry`)
+  carry a one-line pointer here so the rule fires without being duplicated — this file stays the
+  only place the diagram guidance lives.
+- The **Diagrams** knowledge domain (`knowledge/registry.json`) catalogues the tools referenced
+  above (Mermaid, D2, Graphviz, Kroki). Graphify is a separate knowledge-graph tool, catalogued
+  but not a diagram authoring tool.

--- a/plugins/agentic-board/skills/knowledge-registry/SKILL.md
+++ b/plugins/agentic-board/skills/knowledge-registry/SKILL.md
@@ -10,6 +10,9 @@ Capture and read the per-project knowledge references registry. The source of tr
 `knowledge/registry.json` (or `knowledge/registry.yaml`); `knowledge/KNOWLEDGE.md` is a generated
 table grouped by domain.
 
+> **Diagrams in a note or wiki page**: never hand-draw ASCII art — use the `diagram-authoring`
+> skill (Mermaid by default). See `skills/diagram-authoring/SKILL.md`.
+
 **Allow-list repos (#298):** if the repo's pre-commit hook allow-lists code extensions and blocks
 `.json` (often on purpose — OAuth `credentials.json` is `.json`), initialise the registry as YAML with
 `-Format yaml` — `.yaml` is normally allow-listed. Once `registry.yaml` exists every `/knowledge`

--- a/plugins/agentic-board/skills/projects-admin/SKILL.md
+++ b/plugins/agentic-board/skills/projects-admin/SKILL.md
@@ -8,6 +8,10 @@ user-invocable: false
 
 This skill covers the full lifecycle of a GitHub Projects v2 board and its items: creation, field setup, issue management, bulk operations, CI automation, and gap detection/fill via `/board fill`.
 
+> **Diagrams in any artifact** (plan/epic/issue body, handoff, status update): never hand-draw
+> ASCII art — use the `diagram-authoring` skill (Mermaid by default, escalate to D2/Graphviz via
+> Kroki). See `skills/diagram-authoring/SKILL.md`.
+
 ---
 
 ## Step 0 — Identity (always first)

--- a/plugins/agentic-board/tests/DiagramAuthoring.Tests.ps1
+++ b/plugins/agentic-board/tests/DiagramAuthoring.Tests.ps1
@@ -1,0 +1,87 @@
+#Requires -Modules Pester
+<#  Pester tests for the diagram-authoring skill (#376) and the Diagrams knowledge domain (#378).
+
+    Asserts the skill exists as an INTERNAL support skill (never a typed command), and that the
+    knowledge registry carries the Diagrams domain refs + the Graphify catalogue entry.
+#>
+
+BeforeAll {
+    $script:PluginRoot = Join-Path $PSScriptRoot '..' | Resolve-Path
+    $script:RepoRoot   = Join-Path $PSScriptRoot '..' '..' '..' | Resolve-Path
+    $script:SkillMd    = Join-Path $script:PluginRoot 'skills' 'diagram-authoring' 'SKILL.md'
+    $script:CommandMd  = Join-Path $script:PluginRoot 'commands' 'diagram-authoring.md'
+    $script:RegPath    = Join-Path $script:RepoRoot 'knowledge' 'registry.json'
+
+    function Get-Frontmatter([string]$Path) {
+        $lines = Get-Content -LiteralPath $Path
+        $fm = @{}
+        if ($lines[0] -eq '---') {
+            for ($i = 1; $i -lt $lines.Count -and $lines[$i] -ne '---'; $i++) {
+                if ($lines[$i] -match '^\s*([a-zA-Z-]+):\s*(.*)$') { $fm[$matches[1]] = $matches[2] }
+            }
+        }
+        $fm
+    }
+}
+
+Describe 'diagram-authoring skill' {
+    It 'SKILL.md exists' {
+        Test-Path $script:SkillMd | Should -BeTrue
+    }
+
+    It 'is an internal skill (user-invocable: false)' {
+        $fm = Get-Frontmatter $script:SkillMd
+        $fm['user-invocable'] | Should -Be 'false'
+    }
+
+    It 'has name diagram-authoring' {
+        (Get-Frontmatter $script:SkillMd)['name'] | Should -Be 'diagram-authoring'
+    }
+
+    It 'has a non-empty description carrying triggers' {
+        $desc = (Get-Frontmatter $script:SkillMd)['description']
+        [string]::IsNullOrWhiteSpace($desc) | Should -BeFalse
+        $desc | Should -Match 'Triggers'
+        $desc | Should -Match 'Mermaid'
+    }
+
+    It 'is NOT exposed as a typed command (no commands/diagram-authoring.md)' {
+        Test-Path $script:CommandMd | Should -BeFalse -Because 'diagram-authoring is internal — invoked by the model, never typed as /diagram-authoring'
+    }
+
+    It 'states the core rule: Mermaid over ASCII' {
+        $body = Get-Content -LiteralPath $script:SkillMd -Raw
+        $body | Should -Match 'Mermaid'
+        $body | Should -Match '(?i)ASCII'
+        $body | Should -Match '(?i)Kroki'
+    }
+}
+
+Describe 'Diagrams knowledge domain' {
+    BeforeEach {
+        $script:reg = Get-Content -LiteralPath $script:RegPath -Raw | ConvertFrom-Json
+    }
+
+    It 'registry.json parses' {
+        { Get-Content -LiteralPath $script:RegPath -Raw | ConvertFrom-Json } | Should -Not -Throw
+    }
+
+    It 'declares the Diagrams domain' {
+        $script:reg.domains | Should -Contain 'Diagrams'
+    }
+
+    It 'catalogues Mermaid, D2, Graphviz and Kroki under Diagrams' {
+        $diagRefs = @($script:reg.references | Where-Object domain -eq 'Diagrams')
+        $refs = $diagRefs.ref -join ' '
+        $refs | Should -Match 'mermaid-js/mermaid'
+        $refs | Should -Match 'terrastruct/d2'
+        $refs | Should -Match 'graphviz\.org'
+        $refs | Should -Match 'kroki\.io'
+    }
+
+    It 'catalogues Graphify (not built, only referenced) with a sanitization note' {
+        $g = @($script:reg.references | Where-Object { $_.ref -match 'Graphify-Labs/graphify' })
+        $g | Should -Not -BeNullOrEmpty
+        $g[0].note | Should -Match '(?i)sanitiz'
+    }
+}


### PR DESCRIPTION
Implements the diagram-authoring feature (epic #375): the agent emits **Mermaid** diagram-as-code in plugin-produced markdown artifacts instead of hand-drawn ASCII art.

- New internal support skill `diagram-authoring` (`user-invocable: false`, never a typed command): core rule, decision table, anti-invention rule, validation checklist, D2/Graphviz-via-Kroki escalation.
- DRY one-line pointers in `projects-admin` and `knowledge-registry`.
- New **Diagrams** knowledge domain (Mermaid/D2/Graphviz/Kroki) + **Graphify** catalogued in `Claude-Code` with a sanitization note (referenced, not built). `KNOWLEDGE.md` regenerated.
- Pester coverage (`DiagramAuthoring.Tests.ps1`); full suite green (1004 passed).
- CHANGELOG `[Unreleased]` entry.

Part of #375
Closes #376
Closes #377
Closes #378
Closes #379