### PR TITLE
Browse + research view: list ALL referenced tools grouped, each row showing its URL; 'research <id>' surfaces the exact reference before installing

### DIFF
--- a/plugins/agentic-board/scripts/Show-ToolsCatalog.ps1
+++ b/plugins/agentic-board/scripts/Show-ToolsCatalog.ps1
@@ -1,0 +1,79 @@
+<#  Show-ToolsCatalog.ps1 — browse + research view over Get-ToolsCatalog (#386).
+
+    The read-only presentation layer of the /tools catalog. With no -Id it BROWSES: every
+    referenced tool grouped by domain, each row carrying its kind, installed-state and URL — so
+    the whole surface (references + installers) is visible from one list. With -Id it RESEARCHES
+    one tool: name, source, URL and note, so the user reads the reference before deciding to install.
+
+    It never installs and needs no token — it only renders what Get-ToolsCatalog resolves. The
+    -Root / -CatalogDir / -InstalledNames / -InstalledPlugins pass straight through to the resolver
+    (the last two let tests pin the installed inventory).
+
+    EXAMPLES
+      .\Show-ToolsCatalog.ps1                    # browse everything, grouped by domain
+      .\Show-ToolsCatalog.ps1 -Id skills-for-fabric   # research one tool
+#>
+[CmdletBinding()]
+param(
+    [string]$Root = (Get-Location).Path,
+    [string]$CatalogDir,
+    [string]$Id,
+    [string[]]$InstalledNames,
+    [string[]]$InstalledPlugins
+)
+
+$ErrorActionPreference = 'Stop'
+
+# forward only the params the resolver understands (and only when explicitly supplied)
+$fwd = @{ Root = $Root }
+if ($CatalogDir) { $fwd.CatalogDir = $CatalogDir }
+if ($PSBoundParameters.ContainsKey('InstalledNames'))   { $fwd.InstalledNames   = $InstalledNames }
+if ($PSBoundParameters.ContainsKey('InstalledPlugins')) { $fwd.InstalledPlugins = $InstalledPlugins }
+
+$resolver = Join-Path $PSScriptRoot 'Get-ToolsCatalog.ps1'
+
+function Get-State($item) {
+    if (-not $item.installable) { return 'reference' }
+    if ($item.installed)        { return 'installed' }
+    return 'available'
+}
+
+# --- research one tool ---------------------------------------------------------
+if ($PSBoundParameters.ContainsKey('Id') -and $Id) {
+    $one = (& $resolver @fwd -Id $Id).items
+    if (-not $one -or @($one).Count -eq 0) {
+        Write-Output "Tool '$Id' not found in the catalog. Run /tools browse to see valid ids."
+        return
+    }
+    $t = @($one)[0]
+    Write-Output $t.name
+    Write-Output ("  id          : {0}" -f $t.id)
+    Write-Output ("  source      : {0}" -f $t.source)
+    Write-Output ("  domain      : {0}" -f $t.domain)
+    Write-Output ("  kind        : {0}" -f $t.kind)
+    Write-Output ("  url         : {0}" -f $t.url)
+    Write-Output ("  installable : {0}" -f $t.installable)
+    Write-Output ("  installed   : {0}" -f $t.installed)
+    if ($t.installMethod) { Write-Output ("  install     : {0}" -f $t.installMethod) }
+    if ($t.note)          { Write-Output ("  note        : {0}" -f $t.note) }
+    return
+}
+
+# --- browse everything, grouped by domain --------------------------------------
+$cat = & $resolver @fwd
+$items = @($cat.items)
+
+Write-Output ("Referenced tools: {0} total — {1} installable ({2} installed)." -f `
+    $cat.summary.total, $cat.summary.installable, $cat.summary.installed)
+Write-Output ''
+
+foreach ($g in ($items | Group-Object domain | Sort-Object Name)) {
+    Write-Output ("## {0}" -f $g.Name)
+    foreach ($t in ($g.Group | Sort-Object @{e={-[int][bool]$_.installable}}, id)) {
+        $state = Get-State $t
+        Write-Output ("  [{0,-9}] {1}  ({2})  {3}" -f $state, $t.id, $t.kind, $t.url)
+    }
+    Write-Output ''
+}
+
+Write-Output 'research <id> to read a tool before installing · install <id> · install --all'

--- a/plugins/agentic-board/skills/tools-catalog/SKILL.md
+++ b/plugins/agentic-board/skills/tools-catalog/SKILL.md
@@ -24,15 +24,15 @@ carrying: `name, domain, kind, url, installable, install-method, installed`.
 ## Sub-actions
 
 ### browse  (read-only, no token)
-List every referenced tool grouped by domain. Each row shows `kind`, `url`, and installed-state
-(`✓ installed` / `— available` / `plugin: <install cmd>`). The resolver
-`scripts/Get-ToolsCatalog.ps1 -Json` composes registry + presets into the unified item model and
-marks installed via the `Get-SkillGaps` rules — call it and render its `items`. The browse/research
-presentation is refined in #386.
+Run `scripts/Show-ToolsCatalog.ps1` — it renders the unified catalog grouped by domain, each row
+showing `[installed|available|reference]`, the id, the kind, and the URL. It reads
+`scripts/Get-ToolsCatalog.ps1` under the hood (registry + presets merged, installed-state via the
+`Get-SkillGaps` rules); pass `-Json` to the resolver directly when you need the raw item model.
 
 ### research <id>  (read-only)
-Surface the exact reference for ONE tool — its URL and registry note — so the user reads the source
-before installing. Never installs anything.
+Run `scripts/Show-ToolsCatalog.ps1 -Id <id>` — it surfaces ONE tool's name, source, URL, install
+method and note so the user reads the reference before deciding. `<id>` matches the row id or the
+tool name (case-insensitive). Never installs anything.
 
 ### install <id>  (confirm each; never duplicate)
 Install one item by KIND:

--- a/plugins/agentic-board/tests/Show-ToolsCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Show-ToolsCatalog.Tests.ps1
@@ -1,0 +1,61 @@
+#Requires -Modules Pester
+<#  Tests for Show-ToolsCatalog.ps1 (#386) — the browse + research view over the catalog resolver.
+    browse: every tool listed, grouped by domain, each row carrying its URL and installed-state.
+    research <id>: surfaces one tool's exact reference (URL + note) before install.
+#>
+
+BeforeAll {
+    $script:Show = Join-Path $PSScriptRoot '..' 'scripts' 'Show-ToolsCatalog.ps1'
+
+    $script:Root = Join-Path $TestDrive 'proj'
+    $regDir = Join-Path $script:Root 'knowledge'; New-Item -ItemType Directory -Force -Path $regDir | Out-Null
+    @{
+        version=1; project='proj'; domains=@('PowerBI','Vega')
+        references=@(
+            @{ id='kn_001'; domain='PowerBI'; type='repo'; title='skills-for-fabric marketplace'; ref='https://github.com/microsoft/skills-for-fabric'; note='seed of the BI toolkit'; added='2026-07-22' }
+            @{ id='kn_002'; domain='Vega';    type='url';  title='Vega docs'; ref='https://vega.github.io/'; note='charts grammar'; added='2026-07-22' }
+        )
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $regDir 'registry.json') -Encoding utf8
+
+    $script:CatalogDir = Join-Path $TestDrive 'toolkits'; New-Item -ItemType Directory -Force -Path $script:CatalogDir | Out-Null
+    ,@( @{ name='skills-for-fabric'; owner='Microsoft'; repo='microsoft/skills-for-fabric'; kind='plugin'; detect='fabric-collection'; path=$null; homepage='https://github.com/microsoft/skills-for-fabric'; install='claude plugin marketplace add microsoft/skills-for-fabric'; purpose='Fabric/PBI skills + MCP.' } ) |
+        ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'bi.json') -Encoding utf8
+    ,@( @{ name='skill-creator'; owner='Anthropic'; repo='anthropics/skills'; kind='skill-clone'; detect=$null; path='skill-creator'; homepage='https://github.com/anthropics/skills'; install=$null; purpose='Author and test skills.' } ) |
+        ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'quality.json') -Encoding utf8
+
+    $script:Common = @{ Root=$script:Root; CatalogDir=$script:CatalogDir; InstalledNames=@('skill-creator'); InstalledPlugins=@() }
+}
+
+Describe 'Show-ToolsCatalog — browse' {
+    BeforeAll { $script:Browse = (& $script:Show @script:Common) -join "`n" }
+
+    It 'groups tools under their domain headers' {
+        $script:Browse | Should -Match 'PowerBI'
+        $script:Browse | Should -Match 'Vega'
+    }
+    It 'shows every tool URL' {
+        $script:Browse | Should -Match ([regex]::Escape('github.com/microsoft/skills-for-fabric'))
+        $script:Browse | Should -Match ([regex]::Escape('vega.github.io'))
+        $script:Browse | Should -Match ([regex]::Escape('github.com/anthropics/skills'))
+    }
+    It 'marks an installed tool as installed and a bare reference as reference' {
+        ($script:Browse -split "`n" | Where-Object { $_ -match 'skill-creator' }) -join '' | Should -Match 'installed'
+        ($script:Browse -split "`n" | Where-Object { $_ -match 'kn_002' })       -join '' | Should -Match 'reference'
+    }
+}
+
+Describe 'Show-ToolsCatalog — research <id>' {
+    It 'surfaces the exact URL and note for one tool' {
+        $r = (& $script:Show @script:Common -Id 'kn_002') -join "`n"
+        $r | Should -Match ([regex]::Escape('vega.github.io'))
+        $r | Should -Match 'charts grammar'
+    }
+    It 'resolves by name too and shows the install method for an installable' {
+        $r = (& $script:Show @script:Common -Id 'skills-for-fabric') -join "`n"
+        $r | Should -Match 'marketplace'
+    }
+    It 'reports a clear message for an unknown id' {
+        $r = (& $script:Show @script:Common -Id 'does-not-exist') -join "`n"
+        $r | Should -Match 'not found'
+    }
+}


### PR DESCRIPTION
Closes #386