### PR TITLE
Selective install (individual): install one item by id ÔÇö skill-clone via Install-SkillFromRepo (LICENSE preserved), plugin surfaces its own install command; confirm each, never duplicate

### DIFF
--- a/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
+++ b/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
@@ -104,6 +104,7 @@ if (Test-Path -LiteralPath $CatalogDir) {
                 id=$e.name; name=$e.name; domain=$stem; kind=$e.kind; url=$e.homepage
                 installable=$true; installed=$installed; source='preset'; note=$e.purpose
                 installMethod=$method; repo=$e.repo; path=$e.path; detect=$e.detect; refId=$null
+                owner=$e.owner; license=$e.license
             })
             $h = Get-NormUrl $e.homepage
             if ($h) { if (-not $homeIdx.ContainsKey($h)) { $homeIdx[$h] = [System.Collections.Generic.List[string]]::new() }; $homeIdx[$h].Add($pkey) }
@@ -124,6 +125,7 @@ foreach ($r in $refs) {
             id=$r.id; name=$r.title; domain=$r.domain; kind=$r.type; url=$r.ref
             installable=$false; installed=$false; source='registry'; note=$r.note
             installMethod=$null; repo=$null; path=$null; detect=$null; refId=$null
+            owner=$null; license=$null
         })
     }
 }

--- a/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
+++ b/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
@@ -1,0 +1,82 @@
+<#  Install-ToolFromCatalog.ps1 — install referenced tools from the unified catalog (#387).
+
+    Resolves items through Get-ToolsCatalog and installs by KIND, never duplicating:
+      - skill-clone : delegates to Install-SkillFromRepo.ps1 (clean clone, LICENSE preserved).
+      - plugin      : SURFACES its own install command (all-or-nothing) — never auto-run, because a
+                      marketplace plugin is global/interactive and cherry-picking one skill is wrong.
+      - reference   : a catalogued URL with no installer — reports it and the URL to open.
+    An already-installed tool is skipped. -DryRun reports intent without touching anything.
+
+    -Id           install ONE tool by id or name (case-insensitive).
+    -DryRun       report what would happen; install nothing.
+    -Root/-CatalogDir/-InstalledNames/-InstalledPlugins  passthrough to Get-ToolsCatalog.
+    -Dest/-Force  passthrough to the skill installer.
+    -InstallSkillWith  installer script path (default Install-SkillFromRepo.ps1) — injected in tests.
+
+    EXAMPLES
+      .\Install-ToolFromCatalog.ps1 -Id skill-creator
+      .\Install-ToolFromCatalog.ps1 -Id skills-for-fabric   # prints the plugin's install command
+#>
+[CmdletBinding()]
+param(
+    [string]$Id,
+    [switch]$DryRun,
+    [string]$Root = (Get-Location).Path,
+    [string]$CatalogDir,
+    [string[]]$InstalledNames,
+    [string[]]$InstalledPlugins,
+    [string]$Dest,
+    [switch]$Force,
+    [string]$InstallSkillWith
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $InstallSkillWith) { $InstallSkillWith = Join-Path $PSScriptRoot 'Install-SkillFromRepo.ps1' }
+$resolver = Join-Path $PSScriptRoot 'Get-ToolsCatalog.ps1'
+
+# forward only supplied resolver params
+$fwd = @{ Root = $Root }
+if ($CatalogDir) { $fwd.CatalogDir = $CatalogDir }
+if ($PSBoundParameters.ContainsKey('InstalledNames'))   { $fwd.InstalledNames   = $InstalledNames }
+if ($PSBoundParameters.ContainsKey('InstalledPlugins')) { $fwd.InstalledPlugins = $InstalledPlugins }
+
+function Install-One($t) {
+    if (-not $t.installable) {
+        Write-Output ("  {0}: reference only (not installable). Open: {1}" -f $t.id, $t.url)
+        return [pscustomobject]@{ id=$t.id; action='reference'; installed=$false }
+    }
+    if ($t.installed) {
+        Write-Output ("  {0}: already installed - skipping." -f $t.id)
+        return [pscustomobject]@{ id=$t.id; action='skip-installed'; installed=$true }
+    }
+    if ($t.kind -eq 'plugin') {
+        Write-Output ("  {0}: plugin (all-or-nothing) - install it yourself:" -f $t.id)
+        Write-Output ("      {0}" -f $t.installMethod)
+        return [pscustomobject]@{ id=$t.id; action='surface-plugin'; installed=$false; command=$t.installMethod }
+    }
+    # skill-clone
+    if ($DryRun) {
+        Write-Output ("  {0}: WOULD clone {1}/{2} -> ~/.claude/skills/{3}" -f $t.id, $t.repo, $t.path, $t.name)
+        return [pscustomobject]@{ id=$t.id; action='dry-run'; installed=$false }
+    }
+    $iargs = @{ Repo=$t.repo; Path=$t.path; Name=$t.name }
+    if ($t.owner)   { $iargs.Owner   = $t.owner }
+    if ($t.license) { $iargs.License = $t.license }
+    if ($Dest)      { $iargs.Dest    = $Dest }
+    if ($Force)     { $iargs.Force   = $true }
+    $res = & $InstallSkillWith @iargs
+    Write-Output ("  {0}: installed (skill-clone {1}/{2})." -f $t.id, $t.repo, $t.path)
+    return [pscustomobject]@{ id=$t.id; action='install-skill'; installed=$true; result=$res }
+}
+
+if ($PSBoundParameters.ContainsKey('Id') -and $Id) {
+    $item = @((& $resolver @fwd -Id $Id).items)
+    if ($item.Count -eq 0) {
+        Write-Output "Tool '$Id' not found in the catalog. Run /tools browse to see valid ids."
+        return
+    }
+    return (Install-One $item[0])
+}
+
+Write-Output "Nothing to do: pass -Id <id> to install one tool (or -All once #388 lands)."

--- a/plugins/agentic-board/skills/tools-catalog/SKILL.md
+++ b/plugins/agentic-board/skills/tools-catalog/SKILL.md
@@ -35,13 +35,13 @@ method and note so the user reads the reference before deciding. `<id>` matches 
 tool name (case-insensitive). Never installs anything.
 
 ### install <id>  (confirm each; never duplicate)
-Install one item by KIND:
-- `skill-clone` → `scripts/Install-SkillFromRepo.ps1` (clean `--depth 1` clone, copy only the skill
-  folder, **preserve LICENSE**). Skipped with a note when `Get-SkillGaps.ps1` already shows it installed.
-- `plugin` (e.g. `microsoft/skills-for-fabric`) → all-or-nothing: SURFACE its own install command,
-  never cherry-pick a single skill out of it.
-
-The hardened selective-install path is delivered in #387.
+Run `scripts/Install-ToolFromCatalog.ps1 -Id <id>` — it resolves the item and installs by KIND:
+- `skill-clone` → delegates to `Install-SkillFromRepo.ps1` (clean `--depth 1` clone, copy only the
+  skill folder, **preserve LICENSE**). Skipped with a note when it already shows as installed.
+- `plugin` (e.g. `microsoft/skills-for-fabric`) → all-or-nothing: it SURFACES the install command for
+  the user to run, never cherry-picking a single skill out of it.
+- a bare `reference` (not installable) → reports the URL to open instead.
+Confirm before running; `-DryRun` previews. `<id>` matches the row id or the tool name.
 
 ### install --all  (one pass, one confirmation)
 Batch-install every MISSING installable in a single dry-run-then-confirm pass. Plugin-kind entries

--- a/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
@@ -1,0 +1,78 @@
+#Requires -Modules Pester
+<#  Tests for Install-ToolFromCatalog.ps1 (#387) — install ONE referenced tool by id.
+
+    skill-clone → delegates to the injected installer (real default: Install-SkillFromRepo.ps1).
+    plugin      → surfaces its own install command (all-or-nothing, never auto-run).
+    reference / already-installed / unknown id → clear no-op messages.
+    Network is never touched: the installer is injected via -InstallSkillWith and records its calls.
+#>
+
+BeforeAll {
+    $script:Install = Join-Path $PSScriptRoot '..' 'scripts' 'Install-ToolFromCatalog.ps1'
+
+    # --- fixtures: a plugin, a skill-clone, and a bare reference
+    $script:Root = Join-Path $TestDrive 'proj'
+    $regDir = Join-Path $script:Root 'knowledge'; New-Item -ItemType Directory -Force -Path $regDir | Out-Null
+    @{
+        version=1; project='proj'; domains=@('Vega')
+        references=@( @{ id='kn_002'; domain='Vega'; type='url'; title='Vega docs'; ref='https://vega.github.io/'; note='charts'; added='2026-07-22' } )
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $regDir 'registry.json') -Encoding utf8
+
+    $script:CatalogDir = Join-Path $TestDrive 'toolkits'; New-Item -ItemType Directory -Force -Path $script:CatalogDir | Out-Null
+    ,@( @{ name='skills-for-fabric'; owner='Microsoft'; repo='microsoft/skills-for-fabric'; kind='plugin'; detect='fabric-collection'; path=$null; homepage='https://github.com/microsoft/skills-for-fabric'; install='claude plugin marketplace add microsoft/skills-for-fabric'; purpose='Fabric skills.' } ) |
+        ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'bi.json') -Encoding utf8
+    ,@( @{ name='skill-creator'; owner='Anthropic'; repo='anthropics/skills'; kind='skill-clone'; detect=$null; path='skill-creator'; homepage='https://github.com/anthropics/skills'; license='Anthropic'; install=$null; purpose='Author skills.' } ) |
+        ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $script:CatalogDir 'quality.json') -Encoding utf8
+
+    # --- injected installer stub: records its args, never clones
+    $script:StubLog = Join-Path $TestDrive 'stub-calls.txt'
+    $script:Stub    = Join-Path $TestDrive 'Stub-Installer.ps1'
+    Set-Content -LiteralPath $script:Stub -Encoding utf8 -Value @'
+param([string]$Repo,[string]$Path,[string]$Name,[string]$Owner="",[string]$License="",[string]$Dest,[switch]$Force)
+"$Repo|$Path|$Name|$Owner|$License" | Add-Content -LiteralPath $env:ABIOS_STUB_LOG
+[pscustomobject]@{ name=$Name; installed=$true; source="$Repo/$Path" }
+'@
+    $env:ABIOS_STUB_LOG = $script:StubLog
+
+    $script:Base = @{ Root=$script:Root; CatalogDir=$script:CatalogDir; InstallSkillWith=$script:Stub; InstalledPlugins=@() }
+}
+
+Describe 'Install-ToolFromCatalog — install one (#387)' {
+    AfterEach { if (Test-Path $script:StubLog) { Remove-Item $script:StubLog -Force } }
+
+    It 'installs a skill-clone by delegating to the installer with repo/path/name' {
+        $out = (& $script:Install -Id 'skill-creator' @script:Base -InstalledNames @()) -join "`n"
+        (Get-Content -LiteralPath $script:StubLog -Raw) | Should -Match ([regex]::Escape('anthropics/skills|skill-creator|skill-creator'))
+        $out | Should -Match 'skill-creator'
+    }
+
+    It '-DryRun does NOT call the installer' {
+        $out = (& $script:Install -Id 'skill-creator' @script:Base -InstalledNames @() -DryRun) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match 'WOULD'
+    }
+
+    It 'surfaces the install command for a plugin instead of running it' {
+        $out = (& $script:Install -Id 'skills-for-fabric' @script:Base -InstalledNames @()) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match 'marketplace'
+        $out | Should -Match 'plugin'
+    }
+
+    It 'skips a tool that is already installed' {
+        $out = (& $script:Install -Id 'skill-creator' @script:Base -InstalledNames @('skill-creator')) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match 'already installed'
+    }
+
+    It 'refuses a bare reference (not installable)' {
+        $out = (& $script:Install -Id 'kn_002' @script:Base -InstalledNames @()) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match 'not installable'
+    }
+
+    It 'reports a clear message for an unknown id' {
+        $out = (& $script:Install -Id 'nope' @script:Base -InstalledNames @()) -join "`n"
+        $out | Should -Match 'not found'
+    }
+}


### PR DESCRIPTION
Closes #387