### PR TITLE
fix(expert): repair the config CLI wiring so the synthesized role is usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- **`/agentic-board:expert config` produced an unusable role — objective and toolset both empty** (#441, #442).
+  Every contract `config` wrote carried a blank objective and no hooked skills; the failure was
+  invisible because the test suite called the pure functions directly and never exercised the
+  script's own wiring. Three defects: `Expert-Config.ps1` dot-sourced `Expert-RoleSynthesis.ps1`,
+  whose `param()` block executes in the caller's scope and reset `$PlanGoal` to `""` (#441 — the
+  arguments are now captured before any dot-source); both scripts called `Get-SkillInventory` as a
+  function, but the file is a *script* emitting a `{summary, skills, overlaps}` object, so the
+  dot-source ran the scan and dumped it to stdout while the swallowed `CommandNotFound` left the
+  inventory permanently empty (#442 — new `Resolve-SkillInventory` invokes the script with `&` and
+  maps records to names); and `Format-RoleObjective` could never reach its "none installed"
+  fallback, because `@($null).Count` is `1` in PowerShell, rendering a bare `- ` bullet instead.
+  Repaired alongside them, once the toolset became visible: `Get-HookedSkills` matched against the
+  full namespaced string — so the pattern `skill` hooked all 30 skills of a plugin merely named
+  `skills-for-copilot-studio` — and a scan crossing git worktrees listed each skill several times.
+  Matching is now against the skill name only, with deduplication. New CLI-level tests cover
+  `Expert-Config.ps1` end to end.
 
 ## [0.26.0] - 2026-07-27
 ### Added

--- a/plugins/agentic-board/scripts/Expert-Config.ps1
+++ b/plugins/agentic-board/scripts/Expert-Config.ps1
@@ -38,6 +38,12 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Capture our own arguments BEFORE any dot-source. A dot-sourced script's param() block executes
+# in THIS scope: Expert-RoleSynthesis declares $PlanGoal, so dot-sourcing it resets ours to "".
+$myPlanText = $PlanText
+$myPlanGoal = $PlanGoal
+$myPath     = $Path
+
 # Load the sibling pure cores with THEIR guards set, so dot-sourcing does not run their CLIs.
 $prevC = $env:ABIOS_EXPERTCONTRACT_DOTSOURCE
 $env:ABIOS_EXPERTCONTRACT_DOTSOURCE = '1'
@@ -64,15 +70,10 @@ function New-ExpertConfig {
 if ($env:ABIOS_EXPERTCONFIG_DOTSOURCE) { return }
 
 # ── CLI ─────────────────────────────────────────────────────────────────────────
-$inventory = @()
-try {
-    . (Join-Path $PSScriptRoot 'Get-SkillInventory.ps1')
-    $inv = Get-SkillInventory 2>$null
-    $inventory = @($inv | ForEach-Object { if ($_ -is [string]) { $_ } elseif ($_.name) { $_.name } })
-} catch { $inventory = @() }
+$inventory = Resolve-SkillInventory
 
-$contract = New-ExpertConfig -PlanText $PlanText -PlanGoal $PlanGoal -Inventory $inventory
-$target = if ($Path) { $Path } else { Get-ExpertContractPath }
+$contract = New-ExpertConfig -PlanText $myPlanText -PlanGoal $myPlanGoal -Inventory $inventory
+$target = if ($myPath) { $myPath } else { Get-ExpertContractPath }
 
 Write-Host "=== /board expert config ===" -ForegroundColor Cyan
 Write-Host ""

--- a/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
+++ b/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
@@ -59,12 +59,16 @@ function Get-DomainFromPlan {
 
 function Get-HookedSkills {
     param([string]$Domain, [string[]]$Inventory)
-    $inv = @($Inventory)
+    # Dedup: worktrees and nested checkouts make the scanner report the same skill repeatedly.
+    $inv = @(@($Inventory) | Where-Object { $_ } | Select-Object -Unique)
     $patterns = @($script:DomainSkillPatterns[$Domain])
     $hooked = [System.Collections.Generic.List[string]]::new()
     foreach ($s in $inv) {
+        # Match the skill NAME, never the plugin namespace that ships it — otherwise a broad
+        # pattern like 'skill' hooks every skill of a plugin merely named "skills-for-*".
+        $leaf = ($s -split ':')[-1].ToLowerInvariant()
         foreach ($p in $patterns) {
-            if ($s.ToLowerInvariant().Contains($p.ToLowerInvariant())) { $hooked.Add($s); break }
+            if ($leaf.Contains($p.ToLowerInvariant())) { $hooked.Add($s); break }
         }
     }
     # Always engage the quality profile where it is installed.
@@ -77,7 +81,10 @@ function Get-HookedSkills {
 
 function Format-RoleObjective {
     param([string]$Domain, [string[]]$HookedSkills, [string]$PlanGoal)
-    $skillList = if (@($HookedSkills).Count) { (@($HookedSkills) | ForEach-Object { "- $_" }) -join "`n" } else { "- (none installed — research the domain from scratch via /knowledge)" }
+    # Drop empties before counting: @($null).Count is 1 in PowerShell, so a naive count check
+    # skips the fallback and renders a bare "- " bullet.
+    $list = @(@($HookedSkills) | Where-Object { $_ })
+    $skillList = if ($list.Count) { ($list | ForEach-Object { "- $_" }) -join "`n" } else { "- (none installed — research the domain from scratch via /knowledge)" }
     @"
 ## Expert role (objective)
 
@@ -93,16 +100,27 @@ $skillList
 "@
 }
 
+# ── Inventory resolver (touches the filesystem; kept out of the pure core) ──────
+function Resolve-SkillInventory {
+    # Get-SkillInventory.ps1 is a SCRIPT emitting a {summary, skills, overlaps} object — there is
+    # no Get-SkillInventory *function*. Invoke it with & and never dot-source it: a dot-sourced
+    # param() block runs in THIS scope and would clobber same-named variables of the caller.
+    param([string]$Root, [string]$Scope = 'all')
+    $inv = Join-Path $PSScriptRoot 'Get-SkillInventory.ps1'
+    if (-not (Test-Path $inv)) { return @() }
+    $splat = @{}
+    if ($Root)  { $splat.Root  = $Root }
+    if ($Scope) { $splat.Scope = $Scope }
+    try { $result = & $inv @splat } catch { return @() }
+    @(@($result.skills) |
+        ForEach-Object { if ($_.namespace) { $_.namespace } elseif ($_.name) { $_.name } } |
+        Where-Object { $_ })
+}
+
 # Dot-source guard: tests set $env:ABIOS_EXPERTROLE_DOTSOURCE to load the pure core only.
 if ($env:ABIOS_EXPERTROLE_DOTSOURCE) { return }
 
 # ── CLI: synthesize the role from the live inventory ────────────────────────────
 $domain = Get-DomainFromPlan -Text $Text
-$inventory = @()
-try {
-    . (Join-Path $PSScriptRoot 'Get-SkillInventory.ps1')
-    $inv = Get-SkillInventory 2>$null
-    $inventory = @($inv | ForEach-Object { if ($_ -is [string]) { $_ } elseif ($_.name) { $_.name } })
-} catch { $inventory = @() }
-$hooked = Get-HookedSkills -Domain $domain -Inventory $inventory
+$hooked = Get-HookedSkills -Domain $domain -Inventory (Resolve-SkillInventory)
 Format-RoleObjective -Domain $domain -HookedSkills $hooked -PlanGoal $PlanGoal

--- a/plugins/agentic-board/tests/Expert-Config.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Config.Tests.ps1
@@ -32,3 +32,35 @@ Describe 'New-ExpertConfig' {
         (Read-ExpertContract -Path $script:Tmp).role | Should -Match 'semantic-model'
     }
 }
+
+Describe 'Expert-Config.ps1 (CLI wiring)' {
+    # The unit tests above call New-ExpertConfig directly, so they never exercise the script's own
+    # argument handling or inventory resolution — where both #441 and #442 lived.
+    BeforeAll {
+        $script:CliOut  = Join-Path ([System.IO.Path]::GetTempPath()) ("expcli-" + [guid]::NewGuid().ToString('N') + ".json")
+        $script:Stdout = & pwsh -NoProfile -File $script:Script `
+            -PlanText 'Refactor the plugin CLI command surface' `
+            -PlanGoal 'ZZZ-GOAL-MARKER' `
+            -Path $script:CliOut 2>&1 | Out-String
+        $script:Cli = if (Test-Path $script:CliOut) { Get-Content -Raw $script:CliOut | ConvertFrom-Json } else { $null }
+    }
+    AfterAll { if (Test-Path $script:CliOut) { Remove-Item $script:CliOut -Force } }
+
+    It 'writes a contract file' {
+        $script:Cli | Should -Not -BeNullOrEmpty
+    }
+    It 'carries the -PlanGoal through into the role objective' {
+        # Regression #441: a dot-sourced param() block reset $PlanGoal in the caller's scope.
+        $script:Cli.role | Should -Match 'ZZZ-GOAL-MARKER'
+    }
+    It 'hooks skills resolved from the real inventory' {
+        # Regression #442: Get-SkillInventory was called as a function that does not exist,
+        # so the swallowed error left the toolset permanently empty. Assert a NAMED skill —
+        # asserting only the absence of the fallback text passes vacuously on a blank bullet.
+        $script:Cli.role | Should -Match '(?m)^- \S'
+    }
+    It 'does not leak the inventory object into stdout' {
+        $script:Stdout | Should -Not -Match 'byScope'
+        $script:Stdout | Should -Not -Match 'is not recognized as a name of a cmdlet'
+    }
+}

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -50,6 +50,60 @@ Describe 'Get-HookedSkills' {
         $h | Should -Contain 'writing-skills'
         $h | Should -Not -Contain 'reports:deneb-visuals'
     }
+    It 'matches the skill name, not the plugin that ships it' {
+        # 'skills-for-copilot-studio:add-action' must NOT be hooked by the 'skill' pattern:
+        # the plugin namespace is not the skill. Real fallout — it dragged in 30 unrelated skills.
+        $inv = @('skills-for-copilot-studio:add-action','agentic-board:skills-audit')
+        $h = Get-HookedSkills -Domain 'extension' -Inventory $inv
+        $h | Should -Contain 'agentic-board:skills-audit'
+        $h | Should -Not -Contain 'skills-for-copilot-studio:add-action'
+    }
+    It 'deduplicates an inventory that lists the same skill twice' {
+        # Worktrees and nested checkouts make the scanner report the same skill many times.
+        $inv = @('agentic-board:skills-audit','agentic-board:skills-audit','skill-creator','skill-creator')
+        $h = Get-HookedSkills -Domain 'extension' -Inventory $inv
+        @($h).Count | Should -Be (@($h | Select-Object -Unique).Count)
+    }
+}
+
+Describe 'Resolve-SkillInventory' {
+    BeforeAll {
+        # A real fixture tree — Get-SkillInventory.ps1 is run for real against it, no mocks.
+        $script:Fixture = Join-Path ([System.IO.Path]::GetTempPath()) ("expinv-" + [guid]::NewGuid().ToString('N'))
+        foreach ($n in 'deneb-visuals','skill-creator') {
+            $d = Join-Path $script:Fixture ".claude/skills/demo/$n"
+            New-Item -ItemType Directory -Path $d -Force | Out-Null
+            Set-Content -Path (Join-Path $d 'SKILL.md') -Encoding utf8 -Value @"
+---
+name: $n
+description: Fixture skill $n. Use when testing the inventory resolver.
+---
+Body.
+"@
+        }
+    }
+    AfterAll { if (Test-Path $script:Fixture) { Remove-Item $script:Fixture -Recurse -Force } }
+
+    It 'resolves the skill names actually present under a root' {
+        $names = Resolve-SkillInventory -Root $script:Fixture -Scope project
+        $names | Should -Contain 'deneb-visuals'
+        $names | Should -Contain 'skill-creator'
+    }
+    It 'returns plain strings, not the inventory wrapper object' {
+        $names = Resolve-SkillInventory -Root $script:Fixture -Scope project
+        @($names).Count | Should -BeGreaterThan 0
+        foreach ($n in $names) { $n | Should -BeOfType [string] }
+    }
+    It 'feeds Get-HookedSkills so a domain actually hooks something' {
+        $names = Resolve-SkillInventory -Root $script:Fixture -Scope project
+        Get-HookedSkills -Domain 'powerbi-report' -Inventory $names | Should -Contain 'deneb-visuals'
+    }
+    It 'returns an empty list for a root with no skills instead of throwing' {
+        $empty = Join-Path ([System.IO.Path]::GetTempPath()) ("expinv-none-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $empty -Force | Out-Null
+        try { @(Resolve-SkillInventory -Root $empty -Scope project).Count | Should -Be 0 }
+        finally { Remove-Item $empty -Recurse -Force }
+    }
 }
 
 Describe 'Format-RoleObjective' {
@@ -59,5 +113,16 @@ Describe 'Format-RoleObjective' {
         $block | Should -Match 'powerbi-report'
         $block | Should -Match 'Ship a bar-chart visual'
         $block | Should -Match 'reports:deneb-visuals'
+    }
+    It 'renders the no-skills fallback when nothing is hooked' {
+        # @($null).Count is 1 in PowerShell, so a naive count check makes this branch unreachable
+        # and emits a bare "- " bullet instead.
+        Format-RoleObjective -Domain 'generic' -HookedSkills @() -PlanGoal 'g' | Should -Match 'none installed'
+    }
+    It 'renders the no-skills fallback when the hooked list is null' {
+        Format-RoleObjective -Domain 'generic' -HookedSkills $null -PlanGoal 'g' | Should -Match 'none installed'
+    }
+    It 'never emits a blank bullet' {
+        Format-RoleObjective -Domain 'generic' -HookedSkills $null -PlanGoal 'g' | Should -Not -Match '(?m)^- *$'
     }
 }


### PR DESCRIPTION
Closes #441

Fixes the `/agentic-board:expert config` verb, which shipped in 0.26.0 producing a role with **no objective and no toolset**.

Found by dogfooding: running `config` on a real plan rendered

```
You are an **expert in extension**. Your objective for this task:

>                       <- empty
Engage these installed skills as your working toolset:

-                       <- empty
```

## Defects

| Issue | Defect | Effect |
|---|---|---|
| #441 | `Expert-Config.ps1` dot-sourced `Expert-RoleSynthesis.ps1`, whose `param()` block runs in the **caller's scope** and reset `$PlanGoal` to `""` | every contract written with an empty objective |
| #442 | Both scripts called `Get-SkillInventory` as a function; the file is a *script* emitting `{summary, skills, overlaps}` | dot-source ran the scan and dumped it to stdout, then the swallowed `CommandNotFound` left the inventory permanently empty |
| - | `Format-RoleObjective` guarded on `@($HookedSkills).Count`, but `@($null).Count` is `1` in PowerShell | the `(none installed)` fallback was unreachable; an empty toolset rendered a bare `- ` bullet |
| - | `Get-HookedSkills` matched against the full namespaced string, and never deduplicated | the pattern `skill` hooked all 30 skills of a plugin named `skills-for-copilot-studio`, and a scan crossing git worktrees listed each skill several times - 80 bullets of noise |

The last two were **hidden behind the first two** and became visible only once the toolset rendered at all, so they are repaired here rather than deferred.

## Why no test caught this

The whole suite called the pure functions directly (`New-ExpertConfig`, `Format-RoleObjective`) or injected `-Inventory`. Nothing exercised the scripts' own argument handling or inventory resolution - exactly where all four defects lived.

## Changes

- `Expert-Config.ps1`: capture arguments **before** any dot-source; drop the duplicated inventory block.
- `Expert-RoleSynthesis.ps1`: new `Resolve-SkillInventory` (invokes the script with `&`, never dot-sources it, maps records to names); fallback guard filters empties; `Get-HookedSkills` matches the skill name only and deduplicates.
- Tests: CLI-level coverage of `Expert-Config.ps1` end to end, plus unit tests for `Resolve-SkillInventory` (against a real fixture tree), the fallback branch, namespace matching and dedup.

## Verification

- Targeted: 24/24 green. RED verified before every change - the 9 initial failures each failed for their real reason.
- Full suite: **1184 passed, 0 failed**.
- Live re-run of `config`: objective present, 19 unique hooked skills, no stdout leak.

## Known and deliberately out of scope

The `extension` role still hooks `marketplaces:example-skill` and `marketplaces:skill-development`, because its pattern is the over-broad literal `skill`. Fixing role **content** belongs to the roles-extensibility work being designed (moving the role map into `presets/`), not to this wiring fix.

Closes #441
Closes #442