### PR TITLE
fix: #303-class fail-open hardening batch (#382, #336, #319, #309)

### DIFF
--- a/plugins/agentic-board/scripts/Board-Changelog.ps1
+++ b/plugins/agentic-board/scripts/Board-Changelog.ps1
@@ -151,6 +151,24 @@ function Update-ChangelogText {
         Message = "nada que escribir (sin [Unreleased] y sin issues nuevos)." }
 }
 
+# Pick THE plugin.json to read the version from, deterministically (#319). The old code did a
+# RECURSIVE `Get-ChildItem -Recurse -Filter plugin.json | ... -First 1` — a coin toss weighted by
+# directory order that picked a STALE copy inside an ignored `.claude/worktrees/` tree (the very
+# layout `/board work` creates) and stamped the changelog with a version that already shipped, then
+# `-Write` inserted a duplicate block that read as the version going backwards. A silent pick is how
+# the bug works, so given the already-filtered candidate list: none -> $null; exactly one -> it; more
+# than one -> THROW with the list rather than guess. Pure. #303 class (answer confidently or fail,
+# never guess).
+function Select-PluginVersionFile {
+    param([string[]]$Candidates)      # absolute paths, already existence- and ignore-filtered
+    $u = @($Candidates | Where-Object { $_ } | Sort-Object -Unique)
+    if ($u.Count -eq 0) { return $null }
+    if ($u.Count -gt 1) {
+        throw "Version ambigua: varios plugin.json candidatos (resuelve con -Version):`n  $($u -join "`n  ")"
+    }
+    return $u[0]
+}
+
 # Dot-source guard: with $env:ABIOS_CHANGELOG_DOTSOURCE set, return after defining the pure
 # helpers WITHOUT reading gh/the board — lets the tests exercise Update-ChangelogText directly.
 if ($env:ABIOS_CHANGELOG_DOTSOURCE) { return }
@@ -195,10 +213,31 @@ $sinceDt = if ($Since) {
 # ── Defaults for Version / Date ───────────────────────────────────────────────
 if (-not $Date) { $Date = (Get-Date).ToString('yyyy-MM-dd') }
 if (-not $Version) {
-    $pj = Get-ChildItem -Path . -Recurse -Filter plugin.json -ErrorAction SilentlyContinue |
-          Where-Object { $_.FullName -match '\.claude-plugin' } | Select-Object -First 1
-    if ($pj) {
-        $vm = [regex]::Match((Get-Content $pj.FullName -Raw), '"version"\s*:\s*"([^"]+)"')
+    # Resolve the plugin root deterministically, never by a recursive sweep (#319).
+    $candidates = @()
+    # 1. Prefer the plugin.json this script SHIPS beside — it is the one versioning this release.
+    $primary = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '.claude-plugin' | Join-Path -ChildPath 'plugin.json'
+    if (Test-Path $primary) {
+        $candidates += (Resolve-Path -LiteralPath $primary).Path
+    } else {
+        # 2. Fallback: ask git for the repo root and look ONLY at plugins/*/.claude-plugin/plugin.json,
+        #    excluding any path git ignores (the stale worktree copy that triggered this is ignored).
+        $root = (git rev-parse --show-toplevel 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $root) {
+            $pluginsDir = Join-Path $root 'plugins'
+            if (Test-Path $pluginsDir) {
+                foreach ($dir in (Get-ChildItem -Path $pluginsDir -Directory -ErrorAction SilentlyContinue)) {
+                    $pj = Join-Path $dir.FullName '.claude-plugin' | Join-Path -ChildPath 'plugin.json'
+                    if (-not (Test-Path $pj)) { continue }
+                    git check-ignore -q -- "$pj" 2>$null
+                    if ($LASTEXITCODE -ne 0) { $candidates += (Resolve-Path -LiteralPath $pj).Path }   # exit!=0 => NOT ignored
+                }
+            }
+        }
+    }
+    $pjPath = Select-PluginVersionFile -Candidates $candidates
+    if ($pjPath) {
+        $vm = [regex]::Match((Get-Content $pjPath -Raw), '"version"\s*:\s*"([^"]+)"')
         if ($vm.Success) { $Version = $vm.Groups[1].Value }
     }
     if (-not $Version) { $Version = "0.0.0" }

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -89,6 +89,31 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ── Pure helper (unit-testable; no gh/network) ────────────────────────────────
+# Foreign-commit detection (#309). GitHub's commits/{sha}/pulls lists every PR that contains a
+# commit, so a commit GitHub associates with a DIFFERENT PR is provably not this issue's work — the
+# #294 contamination shape, which the "PR grande" warning could not tell apart from a legitimately
+# large PR. Given each commit's associated PR numbers, return the commits whose association is
+# another PR. Warn-only: the caller must NOT let this change the verdict (the base resolution is
+# best-effort, and a contaminating commit with no PR of its own is invisible to this signal). Pure.
+function Find-ForeignCommits {
+    param(
+        [int]$SelfPr,
+        $Commits            # array of { Sha; Pulls (int[]) }
+    )
+    $foreign = @()
+    foreach ($c in @($Commits)) {
+        $others = @($c.Pulls | Where-Object { ($_ -as [int]) -gt 0 -and [int]$_ -ne $SelfPr } | ForEach-Object { [int]$_ })
+        if ($others.Count -gt 0) {
+            $foreign += [pscustomobject]@{ Sha = $c.Sha; OtherPrs = @($others | Sort-Object -Unique) }
+        }
+    }
+    return @($foreign)
+}
+
+# Dot-source guard: tests set $env:ABIOS_REVIEWGATE_DOTSOURCE to load the pure helper only.
+if ($env:ABIOS_REVIEWGATE_DOTSOURCE) { return }
+
 # gh must fail closed on the sites that DRIVE the gate verdict and the ruleset write (#303/#316):
 # a false-empty review read reads as "0 unresolved -> GATE PASSED" and authorizes a merge. The
 # CI/review POLLING reads stay best-effort (a transient failure must keep polling, not throw).
@@ -222,6 +247,40 @@ if ($totalLines -gt $MaxLines -or $size.changedFiles -gt $MaxFiles) {
     Write-Host "       Un PR chico se revisa mejor y mete menos bugs. Considera dividir el issue con:" -ForegroundColor DarkYellow
     Write-Host "       Board-Breakdown.ps1 -Parent <issueNum> -Tasks `"parte A`", `"parte B`"" -ForegroundColor DarkYellow
     Write-Host "       (advertencia, no bloqueo - los umbrales se ajustan con -MaxLines/-MaxFiles)" -ForegroundColor DarkGray
+}
+
+# ── 1.6. Foreign-commit guard (#309): warn when the PR carries commits from another PR ─────────
+# Defence-in-depth for #294 — an issue branch should start from the freshly fetched default branch,
+# but when no base can be resolved Board-Work falls back to the current HEAD, and a hand-cut branch
+# bypasses that entirely. This is the backstop for exactly that case: a commit GitHub associates with
+# a DIFFERENT PR is not this issue's work. Warn-only, like the small-PR guard — it never feeds
+# $blockers below.
+$prCommits = Invoke-Gh -GhArgs @('pr','view',"$PR",'--repo',$Repo,'--json','commits') `
+                       -What "leer los commits del PR #$PR" -Json
+$commitInfo = @()
+foreach ($c in @($prCommits.commits)) {
+    $sha = $c.oid
+    if (-not $sha) { continue }
+    # commits/{sha}/pulls: which PRs contain this commit. Best-effort PER COMMIT — a lookup failure
+    # is a skipped signal, never a failed gate (this is only a warning), so it is caught and dropped.
+    $pulls = @()
+    try {
+        $assoc = Invoke-Gh -GhArgs @('api',"repos/$Repo/commits/$sha/pulls",'--jq','[.[].number]') `
+                           -What "leer los PRs del commit $sha"
+        if ($assoc) { $pulls = @(($assoc | ConvertFrom-Json)) }
+    } catch { }
+    $commitInfo += [pscustomobject]@{ Sha = $sha; Pulls = $pulls }
+}
+$foreign = Find-ForeignCommits -SelfPr $PR -Commits $commitInfo
+if (@($foreign).Count -gt 0) {
+    Write-Host ""
+    Write-Host ("  WARN el PR trae {0} commit(s) asociado(s) a OTRO PR - probablemente no son el trabajo de este issue (#309):" -f @($foreign).Count) -ForegroundColor DarkYellow
+    foreach ($f in $foreign) {
+        $short = $f.Sha.Substring(0, [Math]::Min(9, $f.Sha.Length))
+        Write-Host ("       {0}  -> PR(s) {1}" -f $short, ($f.OtherPrs -join ', ')) -ForegroundColor DarkYellow
+    }
+    Write-Host "       Verifica que la rama haya salido de la default branch fresca (Board-Work sale de origin/main)." -ForegroundColor DarkGray
+    Write-Host "       (advertencia, no bloqueo - un commit contaminante sin PR propio es invisible a esta senal)" -ForegroundColor DarkGray
 }
 
 # ── 1.7 + 1.8. Semantic-model quality gates (M3.3): breaking schema changes AND BPA ──

--- a/plugins/agentic-board/scripts/Board-Triage.ps1
+++ b/plugins/agentic-board/scripts/Board-Triage.ps1
@@ -75,6 +75,31 @@ function Test-PriorityRequest {
     return $null
 }
 
+# Decide which board this invocation targets (#382). The bug: -Number DEFAULTED to 13 (the tool's
+# OWN roadmap board), so an unqualified run (only -Issue) from ANY other repo silently wrote triage
+# onto board #13 instead of the current project's — no error, and #13's item title in the header is
+# easy to miss. Rule: an EXPLICIT -Number is honored as-is; WITHOUT one the board is resolved from
+# the current repo's origin, never a hardcoded fallback. Pure — the network resolve happens in the
+# caller when ResolveFromOrigin is $true. #303 class (a foreign write must never be silent).
+function Get-TriageBoardPlan {
+    param(
+        [bool]  $ExplicitNumber,
+        [bool]  $ExplicitOwner,
+        [int]   $DefaultNumber,
+        [string]$DefaultOwner,
+        [string]$OriginRepo          # 'owner/name', or '' when origin is unavailable
+    )
+    if ($ExplicitNumber) {
+        return [pscustomobject]@{ ResolveFromOrigin = $false; Owner = $DefaultOwner; Number = $DefaultNumber; Reason = 'explicit -Number' }
+    }
+    if ("$OriginRepo" -match '^[^/]+/[^/]+$') {
+        $owner = if ($ExplicitOwner) { $DefaultOwner } else { ($OriginRepo -split '/')[0] }
+        return [pscustomobject]@{ ResolveFromOrigin = $true; Owner = $owner; Number = 0; Reason = "origin $OriginRepo" }
+    }
+    # No explicit -Number AND no usable origin -> refuse rather than default to the tool's own board.
+    return [pscustomobject]@{ ResolveFromOrigin = $false; Owner = $DefaultOwner; Number = 0; Reason = 'no-origin' }
+}
+
 # Dot-source guard: tests set $env:ABIOS_TRIAGE_DOTSOURCE to load the pure helpers only.
 if ($env:ABIOS_TRIAGE_DOTSOURCE) { return }
 
@@ -85,6 +110,27 @@ if (-not $env:GH_TOKEN) {
     $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, 'User')
 }
 if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (and GH_TOKEN empty)." }
+
+# Resolve the target board from origin unless -Number was passed explicitly (#382) — never default to
+# the tool's own #13 from a foreign repo.
+. (Join-Path $PSScriptRoot 'Get-RepoFromOrigin.ps1')
+$originRepo = ''
+try { $originRepo = "$(Get-RepoFromOriginUrl (git remote get-url origin 2>$null))" } catch { $originRepo = '' }
+$plan = Get-TriageBoardPlan -ExplicitNumber $PSBoundParameters.ContainsKey('Number') `
+                            -ExplicitOwner  $PSBoundParameters.ContainsKey('Owner') `
+                            -DefaultNumber  $Number -DefaultOwner $Owner -OriginRepo $originRepo
+if ($plan.Reason -eq 'no-origin') {
+    throw "No pude derivar el board: no hay -Number explicito ni un remote 'origin' aqui. Pasa -Number <n> -Owner <o>."
+}
+$Owner = $plan.Owner
+if ($plan.ResolveFromOrigin) {
+    $resolved = & (Join-Path $PSScriptRoot 'Resolve-Board.ps1') -Owner $Owner -Repo $originRepo -CreateIfMissing $false
+    if (-not $resolved) {
+        throw "El repo $originRepo no tiene board enlazado que yo pueda leer. Crealo con /board init, o pasa -Number <n> -Owner <o>."
+    }
+    $Number = [int]$resolved
+    Write-Host ("  Board resuelto desde origin ($originRepo): #{0} de {1}" -f $Number, $Owner) -ForegroundColor DarkGray
+}
 
 $boardUrl = "https://github.com/users/$Owner/projects/$Number"
 

--- a/plugins/agentic-board/scripts/New-BoardPR.ps1
+++ b/plugins/agentic-board/scripts/New-BoardPR.ps1
@@ -73,6 +73,23 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ── Pure helper (unit-testable; no gh/network) ────────────────────────────────
+# A PR "already exists" ONLY when the read returned a row with a positive-integer number (#336). The
+# old guard was `@($existing).Count -gt 0`, which counted a phantom element with a null `.number` as
+# "exists" and SKIPPED `gh pr create` — the run then reported success with a blank PR number and no PR
+# was created. Return the first genuine PR row, or $null. Pure.
+function Get-ExistingPr {
+    param($PrList)
+    @($PrList) | Where-Object { $_ -and (($_.number -as [int]) -gt 0) } | Select-Object -First 1
+}
+
+# Dot-source guard: tests set $env:ABIOS_NEWBOARDPR_DOTSOURCE to load the pure helper only.
+if ($env:ABIOS_NEWBOARDPR_DOTSOURCE) { return }
+
+# gh must fail closed on the "is there already an open PR?" read (#336/#303): a swallowed failure
+# used to be indistinguishable from "no PR" and took the silent-skip path above.
+. (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+
 # -- 1. Repo: -Repo or origin (strip any embedded credential - never reuse it) --
 if (-not $Repo) {
     $url = git remote get-url origin 2>$null
@@ -130,16 +147,19 @@ $prBody = "Closes #$Issue"
 if ($Body) { $prBody = "$prBody`n`n$Body" }
 
 # -- Existing open PR for this branch? (re-run = iterate on it) ------------------
-$existing = @()
-try { $existing = @(gh pr list --repo $Repo --head $Branch --state open --json number,url 2>$null | ConvertFrom-Json) } catch { }
+# Fail closed (Invoke-Gh -Json) then require a positive-integer number: a phantom/null-number row is
+# NOT an existing PR, so the create path runs instead of silently skipping (#336).
+$existing   = @(Invoke-Gh -GhArgs @('pr','list','--repo',$Repo,'--head',$Branch,'--state','open','--json','number,url') `
+                          -What "buscar un PR abierto para la rama $Branch" -Json)
+$existingPr = Get-ExistingPr $existing
 
 Write-Host "=== Cross-account PR  $Repo ===" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "  Identidad : $login  (via $TokenVar)"
 Write-Host "  Rama      : $Branch -> $Base"
 Write-Host "  Issue     : #$Issue $($iss.title)"
-if (@($existing).Count -gt 0) {
-    Write-Host "  PR        : #$($existing[0].number) ya abierto - solo push (iteracion)" -ForegroundColor Yellow
+if ($existingPr) {
+    Write-Host "  PR        : #$($existingPr.number) ya abierto - solo push (iteracion)" -ForegroundColor Yellow
 } else {
     Write-Host "  PR        : nuevo$(if ($Draft) { ' (draft)' })  titulo: $Title"
 }
@@ -165,9 +185,9 @@ try {
 Write-Host "OK  rama '$Branch' empujada a $Repo como $login" -ForegroundColor Green
 
 # -- 7. PR: reuse the open one, or create ----------------------------------------
-if (@($existing).Count -gt 0) {
-    $prNum = $existing[0].number
-    $prUrl = $existing[0].url
+if ($existingPr) {
+    $prNum = $existingPr.number
+    $prUrl = $existingPr.url
     Write-Host "OK  PR #$prNum ya existia - commits nuevos empujados" -ForegroundColor Green
 } else {
     $ghArgs = @('pr','create','--repo',$Repo,'--head',$Branch,'--base',$Base,'--title',$Title,'--body',$prBody)

--- a/plugins/agentic-board/tests/Board-Changelog.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Changelog.Tests.ps1
@@ -121,3 +121,25 @@ Describe 'Update-ChangelogText — nothing to do' {
         $r.Text | Should -Be $orig
     }
 }
+
+Describe 'Select-PluginVersionFile — deterministic plugin.json, never a recursive guess (#319)' {
+    It 'returns nothing when there are no candidates' {
+        Select-PluginVersionFile -Candidates @() | Should -BeNullOrEmpty
+    }
+    It 'returns the single candidate' {
+        Select-PluginVersionFile -Candidates @('C:\a\.claude-plugin\plugin.json') |
+            Should -Be 'C:\a\.claude-plugin\plugin.json'
+    }
+    It 'dedups identical candidates down to one' {
+        Select-PluginVersionFile -Candidates @('C:\a\plugin.json', 'C:\a\plugin.json') |
+            Should -Be 'C:\a\plugin.json'
+    }
+    It 'THROWS on genuine ambiguity rather than guessing (the stale-worktree bug)' {
+        { Select-PluginVersionFile -Candidates @('C:\a\plugin.json', 'C:\b\plugin.json') } |
+            Should -Throw '*ambigua*'
+    }
+    It 'ignores blank/null entries' {
+        Select-PluginVersionFile -Candidates @('', 'C:\a\plugin.json', $null) |
+            Should -Be 'C:\a\plugin.json'
+    }
+}

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -1,0 +1,43 @@
+#Requires -Modules Pester
+<#  Tests for Board-ReviewGate.ps1's pure foreign-commit detection (#309).
+
+    Board-ReviewGate.ps1 is side-effecting (reads the PR over gh, waits for CI/review), so it exposes
+    a dot-source guard: with $env:ABIOS_REVIEWGATE_DOTSOURCE set it returns after defining the pure
+    helper. Find-ForeignCommits is the defence-in-depth backstop for #294: a commit GitHub associates
+    with a DIFFERENT PR is not this issue's work. It is warn-only — these tests pin the detection, and
+    the known limitation (a commit with no PR of its own is invisible) is asserted, not papered over. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Board-ReviewGate.ps1' | Resolve-Path
+    $env:ABIOS_REVIEWGATE_DOTSOURCE = '1'
+    . $script:Script -Repo 'owner/repo'    # -Repo is Mandatory; the guard returns before it is used
+    $env:ABIOS_REVIEWGATE_DOTSOURCE = ''
+}
+
+Describe 'Find-ForeignCommits — warn on commits owned by another PR (#309)' {
+    It 'returns nothing when every commit belongs only to this PR (no false positive)' {
+        $c = @(
+            [pscustomobject]@{ Sha = 'aaa'; Pulls = @(50) },
+            [pscustomobject]@{ Sha = 'bbb'; Pulls = @(50) }
+        )
+        Find-ForeignCommits -SelfPr 50 -Commits $c | Should -BeNullOrEmpty
+    }
+    It 'flags a commit associated with a DIFFERENT PR' {
+        $f = Find-ForeignCommits -SelfPr 50 -Commits @([pscustomobject]@{ Sha = 'ccc'; Pulls = @(99) })
+        @($f).Count      | Should -Be 1
+        $f[0].Sha        | Should -Be 'ccc'
+        $f[0].OtherPrs   | Should -Contain 99
+    }
+    It 'ignores this PR in a mixed association but keeps the foreign one' {
+        $f = Find-ForeignCommits -SelfPr 50 -Commits @([pscustomobject]@{ Sha = 'ddd'; Pulls = @(50, 77) })
+        @($f).Count      | Should -Be 1
+        $f[0].OtherPrs   | Should -Be @(77)
+    }
+    It 'treats a commit with no PR association as not-foreign (invisible to this signal, documented)' {
+        Find-ForeignCommits -SelfPr 50 -Commits @([pscustomobject]@{ Sha = 'eee'; Pulls = @() }) |
+            Should -BeNullOrEmpty
+    }
+    It 'handles an empty commit set' {
+        Find-ForeignCommits -SelfPr 50 -Commits @() | Should -BeNullOrEmpty
+    }
+}

--- a/plugins/agentic-board/tests/Board-Triage.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Triage.Tests.ps1
@@ -51,3 +51,27 @@ Describe 'Format-PriorityProposal (visible, correctable)' {
         $line | Should -Match 'blocks the release'
     }
 }
+
+Describe 'Get-TriageBoardPlan — never default to the tool board from a foreign repo (#382)' {
+    It 'honors an explicit -Number as-is (no origin resolution)' {
+        $p = Get-TriageBoardPlan -ExplicitNumber $true -ExplicitOwner $true -DefaultNumber 13 -DefaultOwner 'CSalcedoDataBI' -OriginRepo 'someone/other'
+        $p.ResolveFromOrigin | Should -BeFalse
+        $p.Number            | Should -Be 13
+    }
+    It 'resolves from origin when -Number is absent (the footgun fix)' {
+        $p = Get-TriageBoardPlan -ExplicitNumber $false -ExplicitOwner $false -DefaultNumber 13 -DefaultOwner 'CSalcedoDataBI' -OriginRepo 'acme/reports'
+        $p.ResolveFromOrigin | Should -BeTrue
+        $p.Owner             | Should -Be 'acme'
+        $p.Number            | Should -Be 0
+    }
+    It 'keeps an explicit -Owner even when resolving the board from origin' {
+        $p = Get-TriageBoardPlan -ExplicitNumber $false -ExplicitOwner $true -DefaultNumber 13 -DefaultOwner 'MyOrg' -OriginRepo 'acme/reports'
+        $p.ResolveFromOrigin | Should -BeTrue
+        $p.Owner             | Should -Be 'MyOrg'
+    }
+    It 'refuses (no-origin) with neither an explicit -Number nor a usable origin — never falls back to #13' {
+        $p = Get-TriageBoardPlan -ExplicitNumber $false -ExplicitOwner $false -DefaultNumber 13 -DefaultOwner 'CSalcedoDataBI' -OriginRepo ''
+        $p.ResolveFromOrigin | Should -BeFalse
+        $p.Reason            | Should -Be 'no-origin'
+    }
+}

--- a/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
+++ b/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
@@ -1,0 +1,41 @@
+#Requires -Modules Pester
+<#  Tests for New-BoardPR.ps1's pure PR-existence check (#336).
+
+    New-BoardPR.ps1 is side-effecting (git push + gh pr create), so it exposes a dot-source guard:
+    with $env:ABIOS_NEWBOARDPR_DOTSOURCE set it returns after defining the pure helper. The bug was
+    `@($existing).Count -gt 0`: a phantom read row with a null `.number` counted as "PR exists", so
+    `gh pr create` was skipped and the run reported success with a BLANK PR number. Get-ExistingPr
+    treats a PR as existing only when the row carries a positive-integer number. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'New-BoardPR.ps1' | Resolve-Path
+    $env:ABIOS_NEWBOARDPR_DOTSOURCE = '1'
+    . $script:Script -Issue 1              # -Issue is Mandatory; the guard returns before it is used
+    $env:ABIOS_NEWBOARDPR_DOTSOURCE = ''
+}
+
+Describe 'Get-ExistingPr — a phantom row is not an existing PR (#336)' {
+    It 'returns nothing for an empty read ([] -> create path)' {
+        Get-ExistingPr @() | Should -BeNullOrEmpty
+    }
+    It 'returns nothing for a null read' {
+        Get-ExistingPr $null | Should -BeNullOrEmpty
+    }
+    It 'ignores a phantom row with a null number (the bug: it skipped create and printed a blank PR)' {
+        Get-ExistingPr @([pscustomobject]@{ number = $null; url = '' }) | Should -BeNullOrEmpty
+    }
+    It 'ignores a row whose number is zero' {
+        Get-ExistingPr @([pscustomobject]@{ number = 0; url = 'x' }) | Should -BeNullOrEmpty
+    }
+    It 'returns the first genuine PR row (positive number -> iterate path)' {
+        $r = Get-ExistingPr @([pscustomobject]@{ number = 42; url = 'https://x/42' })
+        $r.number | Should -Be 42
+    }
+    It 'skips a leading phantom and returns the real PR behind it' {
+        $r = Get-ExistingPr @(
+            [pscustomobject]@{ number = $null; url = '' },
+            [pscustomobject]@{ number = 7;     url = 'https://x/7' }
+        )
+        $r.number | Should -Be 7
+    }
+}


### PR DESCRIPTION
Closes #382

Closes #336
Closes #319
Closes #309

#303-class fail-open hardening: Board-Triage default-board footgun, New-BoardPR phantom PR, Board-Changelog stale plugin.json, review-gate foreign-commit guard. Each fix ships a pure-helper Pester test (41 new/updated assertions green; 56/56 script-parse green).