### PR TITLE
Install-all (one shot): batch-install every missing installable in a single pass with a dry-run summary + one confirmation; plugin entries listed separately (surfaced, not cherry-picked)

### DIFF
--- a/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
+++ b/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
@@ -20,6 +20,8 @@
 [CmdletBinding()]
 param(
     [string]$Id,
+    [switch]$All,
+    [switch]$Yes,
     [switch]$DryRun,
     [string]$Root = (Get-Location).Path,
     [string]$CatalogDir,
@@ -41,7 +43,7 @@ if ($CatalogDir) { $fwd.CatalogDir = $CatalogDir }
 if ($PSBoundParameters.ContainsKey('InstalledNames'))   { $fwd.InstalledNames   = $InstalledNames }
 if ($PSBoundParameters.ContainsKey('InstalledPlugins')) { $fwd.InstalledPlugins = $InstalledPlugins }
 
-function Install-One($t) {
+function Install-One($t, [bool]$dry) {
     if (-not $t.installable) {
         Write-Output ("  {0}: reference only (not installable). Open: {1}" -f $t.id, $t.url)
         return [pscustomobject]@{ id=$t.id; action='reference'; installed=$false }
@@ -56,7 +58,7 @@ function Install-One($t) {
         return [pscustomobject]@{ id=$t.id; action='surface-plugin'; installed=$false; command=$t.installMethod }
     }
     # skill-clone
-    if ($DryRun) {
+    if ($dry) {
         Write-Output ("  {0}: WOULD clone {1}/{2} -> ~/.claude/skills/{3}" -f $t.id, $t.repo, $t.path, $t.name)
         return [pscustomobject]@{ id=$t.id; action='dry-run'; installed=$false }
     }
@@ -76,7 +78,34 @@ if ($PSBoundParameters.ContainsKey('Id') -and $Id) {
         Write-Output "Tool '$Id' not found in the catalog. Run /tools browse to see valid ids."
         return
     }
-    return (Install-One $item[0])
+    return (Install-One $item[0] ([bool]$DryRun))
 }
 
-Write-Output "Nothing to do: pass -Id <id> to install one tool (or -All once #388 lands)."
+if ($All) {
+    $missing  = @((& $resolver @fwd -MissingOnly).items)
+    $skills   = @($missing | Where-Object { $_.kind -eq 'skill-clone' })
+    $plugins  = @($missing | Where-Object { $_.kind -eq 'plugin' })
+
+    if ($missing.Count -eq 0) {
+        Write-Output "install --all: nothing to install - every installable tool is already present."
+        return [pscustomobject]@{ installed=0; surfaced=0; missing=0 }
+    }
+
+    Write-Output ("install --all: {0} missing installable(s) - {1} skill-clone(s) to install, {2} plugin(s) to surface." -f $missing.Count, $skills.Count, $plugins.Count)
+    foreach ($s in $skills)  { Write-Output ("  - {0} (skill-clone {1}/{2})" -f $s.id, $s.repo, $s.path) }
+    foreach ($p in $plugins) { Write-Output ("  ~ {0} (plugin): {1}" -f $p.id, $p.installMethod) }
+
+    # Safe by default: only -Yes actually clones. Without it (or with -DryRun) this is a preview.
+    $proceed = $Yes -and -not $DryRun
+    if (-not $proceed) {
+        Write-Output "(preview) re-run with -Yes to install the skill-clone(s); plugins are surfaced for you to run."
+        return [pscustomobject]@{ installed=0; surfaced=$plugins.Count; missing=$missing.Count; previewed=$true }
+    }
+
+    $results = foreach ($t in $missing) { Install-One $t $false }
+    $done = @($results | Where-Object { $_.action -eq 'install-skill' }).Count
+    Write-Output ("install --all: installed {0} skill-clone(s); {1} plugin(s) surfaced." -f $done, $plugins.Count)
+    return [pscustomobject]@{ installed=$done; surfaced=$plugins.Count; missing=$missing.Count }
+}
+
+Write-Output "Nothing to do: pass -Id <id> to install one tool, or -All to install every missing installable."

--- a/plugins/agentic-board/skills/tools-catalog/SKILL.md
+++ b/plugins/agentic-board/skills/tools-catalog/SKILL.md
@@ -44,8 +44,10 @@ Run `scripts/Install-ToolFromCatalog.ps1 -Id <id>` — it resolves the item and 
 Confirm before running; `-DryRun` previews. `<id>` matches the row id or the tool name.
 
 ### install --all  (one pass, one confirmation)
-Batch-install every MISSING installable in a single dry-run-then-confirm pass. Plugin-kind entries
-are listed SEPARATELY (surfaced, not installed blindly). Delivered in #388.
+Run `scripts/Install-ToolFromCatalog.ps1 -All` — it lists every MISSING installable, skill-clones and
+plugins SEPARATELY, and is a safe preview by default (installs nothing). Show that plan to the user,
+get ONE confirmation, then re-run with `-All -Yes` to clone the skill-clones; plugin entries are
+always surfaced (their install command printed) for the user to run, never installed blindly.
 
 ## Identity
 `browse` and `research` need no token. An install that clones or files follows the `gh-account`

--- a/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
@@ -76,3 +76,35 @@ Describe 'Install-ToolFromCatalog — install one (#387)' {
         $out | Should -Match 'not found'
     }
 }
+
+Describe 'Install-ToolFromCatalog — install --all (#388)' {
+    AfterEach { if (Test-Path $script:StubLog) { Remove-Item $script:StubLog -Force } }
+
+    It '-All -DryRun lists skill-clones and plugins separately, installing nothing' {
+        $out = (& $script:Install -All @script:Base -InstalledNames @() -DryRun) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match '1 skill-clone\(s\) to install, 1 plugin\(s\)'
+        $out | Should -Match 'skill-creator \(skill-clone anthropics/skills'   # skill listed in the plan
+        $out | Should -Match 'marketplace'                                     # fabric plugin surfaced
+    }
+
+    It '-All without -Yes is a safe preview (no install)' {
+        $out = (& $script:Install -All @script:Base -InstalledNames @()) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match '-Yes'
+    }
+
+    It '-All -Yes installs the skill-clones and surfaces the plugins' {
+        $out = (& $script:Install -All @script:Base -InstalledNames @() -Yes) -join "`n"
+        (Get-Content -LiteralPath $script:StubLog -Raw) | Should -Match ([regex]::Escape('anthropics/skills|skill-creator|skill-creator'))
+        (Get-Content -LiteralPath $script:StubLog -Raw) | Should -Not -Match 'skills-for-fabric'  # plugin not auto-run
+        $out | Should -Match 'installed 1 skill-clone'
+    }
+
+    It '-All reports nothing to do when all installables are present' {
+        $b = $script:Base.Clone(); $b.InstalledPlugins = @('fabric-collection')
+        $out = (& $script:Install -All @b -InstalledNames @('skill-creator') -Yes) -join "`n"
+        (Test-Path $script:StubLog) | Should -BeFalse
+        $out | Should -Match 'nothing to install'
+    }
+}


### PR DESCRIPTION
Closes #388