### PR TITLE
Unified catalog resolver: merge knowledge/registry.json refs + presets/toolkits/*.json into one item model (name, domain, kind, url, installable, install-method, installed) reusing Get-SkillGaps for installed-detection

### DIFF
--- a/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
+++ b/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
@@ -1,0 +1,151 @@
+<#  Get-ToolsCatalog.ps1 — the unified referenced-tools catalog resolver (#385).
+
+    Merges the two sources that describe the external tools a project references and can install:
+      - the knowledge registry  (knowledge/registry.json)   — the *references* (what exists / why)
+      - the toolkit presets      (presets/toolkits/*.json)    — the *installers* (what can be installed)
+    into ONE de-duplicated item model. Installed-detection reuses the Get-SkillGaps rules
+    (skill-clone matched by `name`, plugin matched by `detect` falling back to `name`).
+
+    It NEVER installs anything — install is the agentic step Install-ToolFromCatalog.ps1 / the
+    tools-catalog SKILL drive. This script is deterministic and side-effect free.
+
+    Item model (each row):
+      id            stable id — preset `name` for installables, registry `id` (kn_xxx) otherwise
+      name          human title
+      domain        registry domain, else the preset's toolkit file stem
+      kind          registry `type` (url/repo/…) OR install kind (plugin / skill-clone)
+      url           canonical URL
+      installable   $true when a preset carries an install method
+      installed     $true when detected in the installed inventory (installables only)
+      source        'registry' | 'preset' | 'both'
+      note          registry note, else the preset purpose
+      installMethod plugin: its install command; skill-clone: 'skill-clone'; else $null
+      repo/path/detect  installer coordinates (null for registry-only refs)
+
+    -Root         repo root that holds knowledge/registry.json (default: cwd)
+    -CatalogDir   presets/toolkits dir (default: alongside this script)
+    -MissingOnly  keep only installable tools that are not installed (feeds install --all)
+    -Id           return only the item whose id OR name matches (case-insensitive)
+    -InstalledNames / -InstalledPlugins  override the detected install sets (tests); default = live
+    -Json         emit JSON
+
+    EXAMPLES
+      .\Get-ToolsCatalog.ps1
+      .\Get-ToolsCatalog.ps1 -MissingOnly -Json
+      .\Get-ToolsCatalog.ps1 -Id skills-for-fabric
+#>
+[CmdletBinding()]
+param(
+    [string]$Root = (Get-Location).Path,
+    [string]$CatalogDir,
+    [switch]$MissingOnly,
+    [string]$Id,
+    [string[]]$InstalledNames,
+    [string[]]$InstalledPlugins,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $CatalogDir) { $CatalogDir = Join-Path $PSScriptRoot '..' 'presets' 'toolkits' }
+
+# --- installed inventory (same sources as Get-SkillGaps) -----------------------
+if (-not $PSBoundParameters.ContainsKey('InstalledNames')) {
+    $engine = Join-Path $PSScriptRoot 'Get-SkillInventory.ps1'
+    $InstalledNames = if (Test-Path $engine) { (& $engine -Scope all).skills.name } else { @() }
+}
+if (-not $PSBoundParameters.ContainsKey('InstalledPlugins')) {
+    $pl = Join-Path $PSScriptRoot 'Get-InstalledPlugins.ps1'
+    $InstalledPlugins = if (Test-Path $pl) { @(& $pl) } else { @() }
+}
+$haveSkill = @{}; foreach ($n in $InstalledNames)   { if ($n) { $haveSkill[([string]$n).ToLower()]  = $true } }
+$havePlugin = @{}; foreach ($p in $InstalledPlugins) { if ($p) { $havePlugin[([string]$p).ToLower()] = $true } }
+
+function Test-PresetInstalled($e) {
+    if ($e.kind -eq 'plugin') {
+        $key = if ($e.PSObject.Properties.Name -contains 'detect' -and $e.detect) { $e.detect } else { $e.name }
+        return $havePlugin.ContainsKey(([string]$key).ToLower())
+    }
+    return $haveSkill.ContainsKey(([string]$e.name).ToLower())
+}
+
+function Get-NormUrl($u) {
+    if ([string]::IsNullOrWhiteSpace([string]$u)) { return $null }
+    $s = ([string]$u).Trim().ToLower() -replace '^https?://', ''
+    return $s.TrimEnd('/')
+}
+
+# --- source 1: the knowledge registry (references) -----------------------------
+. (Join-Path $PSScriptRoot 'KnowledgeRegistryIo.ps1')
+$regPath = Resolve-KnowledgeRegistryPath -Root $Root
+$refs = @()
+if (Test-Path -LiteralPath $regPath) { $refs = @((Read-KnowledgeRegistry -Path $regPath).references) }
+
+$order = [System.Collections.Generic.List[string]]::new()
+$map   = @{}
+function Add-Key([string]$key, $item) { if (-not $map.ContainsKey($key)) { $order.Add($key) }; $map[$key] = $item }
+
+# --- source 2 FIRST: the toolkit presets (installers) --------------------------
+# Each preset is its OWN item, keyed by a unique identity — NOT by homepage, because several
+# skills can live in one monorepo (same homepage) yet be distinct tools (skill-improver +
+# second-opinion both sit in trailofbits/skills). We index homepage → preset keys only to merge
+# a registry ref when it maps to EXACTLY ONE preset (an unambiguous whole-tool match).
+$homeIdx = @{}
+if (Test-Path -LiteralPath $CatalogDir) {
+    foreach ($f in (Get-ChildItem -LiteralPath $CatalogDir -Filter '*.json' | Sort-Object Name)) {
+        $stem = [System.IO.Path]::GetFileNameWithoutExtension($f.Name)
+        foreach ($e in @(Get-Content -LiteralPath $f.FullName -Raw | ConvertFrom-Json)) {
+            $installed = Test-PresetInstalled $e
+            $method = if ($e.kind -eq 'plugin' -and $e.install) { $e.install } else { $e.kind }
+            $pkey = if ($e.kind -eq 'plugin') { "plugin:$(([string]($(if ($e.detect) { $e.detect } else { $e.name }))).ToLower())" }
+                    elseif ($e.repo -and $e.path) { "skill:$((([string]$e.repo)+'#'+([string]$e.path)).ToLower())" }
+                    else { "name:$(([string]$e.name).ToLower())" }
+            Add-Key $pkey ([pscustomobject]@{
+                id=$e.name; name=$e.name; domain=$stem; kind=$e.kind; url=$e.homepage
+                installable=$true; installed=$installed; source='preset'; note=$e.purpose
+                installMethod=$method; repo=$e.repo; path=$e.path; detect=$e.detect; refId=$null
+            })
+            $h = Get-NormUrl $e.homepage
+            if ($h) { if (-not $homeIdx.ContainsKey($h)) { $homeIdx[$h] = [System.Collections.Generic.List[string]]::new() }; $homeIdx[$h].Add($pkey) }
+        }
+    }
+}
+
+# --- merge registry refs: into a preset when the URL is unambiguous, else add as a reference ----
+foreach ($r in $refs) {
+    $u = Get-NormUrl $r.ref
+    if ($u -and $homeIdx.ContainsKey($u) -and $homeIdx[$u].Count -eq 1) {
+        $x = $map[$homeIdx[$u][0]]              # exactly one preset shares this URL → same tool
+        $x.source = 'both'; $x.refId = $r.id; $x.domain = $r.domain
+        if ([string]::IsNullOrWhiteSpace([string]$x.note)) { $x.note = $r.note }
+    } else {
+        $rkey = if ($u) { "ref:$u" } else { "refname:$(([string]$r.title).ToLower())" }
+        Add-Key $rkey ([pscustomobject]@{
+            id=$r.id; name=$r.title; domain=$r.domain; kind=$r.type; url=$r.ref
+            installable=$false; installed=$false; source='registry'; note=$r.note
+            installMethod=$null; repo=$null; path=$null; detect=$null; refId=$null
+        })
+    }
+}
+
+$items = [System.Collections.Generic.List[object]]::new()
+foreach ($k in $order) { $items.Add($map[$k]) }
+
+# --- filters -------------------------------------------------------------------
+$out = @($items)
+if ($MissingOnly) { $out = @($out | Where-Object { $_.installable -and -not $_.installed }) }
+if ($PSBoundParameters.ContainsKey('Id') -and $Id) {
+    $needle = $Id.ToLower()
+    $out = @($out | Where-Object { ([string]$_.id).ToLower() -eq $needle -or ([string]$_.name).ToLower() -eq $needle })
+}
+
+$result = [pscustomobject]@{
+    items   = $out
+    summary = [pscustomobject]@{
+        total       = @($out).Count
+        installable = @($out | Where-Object installable).Count
+        installed   = @($out | Where-Object installed).Count
+    }
+}
+
+if ($Json) { $result | ConvertTo-Json -Depth 8 } else { $result }

--- a/plugins/agentic-board/skills/tools-catalog/SKILL.md
+++ b/plugins/agentic-board/skills/tools-catalog/SKILL.md
@@ -25,10 +25,10 @@ carrying: `name, domain, kind, url, installable, install-method, installed`.
 
 ### browse  (read-only, no token)
 List every referenced tool grouped by domain. Each row shows `kind`, `url`, and installed-state
-(`✓ installed` / `— available` / `plugin: <install cmd>`). Prefer the resolver
-`scripts/Get-ToolsCatalog.ps1 -Json` (the unified catalog model, delivered in #385) which composes
-registry + presets and marks installed via `Get-SkillGaps.ps1`. Until it lands, compose in-context:
-read `knowledge/registry.json` and every `presets/toolkits/*.json`, then union by `url`/`name`.
+(`✓ installed` / `— available` / `plugin: <install cmd>`). The resolver
+`scripts/Get-ToolsCatalog.ps1 -Json` composes registry + presets into the unified item model and
+marks installed via the `Get-SkillGaps` rules — call it and render its `items`. The browse/research
+presentation is refined in #386.
 
 ### research <id>  (read-only)
 Surface the exact reference for ONE tool — its URL and registry note — so the user reads the source

--- a/plugins/agentic-board/tests/Get-ToolsCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ToolsCatalog.Tests.ps1
@@ -1,0 +1,132 @@
+#Requires -Modules Pester
+<#  Tests for Get-ToolsCatalog.ps1 (#385) — the unified referenced-tools catalog resolver.
+
+    It merges the knowledge registry (references) with the toolkit presets (installers) into one
+    item model, de-duplicated by URL, with installed-detection reusing the Get-SkillGaps rules
+    (skill-clone by name, plugin by detect/name). Fixtures are built under TestDrive so nothing
+    depends on the live registry or installed inventory.
+#>
+
+BeforeAll {
+    $script:Resolver = Join-Path $PSScriptRoot '..' 'scripts' 'Get-ToolsCatalog.ps1'
+
+    # --- fixture: a registry with one ref that OVERLAPS a preset (skills-for-fabric) and one that does not
+    $script:Root = Join-Path $TestDrive 'proj'
+    $regDir = Join-Path $script:Root 'knowledge'
+    New-Item -ItemType Directory -Force -Path $regDir | Out-Null
+    @{
+        version    = 1
+        project    = 'proj'
+        domains    = @('PowerBI','Vega')
+        references = @(
+            @{ id='kn_001'; domain='PowerBI'; type='repo'; title='skills-for-fabric marketplace'; ref='https://github.com/microsoft/skills-for-fabric'; note='seed of the BI toolkit'; added='2026-07-22' }
+            @{ id='kn_002'; domain='Vega';    type='url';  title='Vega docs';                    ref='https://vega.github.io/';                         note='charts grammar';     added='2026-07-22' }
+        )
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $regDir 'registry.json') -Encoding utf8
+
+    # --- fixture: two toolkit presets (one plugin, one skill-clone)
+    $script:CatalogDir = Join-Path $TestDrive 'toolkits'
+    New-Item -ItemType Directory -Force -Path $script:CatalogDir | Out-Null
+    ,@(
+        @{ name='skills-for-fabric'; owner='Microsoft'; repo='microsoft/skills-for-fabric'; kind='plugin'; detect='fabric-collection'; path=$null; homepage='https://github.com/microsoft/skills-for-fabric'; install='claude plugin marketplace add microsoft/skills-for-fabric'; purpose='Fabric/PBI skills + MCP.' }
+    ) | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'bi.json') -Encoding utf8
+    ,@(
+        @{ name='skill-creator'; owner='Anthropic'; repo='anthropics/skills'; kind='skill-clone'; detect=$null; path='skill-creator'; homepage='https://github.com/anthropics/skills'; install=$null; purpose='Author and test skills.' }
+    ) | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'quality.json') -Encoding utf8
+
+    # skill-creator is "installed", the fabric plugin is not
+    $script:Common = @{
+        Root             = $script:Root
+        CatalogDir       = $script:CatalogDir
+        InstalledNames   = @('skill-creator')
+        InstalledPlugins = @()
+    }
+    $script:Cat = & $script:Resolver @script:Common
+}
+
+Describe 'Get-ToolsCatalog — unified model' {
+    It 'merges registry + presets and de-duplicates by URL' {
+        # registry(2) ∪ presets(2), skills-for-fabric collapses to one → 3 items
+        @($script:Cat.items).Count | Should -Be 3
+    }
+
+    It 'marks the overlapping tool as coming from BOTH sources and installable' {
+        $f = $script:Cat.items | Where-Object { $_.id -eq 'skills-for-fabric' }
+        $f | Should -Not -BeNullOrEmpty
+        $f.source      | Should -Be 'both'
+        $f.installable | Should -BeTrue
+        $f.kind        | Should -Be 'plugin'
+        $f.installed   | Should -BeFalse -Because 'the fabric plugin is not in InstalledPlugins'
+        $f.installMethod | Should -Match 'marketplace'
+    }
+
+    It 'detects an installed skill-clone by name' {
+        $s = $script:Cat.items | Where-Object { $_.id -eq 'skill-creator' }
+        $s.installable | Should -BeTrue
+        $s.kind        | Should -Be 'skill-clone'
+        $s.installed   | Should -BeTrue
+        $s.source      | Should -Be 'preset'
+    }
+
+    It 'keeps a registry-only reference as non-installable' {
+        $v = $script:Cat.items | Where-Object { $_.id -eq 'kn_002' }
+        $v.installable | Should -BeFalse
+        $v.source      | Should -Be 'registry'
+        $v.domain      | Should -Be 'Vega'
+    }
+
+    It 'reports a summary count' {
+        $script:Cat.summary.total       | Should -Be 3
+        $script:Cat.summary.installable | Should -Be 2
+        $script:Cat.summary.installed   | Should -Be 1
+    }
+}
+
+Describe 'Get-ToolsCatalog — filters and lookup' {
+    It '-MissingOnly returns only installable tools that are not installed' {
+        $missing = & $script:Resolver @script:Common -MissingOnly
+        @($missing.items).Count | Should -Be 1
+        $missing.items[0].id | Should -Be 'skills-for-fabric'
+    }
+
+    It '-Id resolves one item by id' {
+        $one = & $script:Resolver @script:Common -Id 'kn_002'
+        @($one.items).Count | Should -Be 1
+        $one.items[0].domain | Should -Be 'Vega'
+    }
+
+    It '-Id resolves by name case-insensitively' {
+        $one = & $script:Resolver @script:Common -Id 'SKILLS-FOR-FABRIC'
+        @($one.items).Count | Should -Be 1
+        $one.items[0].kind | Should -Be 'plugin'
+    }
+
+    It '-Json emits parseable JSON with the same items' {
+        $json = & $script:Resolver @script:Common -Json
+        $parsed = $json | ConvertFrom-Json
+        @($parsed.items).Count | Should -Be 3
+    }
+}
+
+Describe 'Get-ToolsCatalog — resilience' {
+    It 'works with no registry (presets only)' {
+        $empty = Join-Path $TestDrive 'noreg'
+        New-Item -ItemType Directory -Force -Path $empty | Out-Null
+        $cat = & $script:Resolver -Root $empty -CatalogDir $script:CatalogDir -InstalledNames @() -InstalledPlugins @()
+        @($cat.items).Count | Should -Be 2
+        ($cat.items | Where-Object installable).Count | Should -Be 2
+    }
+
+    It 'keeps two skills from the SAME monorepo as distinct items (no URL-collapse)' {
+        # regression: skill-improver + second-opinion both live in trailofbits/skills (same homepage)
+        $mono = Join-Path $TestDrive 'mono'; New-Item -ItemType Directory -Force -Path $mono | Out-Null
+        ,@(
+            @{ name='skill-improver'; repo='trailofbits/skills'; kind='skill-clone'; path='skill-improver'; homepage='https://github.com/trailofbits/skills'; install=$null; purpose='improve' }
+            @{ name='second-opinion'; repo='trailofbits/skills'; kind='skill-clone'; path='second-opinion'; homepage='https://github.com/trailofbits/skills'; install=$null; purpose='review' }
+        ) | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $mono 'q.json') -Encoding utf8
+        $noreg = Join-Path $TestDrive 'mono-root'; New-Item -ItemType Directory -Force -Path $noreg | Out-Null
+        $cat = & $script:Resolver -Root $noreg -CatalogDir $mono -InstalledNames @() -InstalledPlugins @()
+        @($cat.items).Count | Should -Be 2
+        ($cat.items.id | Sort-Object) | Should -Be @('second-opinion','skill-improver')
+    }
+}


### PR DESCRIPTION
Closes #385