### PR TITLE
Command surface: add /agentic-board:tools command + internal tools-catalog skill (commands/tools.md + user-invocable:false skill per Command Surface Contract; wire menu + CommandSurface.Tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ one door, not a wall of commands.
 | `/knowledge` | Manage the project knowledge references registry by domain (add/harvest/list/gen/wiki). Versioned in knowledge/registry.json + generated KNOWLEDGE.md. |
 | `/scan` | Scan the CURRENT project for untracked work (code TODOs, doc checklists/pending, plans/specs) and turn the chosen items into issues + a board plan. Targets the current repo, not the tool's. |
 | `/skills` | Manage the Agent Skills lifecycle — organize/catalog, audit for failures, bootstrap best-practice toolkits by profile (quality or bi = Microsoft Fabric / Power BI), or check installed-tool freshness. Part of the skills-ops module. |
+| `/tools` | Browse, research and install the project's referenced external tools from one unified catalog — it merges the knowledge registry (references) with the installable toolkit presets. Install one tool or all missing at once, kind-aware (skill-clone preserves LICENSE; a plugin surfaces its own install command, never cherry-picked). |
 <!-- END:commands -->
 
 Two rules keep it discoverable, so nothing has to be memorized:

--- a/plugins/agentic-board/commands/board.md
+++ b/plugins/agentic-board/commands/board.md
@@ -35,6 +35,7 @@ for the user to pick (they can answer with just the number):
 /scan       → escanear ESTE proyecto por trabajo sin trackear (TODOs, checklists, planes) → issues + plan
 /skills     → ciclo de vida de Agent Skills (organize / audit / bootstrap [bi] / freshness)
 /knowledge  → registro de referencias externas por dominio (add / harvest / wiki)
+/tools      → catálogo unificado de herramientas externas: navegar, investigar e instalar (individual o todas)
 
 ── canal de feedback (NO se tipea — se dispara solo) ───────────
 abios-feedback → ¿bug o mejora para ESTA herramienta? DILO en lenguaje natural
@@ -43,8 +44,8 @@ abios-feedback → ¿bug o mejora para ESTA herramienta? DILO en lenguaje natura
 ```
 
 If the user picks one of the **otros comandos**, do NOT run a board sub-action — tell them it is a
-separate command and to invoke it directly (`/scan`, `/skills`, `/knowledge`); this menu lists them
-only so the whole tool is discoverable from one entry point.
+separate command and to invoke it directly (`/scan`, `/skills`, `/knowledge`, `/tools`); this menu
+lists them only so the whole tool is discoverable from one entry point.
 
 `abios-feedback` is DIFFERENT: it is an internal skill, NOT a typeable command — it is never typed
 with a slash. It fires on its own when the user describes a bug/improvement for THIS tool (e.g.

--- a/plugins/agentic-board/commands/tools.md
+++ b/plugins/agentic-board/commands/tools.md
@@ -1,0 +1,42 @@
+---
+description: Browse, research and install the project's referenced external tools from one unified catalog — it merges the knowledge registry (references) with the installable toolkit presets. Install one tool or all missing at once, kind-aware (skill-clone preserves LICENSE; a plugin surfaces its own install command, never cherry-picked).
+---
+You are running the agentic-board /tools command.
+
+**If $ARGUMENTS is empty or only whitespace, do NOT run anything yet.** Show this menu and wait
+for the user to pick (they can answer with just the number):
+
+```
+¿Qué quieres hacer con las herramientas referenciadas?
+
+1. browse            → listar TODAS las herramientas referenciadas (registry + presets),
+                       agrupadas por dominio, con su URL y si ya está instalada
+2. research <id>     → mostrar la referencia exacta de una herramienta (URL + nota) antes de instalar
+3. install <id>      → instalar UNA por id: skill-clone conserva su LICENSE; un plugin
+                       (ej. microsoft/skills-for-fabric) muestra su propio comando de install — no se cherry-pickea
+4. install --all     → instalar de una pasada todo lo instalable que falte (dry-run + UNA
+                       confirmación); las entradas plugin se listan aparte (se muestran, no se instalan a ciegas)
+```
+
+When they answer (number or name), invoke the **tools-catalog** skill and follow it. It composes the
+catalog from two sources — the knowledge registry (`knowledge/registry.json`, the *references*) and
+the installable toolkit presets (`presets/toolkits/*.json`, the *installers*) — reusing
+`Get-SkillGaps.ps1` so nothing already installed is offered again.
+
+- **browse** → list every referenced tool grouped by domain, each row showing kind, URL and
+  installed-state. Read-only, no token.
+- **research <id>** → surface the exact reference (URL + note) for one tool so the user can read the
+  source before installing.
+- **install <id>** → install one item by kind: `skill-clone` via `Install-SkillFromRepo.ps1` (clean
+  clone, LICENSE preserved); a `plugin` surfaces its own install command (all-or-nothing). Confirm
+  each; never duplicate an already-installed tool.
+- **install --all** → batch-install every missing installable in one pass with a dry-run summary and
+  a single confirmation; plugin-kind entries are listed separately, surfaced not cherry-picked.
+
+Identity: browse and research are read-only and need no token; an install that clones or files
+follows the same account discipline as the rest of the suite (`gh-account`, default CSalcedoDataBI).
+
+This catalog is the intersection of the knowledge-ops (references) and skills-ops (installers)
+modules — use the knowledge and skills commands to manage each source directly.
+
+Arguments: $ARGUMENTS

--- a/plugins/agentic-board/skills/tools-catalog/SKILL.md
+++ b/plugins/agentic-board/skills/tools-catalog/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: tools-catalog
+description: Use to browse, research and install the project's referenced external tools from one unified catalog that merges the knowledge registry (references) with the installable toolkit presets. Install one tool or all missing installables at once, kind-aware (skill-clone preserves LICENSE; a plugin surfaces its own install command, never cherry-picked). The discoverability surface at the intersection of knowledge-ops and skills-ops. Triggers — "/tools", "navega las herramientas referenciadas", "instala esta herramienta", "instálalas todas", "qué herramientas hay para instalar".
+user-invocable: false
+---
+
+# tools-catalog — unified referenced-tools catalog (browse · research · install)
+
+The single browsable surface for the external tools this project *references* and can *install*.
+It merges two sources that until now lived apart:
+
+- **References** — `knowledge/registry.json` (the knowledge-ops registry): every catalogued
+  URL / repo / doc, by domain. This is *what exists and why* — not necessarily installable.
+- **Installers** — `presets/toolkits/*.json` (the skills-ops toolkit presets, e.g. `bi.json`,
+  `quality.json`): the curated tools that carry an install method. This is *what can be installed*.
+
+A tool can appear in one source or both. The catalog is their union, de-duplicated, each item
+carrying: `name, domain, kind, url, installable, install-method, installed`.
+
+> **Scope (M3 ∩ M5).** This surface REFERENCES / INSTALLS / MONITORS external tools — it never
+> rebuilds them. It reuses the existing engines (`Get-SkillGaps.ps1` for installed-detection,
+> `Install-SkillFromRepo.ps1` for skill-clone); it does not reimplement install or gap logic.
+
+## Sub-actions
+
+### browse  (read-only, no token)
+List every referenced tool grouped by domain. Each row shows `kind`, `url`, and installed-state
+(`✓ installed` / `— available` / `plugin: <install cmd>`). Prefer the resolver
+`scripts/Get-ToolsCatalog.ps1 -Json` (the unified catalog model, delivered in #385) which composes
+registry + presets and marks installed via `Get-SkillGaps.ps1`. Until it lands, compose in-context:
+read `knowledge/registry.json` and every `presets/toolkits/*.json`, then union by `url`/`name`.
+
+### research <id>  (read-only)
+Surface the exact reference for ONE tool — its URL and registry note — so the user reads the source
+before installing. Never installs anything.
+
+### install <id>  (confirm each; never duplicate)
+Install one item by KIND:
+- `skill-clone` → `scripts/Install-SkillFromRepo.ps1` (clean `--depth 1` clone, copy only the skill
+  folder, **preserve LICENSE**). Skipped with a note when `Get-SkillGaps.ps1` already shows it installed.
+- `plugin` (e.g. `microsoft/skills-for-fabric`) → all-or-nothing: SURFACE its own install command,
+  never cherry-pick a single skill out of it.
+
+The hardened selective-install path is delivered in #387.
+
+### install --all  (one pass, one confirmation)
+Batch-install every MISSING installable in a single dry-run-then-confirm pass. Plugin-kind entries
+are listed SEPARATELY (surfaced, not installed blindly). Delivered in #388.
+
+## Identity
+`browse` and `research` need no token. An install that clones or files follows the `gh-account`
+discipline (default CSalcedoDataBI) like the rest of the suite.
+
+## Not this
+- Managing the references themselves (add / harvest / wiki) → the `knowledge-registry` skill.
+- Installing a whole profile toolkit without the catalog UI → the `skills-bootstrap` skill.
+- Auditing installed skills' health → `skills-organize` / `skills-audit`.

--- a/plugins/agentic-board/tests/CommandSurface.Tests.ps1
+++ b/plugins/agentic-board/tests/CommandSurface.Tests.ps1
@@ -77,3 +77,18 @@ Describe 'Command surface — menu entries resolve to real commands' {
         }
     }
 }
+
+Describe 'Command surface — /tools referenced-tools catalog (#384)' {
+    It 'exposes /tools as a real typed command' {
+        $script:RealCommands | Should -Contain 'tools' -Because 'the unified referenced-tools catalog is invoked as /agentic-board:tools (commands/tools.md)'
+    }
+
+    It 'ships tools-catalog as an internal (user-invocable:false) skill' {
+        $script:InternalSkills | Should -Contain 'tools-catalog' -Because 'the catalog logic is an internal skill the /tools command routes to — never typed directly'
+    }
+
+    It 'lists /tools in the /board discoverability menu' {
+        $board = Get-Content -LiteralPath (Join-Path $script:CommandsDir 'board.md') -Raw
+        $board | Should -Match '(?m)^\s*/tools\b' -Because 'the whole tool must be discoverable from the /board entry point, alongside /scan /skills /knowledge'
+    }
+}


### PR DESCRIPTION
Closes #384