### PR TITLE
feat(expert): extensible roles - a project-local role catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,13 @@ Thumbs.db
 # internal per-repo state (sessions, briefings, handoffs, fleet) — never commit.
 # both names: .agentic-board/ is the current name, .agentic-bi-ops/ the pre-rebrand
 # one still present in repos until the one-time migration runs (Get-AbiosStateDir).
-.agentic-board/
-.agentic-bi-ops/
+# roles.json is the exception: the expert role catalog is shared team knowledge, so it IS
+# versioned. Exclude the directory's CONTENTS rather than the directory itself — git cannot
+# re-include a file whose parent directory is excluded.
+.agentic-board/*
+!.agentic-board/roles.json
+.agentic-bi-ops/*
+!.agentic-bi-ops/roles.json
 **/.backups/
 *.items.json
 *.project.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- **Expert roles are now extensible per project** (#444; #445–#454).
+  The five built-in roles moved out of `Expert-RoleSynthesis.ps1` into a shipped
+  `presets/roles.json`, alongside the fields/labels/toolkit presets the plugin already ships, and
+  a project may add `.agentic-board/roles.json` (versioned in git) to add, extend or override
+  roles: `keywords`/`skills` union with the factory role of the same name,
+  `agent`/`standards`/`knowledgeDomain` replace it, and `"replace": true` drops the factory values
+  entirely. Local roles are evaluated first, so a project can always outrank a factory role, and a
+  merged role takes the local position. Before this, any project outside Power BI / semantic
+  models / Fabric / plugin-development resolved to `generic`, whose skill list is empty, and the
+  only fix was editing the plugin's source.
+  A role gives its expert a persona by **pointing at an existing agent definition** (`agents/*.md`,
+  the same registry the Agent tool resolves) rather than restating one — inline `standards` remain
+  as the shortcut. A plan matching no role is now reported (`roleMatched`) so the expert can
+  research the domain, propose a role and persist it with `Add-ExpertRole` **on the user's
+  confirmation** — never silently, since it changes how every future plan is classified.
+  New `/agentic-board:expert roles` verb (`Expert-Roles.ps1`): `list` prints the effective catalog
+  with each role's source and **how many installed skills it actually hooks** — a role that hooks
+  zero looks fine on paper and gives the expert no toolset — and `why "<text>"` explains which
+  keyword in which role decided a match. A broken local catalog never degrades the expert below
+  the factory roles (`ExpertRolesIo.ps1`), and `.gitignore` now exempts `roles.json` from the
+  `.agentic-board/` exclusion by excluding the directory's contents, since git cannot re-include a
+  file whose parent directory is excluded.
+
 ### Fixed
 - **`/agentic-board:expert config` produced an unusable role — objective and toolset both empty** (#441, #442).
   Every contract `config` wrote carried a blank objective and no hooked skills; the failure was

--- a/plugins/agentic-board/commands/expert.md
+++ b/plugins/agentic-board/commands/expert.md
@@ -15,6 +15,11 @@ for the user to pick (they can answer with just the number):
                      construye, prueba dejando evidencia, se auto-usa agentic-board para el
                      trabajo lateral que encuentra, y FRENA antes de lo irreversible (merge/
                      deploy/refresh/publish/delete) — deja el PR listo para tu OK.
+3. roles [why "<texto>"]
+                   → ver el CATÁLOGO de roles efectivo (los de fábrica + los locales del
+                     proyecto, marcando cuál sobreescribe a cuál y cuántas skills engancha de
+                     verdad). Con `why` explica qué rol ganó para un texto de plan y por qué
+                     keyword.
 ```
 
 First apply the `gh-account` skill to set `$env:GH_TOKEN` for the right account (default
@@ -27,6 +32,20 @@ plan's domain, hooks the installed skills/profiles for it, synthesizes the role-
 autonomy brakes only on the irreversible, evidence goes to three places (PR + `[abios-evidence]`
 issue comment + versioned file), board self-drive is on with a cap, and a budget bounds the run.
 Show the role preview and let the user edit it before running `auto`.
+
+If it reports **NO ROLE MATCHED**, research the plan's domain (via `/knowledge`, and `/tools` for
+ready-made agent definitions such as `wshobson/agents`), propose a complete role — `name`,
+`keywords`, `skills`, and an `agent` pointer when a fitting definition exists — and persist it with
+`Add-ExpertRole` **only after the user confirms**: writing a role changes how every future plan is
+classified, so it is never a silent side effect of `config`.
+
+## roles
+Run `scripts/Expert-Roles.ps1 -List`, or `scripts/Expert-Roles.ps1 -Why "<plan text>"`.
+
+The catalog is `presets/roles.json` (factory) merged with `.agentic-board/roles.json` (this
+project, versioned in git). Local roles are evaluated first, so a project can always outrank a
+factory role. A role hooking **0 skills** is printed in yellow: it will give the expert no
+toolset. See `references/roles.md` for the schema and the merge rules.
 
 ## auto
 Run `scripts/Expert-Auto.ps1 -Issue <n> -ProjectNum <n>`. It reads the contract, composes the

--- a/plugins/agentic-board/presets/roles.json
+++ b/plugins/agentic-board/presets/roles.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "qualityProfile": ["skill-creator", "writing-skills", "skill-improver", "second-opinion"],
+  "roles": [
+    {
+      "name": "powerbi-report",
+      "keywords": ["deneb", "visual", "chart", "dashboard", "report", "pbir", "svg"],
+      "skills": ["report", "deneb", "pbi", "svg-visuals", "python-visuals", "r-visuals", "theme"]
+    },
+    {
+      "name": "semantic-model",
+      "keywords": ["tmdl", "dax", "measure", "semantic model", "tabular", "bpa", "relationship"],
+      "skills": ["semantic-model", "tmdl", "dax", "tabular", "bpa", "power-query", "lineage"]
+    },
+    {
+      "name": "fabric",
+      "keywords": ["fabric", "lakehouse", "warehouse", "pipeline", "notebook", "spark", "eventhouse"],
+      "skills": ["fabric", "spark", "warehouse", "lakehouse", "eventhouse", "dataflow", "activator"]
+    },
+    {
+      "name": "extension",
+      "keywords": ["extension", "plugin", "cli", "command", "vs code", "vscode"],
+      "skills": ["frontend-design", "skill", "writing-skills"]
+    },
+    {
+      "name": "generic",
+      "keywords": [],
+      "skills": []
+    }
+  ]
+}

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -50,11 +50,17 @@ function Format-AutoBrief {
     $irr = @()
     if ($Contract.autonomy -and $Contract.autonomy.irreversible) { $irr = @($Contract.autonomy.irreversible) }
     $irrList = ($irr -join ', ')
+    # A role may name an agent definition; its persona is already folded into $RoleObjective,
+    # and naming it here lets the launched run adopt it as its agent type too.
+    $agentLine = if ($Contract.roleAgent) {
+        "`nAdopt the agent type ``$($Contract.roleAgent)`` for this run — its definition is your persona.`n"
+    } else { '' }
 
     @"
 # Autonomous brief — /board expert auto
 
 $RoleObjective
+$agentLine
 
 ## Plan (what to deliver)
 $PlanBody

--- a/plugins/agentic-board/scripts/Expert-Config.ps1
+++ b/plugins/agentic-board/scripts/Expert-Config.ps1
@@ -57,12 +57,17 @@ $env:ABIOS_EXPERTROLE_DOTSOURCE = $prevR
 
 # ── Pure core ───────────────────────────────────────────────────────────────────
 function New-ExpertConfig {
-    param([string]$PlanText, [string]$PlanGoal, [string[]]$Inventory = @())
-    $domain = Get-DomainFromPlan -Text $PlanText
-    $hooked = Get-HookedSkills -Domain $domain -Inventory $Inventory
-    $role   = Format-RoleObjective -Domain $domain -HookedSkills $hooked -PlanGoal $PlanGoal
+    [CmdletBinding()]
+    param([string]$PlanText, [string]$PlanGoal, [string[]]$Inventory = @(), [hashtable]$Catalog)
+    if (-not $Catalog) { $Catalog = Get-ExpertRoles }
+    $domain  = Get-DomainFromPlan -Text $PlanText -Catalog $Catalog
+    $role    = @($Catalog.roles) | Where-Object { $_.name -eq $domain } | Select-Object -First 1
+    $hooked  = Get-HookedSkills -Domain $domain -Inventory $Inventory -Catalog $Catalog
+    $persona = if ($role) { Resolve-RolePersona -Role $role } else { '' }
     $c = New-ExpertContract
-    $c.role = $role
+    $c.role        = Format-RoleObjective -Domain $domain -HookedSkills $hooked -PlanGoal $PlanGoal -Persona $persona
+    $c.roleMatched = ($domain -ne 'generic')
+    if ($role -and $role.agent) { $c.roleAgent = [string]$role.agent }
     $c
 }
 
@@ -80,6 +85,13 @@ Write-Host ""
 Write-Host "Synthesized role (editable preview):" -ForegroundColor Cyan
 Write-Host $contract.role -ForegroundColor Gray
 Write-Host ""
+if (-not $contract.roleMatched) {
+    Write-Host "  NO ROLE MATCHED this plan - the expert would run as 'generic', with no domain toolset." -ForegroundColor Yellow
+    Write-Host "  Research the plan's domain and propose a role, then persist it with:" -ForegroundColor DarkGray
+    Write-Host "    Add-ExpertRole -Role @{ name='<domain>'; keywords=@(...); skills=@(...) }" -ForegroundColor DarkGray
+    Write-Host "  Never write it without the user's confirmation: it changes how every future plan is classified." -ForegroundColor DarkGray
+    Write-Host ""
+}
 $written = Write-ExpertContract -Contract $contract -Path $target
 Write-Host "  OK  contract written -> $written" -ForegroundColor Green
 Write-Host "      autonomy brakes only on: $($contract.autonomy.irreversible -join ', ')" -ForegroundColor DarkGray

--- a/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
+++ b/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
@@ -23,58 +23,50 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# The role catalog lives in files, not here. Load the reader with ITS guard set so dot-sourcing
+# does not run its CLI.
+$prevRoles = $env:ABIOS_EXPERTROLES_DOTSOURCE
+$env:ABIOS_EXPERTROLES_DOTSOURCE = '1'
+. (Join-Path $PSScriptRoot 'ExpertRolesIo.ps1')
+$env:ABIOS_EXPERTROLES_DOTSOURCE = $prevRoles
+
 # ── Pure core ───────────────────────────────────────────────────────────────────
 
-# Domain keyword map. Order = precedence: the first domain with a keyword hit wins, so the
-# more specific BI domains are checked before the broad 'extension' catch.
-$script:DomainKeywords = [ordered]@{
-    'powerbi-report'  = @('deneb','visual','chart','dashboard','report','pbir','svg')
-    'semantic-model'  = @('tmdl','dax','measure','semantic model','tabular','bpa','relationship')
-    'fabric'          = @('fabric','lakehouse','warehouse','pipeline','notebook','spark','eventhouse')
-    'extension'       = @('extension','plugin','cli','command','vs code','vscode')
-}
-
-# Domain -> skill-name patterns to hook from the installed inventory.
-$script:DomainSkillPatterns = @{
-    'powerbi-report' = @('report','deneb','pbi','svg-visuals','python-visuals','r-visuals','theme')
-    'semantic-model' = @('semantic-model','tmdl','dax','tabular','bpa','power-query','lineage')
-    'fabric'         = @('fabric','spark','warehouse','lakehouse','eventhouse','dataflow','activator')
-    'extension'      = @('frontend-design','skill','writing-skills')
-    'generic'        = @()
-}
-
-# The quality profile — always engaged, whatever the domain (good engineering hygiene).
-$script:QualityProfile = @('skill-creator','writing-skills','skill-improver','second-opinion')
-
 function Get-DomainFromPlan {
-    param([string]$Text)
+    # Order is precedence: local roles first, then factory, most specific first within each.
+    [CmdletBinding()]
+    param([string]$Text, [hashtable]$Catalog)
+    if (-not $Catalog) { $Catalog = Get-ExpertRoles }
     $t = ($Text ?? '').ToLowerInvariant()
-    foreach ($domain in $script:DomainKeywords.Keys) {
-        foreach ($kw in $script:DomainKeywords[$domain]) {
-            if ($t.Contains($kw)) { return $domain }
+    foreach ($role in @($Catalog.roles)) {
+        foreach ($kw in @($role.keywords)) {
+            if ($kw -and $t.Contains(([string]$kw).ToLowerInvariant())) { return $role.name }
         }
     }
     'generic'
 }
 
 function Get-HookedSkills {
-    param([string]$Domain, [string[]]$Inventory)
+    [CmdletBinding()]
+    param([string]$Domain, [string[]]$Inventory, [hashtable]$Catalog)
+    if (-not $Catalog) { $Catalog = Get-ExpertRoles }
     # Dedup: worktrees and nested checkouts make the scanner report the same skill repeatedly.
-    $inv = @(@($Inventory) | Where-Object { $_ } | Select-Object -Unique)
-    $patterns = @($script:DomainSkillPatterns[$Domain])
+    $inv  = @(@($Inventory) | Where-Object { $_ } | Select-Object -Unique)
+    $role = @($Catalog.roles) | Where-Object { $_.name -eq $Domain } | Select-Object -First 1
+    $patterns = @($role.skills)
     $hooked = [System.Collections.Generic.List[string]]::new()
     foreach ($s in $inv) {
         # Match the skill NAME, never the plugin namespace that ships it — otherwise a broad
         # pattern like 'skill' hooks every skill of a plugin merely named "skills-for-*".
         $leaf = ($s -split ':')[-1].ToLowerInvariant()
         foreach ($p in $patterns) {
-            if ($leaf.Contains($p.ToLowerInvariant())) { $hooked.Add($s); break }
+            if ($p -and $leaf.Contains(([string]$p).ToLowerInvariant())) { $hooked.Add($s); break }
         }
     }
     # Always engage the quality profile where it is installed.
     foreach ($s in $inv) {
         $leaf = ($s -split ':')[-1]
-        if (($script:QualityProfile -contains $leaf) -and (-not $hooked.Contains($s))) { $hooked.Add($s) }
+        if ((@($Catalog.qualityProfile) -contains $leaf) -and (-not $hooked.Contains($s))) { $hooked.Add($s) }
     }
     $hooked.ToArray()
 }

--- a/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
+++ b/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
@@ -71,12 +71,64 @@ function Get-HookedSkills {
     $hooked.ToArray()
 }
 
+function Find-AgentDefinition {
+    # Agent definitions are <root>/**/agents/<stem>.md. A 'plugin:agent' name resolves by stem —
+    # the namespace is how the Agent tool disambiguates, not part of the filename.
+    [CmdletBinding()]
+    param([string]$Name, [string[]]$SearchRoots)
+    if (-not $Name) { return $null }
+    $stem = ($Name -split ':')[-1]
+    foreach ($root in @($SearchRoots)) {
+        if (-not $root -or -not (Test-Path -LiteralPath $root)) { continue }
+        $hit = Get-ChildItem -LiteralPath $root -Recurse -File -Filter "$stem.md" -ErrorAction SilentlyContinue |
+               Where-Object { ($_.FullName -replace '\\','/') -match '/agents/' } |
+               Select-Object -First 1
+        if ($hit) { return $hit.FullName }
+    }
+    $null
+}
+
+function Get-DefaultAgentRoots {
+    $userHome = $env:USERPROFILE; if (-not $userHome) { $userHome = $HOME }
+    @(
+        (Join-Path (Get-Location).Path '.claude'),
+        (Split-Path $PSScriptRoot -Parent),
+        (Join-Path $userHome '.claude/agents'),
+        (Join-Path $userHome '.claude/plugins/cache')
+    ) | Where-Object { $_ }
+}
+
+function Resolve-RolePersona {
+    # A role's persona comes from an existing agent definition rather than restating one.
+    # Inline standards are the shortcut for when no definition is worth creating.
+    [CmdletBinding()]
+    param([hashtable]$Role, [string[]]$SearchRoots)
+    if (-not $SearchRoots) { $SearchRoots = Get-DefaultAgentRoots }
+    if ($Role.agent) {
+        $path = Find-AgentDefinition -Name $Role.agent -SearchRoots $SearchRoots
+        if ($path) {
+            # Drop the frontmatter block; the body is the persona.
+            $raw = Get-Content -Raw -LiteralPath $path
+            return ($raw -replace '(?s)^\s*---.*?---\s*', '').Trim()
+        }
+        Write-Warning "roles: role '$($Role.name)' names agent '$($Role.agent)', which is not installed - install it with /tools, or the role falls back to its standards."
+    }
+    if ($Role.standards) { return (@($Role.standards) -join "`n") }
+    ''
+}
+
 function Format-RoleObjective {
-    param([string]$Domain, [string[]]$HookedSkills, [string]$PlanGoal)
+    param([string]$Domain, [string[]]$HookedSkills, [string]$PlanGoal, [string]$Persona)
     # Drop empties before counting: @($null).Count is 1 in PowerShell, so a naive count check
     # skips the fallback and renders a bare "- " bullet.
     $list = @(@($HookedSkills) | Where-Object { $_ })
     $skillList = if ($list.Count) { ($list | ForEach-Object { "- $_" }) -join "`n" } else { "- (none installed — research the domain from scratch via /knowledge)" }
+    $standards = if ($Persona) { $Persona } else {
+@"
+Your standards: you research prior-art before building (register findings via ``/knowledge``),
+you build test-first, you record evidence of every test, and you never ship past a failing gate.
+"@
+    }
     @"
 ## Expert role (objective)
 
@@ -84,8 +136,7 @@ You are an **expert in $Domain**. Your objective for this task:
 
 > $PlanGoal
 
-Your standards: you research prior-art before building (register findings via ``/knowledge``),
-you build test-first, you record evidence of every test, and you never ship past a failing gate.
+$standards
 Engage these installed skills as your working toolset:
 
 $skillList

--- a/plugins/agentic-board/scripts/Expert-Roles.ps1
+++ b/plugins/agentic-board/scripts/Expert-Roles.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    /board expert `roles` — show the effective role catalog and explain how a plan matches.
+
+.DESCRIPTION
+    `-List` prints every role in precedence order with its source (factory / local / local
+    overriding factory) and how many installed skills it actually hooks — the honest column: a
+    role that hooks zero skills looks fine on paper and is useless in practice.
+    `-Why "<plan text>"` prints the resolution trace: which roles were evaluated, in order, and
+    which keyword in which role decided the match.
+
+    Pure core behind a dot-source guard ($env:ABIOS_EXPERTROLESCMD_DOTSOURCE).
+
+.EXAMPLE
+    .\Expert-Roles.ps1 -List
+    .\Expert-Roles.ps1 -Why "Build a Deneb bar chart"
+#>
+[CmdletBinding()]
+param([switch]$List, [string]$Why = "")
+
+$ErrorActionPreference = "Stop"
+
+# Load the sibling cores with THEIR guards set, so dot-sourcing does not run their CLIs.
+$prevRoles = $env:ABIOS_EXPERTROLES_DOTSOURCE
+$env:ABIOS_EXPERTROLES_DOTSOURCE = '1'
+. (Join-Path $PSScriptRoot 'ExpertRolesIo.ps1')
+$env:ABIOS_EXPERTROLES_DOTSOURCE = $prevRoles
+
+$prevSyn = $env:ABIOS_EXPERTROLE_DOTSOURCE
+$env:ABIOS_EXPERTROLE_DOTSOURCE = '1'
+. (Join-Path $PSScriptRoot 'Expert-RoleSynthesis.ps1')
+$env:ABIOS_EXPERTROLE_DOTSOURCE = $prevSyn
+
+# Capture our own arguments AFTER the dot-sources: a dot-sourced param() block runs in this
+# scope, and Expert-RoleSynthesis declares $Text/$PlanGoal. Ours survive only because they are
+# named differently — re-read them here so the CLI below cannot be surprised by a future clash.
+$myList = $List
+$myWhy  = $Why
+
+# ── Pure core ───────────────────────────────────────────────────────────────────
+function Get-RoleSource {
+    [CmdletBinding()]
+    param([hashtable]$Role, [hashtable]$Factory, [hashtable]$Local)
+    $inFactory = @($Factory.roles.name) -contains $Role.name
+    $inLocal   = @($Local.roles.name)   -contains $Role.name
+    if ($inLocal -and $inFactory) { return 'local (overrides factory)' }
+    if ($inLocal)                 { return 'local' }
+    'factory'
+}
+
+function Get-RoleMatchTrace {
+    [CmdletBinding()]
+    param([string]$Text, [hashtable]$Catalog)
+    $t = ($Text ?? '').ToLowerInvariant()
+    $evaluated = [System.Collections.Generic.List[string]]::new()
+    foreach ($role in @($Catalog.roles)) {
+        $evaluated.Add($role.name) | Out-Null
+        foreach ($kw in @($role.keywords)) {
+            if ($kw -and $t.Contains(([string]$kw).ToLowerInvariant())) {
+                return @{ role = $role.name; keyword = [string]$kw; evaluated = $evaluated.ToArray() }
+            }
+        }
+    }
+    @{ role = 'generic'; keyword = $null; evaluated = $evaluated.ToArray() }
+}
+
+# Dot-source guard: tests set $env:ABIOS_EXPERTROLESCMD_DOTSOURCE to load the pure core only.
+if ($env:ABIOS_EXPERTROLESCMD_DOTSOURCE) { return }
+
+# ── CLI ─────────────────────────────────────────────────────────────────────────
+$catalog = Get-ExpertRoles
+
+if ($myWhy) {
+    $trace = Get-RoleMatchTrace -Text $myWhy -Catalog $catalog
+    Write-Host "=== /board expert roles why ===" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Evaluated (in precedence order): $($trace.evaluated -join ' -> ')" -ForegroundColor DarkGray
+    if ($trace.keyword) {
+        Write-Host "  MATCH  '$($trace.role)' on keyword '$($trace.keyword)'" -ForegroundColor Green
+    } else {
+        Write-Host "  NO MATCH - falling back to 'generic'." -ForegroundColor Yellow
+        Write-Host "  Add a role in .agentic-board/roles.json, or run /board expert config to synthesize one." -ForegroundColor DarkGray
+    }
+    return
+}
+
+$factory   = Get-ExpertRoles -PresetPath (Get-ExpertRolePresetPath) -LocalPath '' -NoCache
+$localRaw  = Read-ExpertRoleFile -Path (Get-ExpertRoleLocalPath)
+$local     = if ($localRaw) { $localRaw } else { @{ roles = @() } }
+$inventory = Resolve-SkillInventory
+
+Write-Host "=== /board expert roles ===" -ForegroundColor Cyan
+Write-Host ""
+Write-Host ("  {0,-22} {1,-26} {2,8} {3,7}" -f 'ROLE','SOURCE','KEYWORDS','HOOKS') -ForegroundColor DarkGray
+foreach ($role in @($catalog.roles)) {
+    $hooks  = @(Get-HookedSkills -Domain $role.name -Inventory $inventory -Catalog $catalog).Count
+    $colour = if ($hooks -eq 0 -and @($role.keywords).Count -gt 0) { 'Yellow' } else { 'Gray' }
+    Write-Host ("  {0,-22} {1,-26} {2,8} {3,7}" -f `
+        $role.name, (Get-RoleSource -Role $role -Factory $factory -Local $local), `
+        @($role.keywords).Count, $hooks) -ForegroundColor $colour
+}
+Write-Host ""
+Write-Host "  Local catalog: $(Get-ExpertRoleLocalPath)" -ForegroundColor DarkGray
+Write-Host "  A role hooking 0 skills will give the expert no toolset - fix its 'skills' patterns." -ForegroundColor DarkGray

--- a/plugins/agentic-board/scripts/ExpertRolesIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertRolesIo.ps1
@@ -37,6 +37,30 @@ function Read-ExpertRoleFile {
     }
 }
 
+function Select-ValidExpertRoles {
+    # A structurally broken role costs only itself. The rest of the file still loads.
+    # CmdletBinding makes this an advanced function, so callers can capture or silence its
+    # warnings with -WarningVariable / -WarningAction. Without it those are silently inert.
+    [CmdletBinding()]
+    param([object[]]$Roles)
+    $out = [System.Collections.Specialized.OrderedDictionary]::new()
+    foreach ($r in @($Roles)) {
+        if (-not $r.name) {
+            Write-Warning "roles: a role without a 'name' was skipped."
+            continue
+        }
+        if ($null -eq $r.keywords -or $null -eq $r.skills) {
+            Write-Warning "roles: role '$($r.name)' is missing 'keywords' or 'skills' - skipped."
+            continue
+        }
+        if ($out.Contains($r.name)) {
+            Write-Warning "roles: role '$($r.name)' is declared more than once - the last declaration wins."
+        }
+        $out[$r.name] = $r
+    }
+    @($out.Values)
+}
+
 function Merge-ExpertRoles {
     param([hashtable]$Factory, [hashtable]$Local)
     $factoryRoles = @($Factory.roles)
@@ -98,6 +122,15 @@ function Get-ExpertRoles {
 
     if (-not $PSBoundParameters.ContainsKey('LocalPath')) { $LocalPath = Get-ExpertRoleLocalPath }
     $local = Read-ExpertRoleFile -Path $LocalPath
+    if ($local) {
+        $v = if ($local.ContainsKey('version')) { [int]$local.version } else { 0 }
+        if ($v -ne $script:ExpertRolesSchemaVersion) {
+            Write-Warning "roles: '$LocalPath' declares version '$v'; this build understands version $($script:ExpertRolesSchemaVersion) - ignoring the file."
+            $local = $null
+        } else {
+            $local.roles = Select-ValidExpertRoles -Roles @($local.roles)
+        }
+    }
     $catalog = Merge-ExpertRoles -Factory $factory -Local $local
     if ($usingDefaults) { $script:ExpertRolesCache = $catalog }
     $catalog

--- a/plugins/agentic-board/scripts/ExpertRolesIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertRolesIo.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+    Load and merge the /board expert role catalog — shipped preset + optional project-local file.
+
+.DESCRIPTION
+    Roles are data, not code. presets/roles.json ships the factory catalog; a project may add
+    .agentic-board/roles.json (versioned in git) to add, extend or override roles. This script is
+    the single place that knows roles live in files.
+
+    Pure filesystem IO (no gh) behind a dot-source guard ($env:ABIOS_EXPERTROLES_DOTSOURCE).
+
+.EXAMPLE
+    . .\ExpertRolesIo.ps1 ; (Get-ExpertRoles).roles.name
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$script:ExpertRolesSchemaVersion = 1
+$script:ExpertRolesCache = $null
+
+function Clear-ExpertRolesCache { $script:ExpertRolesCache = $null }
+
+function Get-ExpertRolePresetPath {
+    Join-Path (Split-Path $PSScriptRoot -Parent) 'presets/roles.json'
+}
+
+function Read-ExpertRoleFile {
+    param([string]$Path)
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return $null }
+    try {
+        Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -AsHashtable
+    } catch {
+        Write-Warning "roles: could not parse '$Path' ($($_.Exception.Message)) - ignoring it."
+        $null
+    }
+}
+
+function Get-ExpertRoles {
+    param([string]$PresetPath, [string]$LocalPath, [switch]$NoCache)
+    $usingDefaults = -not $PresetPath -and -not $PSBoundParameters.ContainsKey('LocalPath')
+    if ($script:ExpertRolesCache -and -not $NoCache -and $usingDefaults) {
+        return $script:ExpertRolesCache
+    }
+    if (-not $PresetPath) { $PresetPath = Get-ExpertRolePresetPath }
+
+    $factory = Read-ExpertRoleFile -Path $PresetPath
+    if (-not $factory) { throw "roles: the shipped preset is missing or unreadable at '$PresetPath' - this is a broken install." }
+
+    $catalog = @{
+        roles          = @($factory.roles)
+        qualityProfile = @($factory.qualityProfile)
+    }
+    if ($usingDefaults) { $script:ExpertRolesCache = $catalog }
+    $catalog
+}
+
+# Dot-source guard: tests set $env:ABIOS_EXPERTROLES_DOTSOURCE to load the functions only.
+if ($env:ABIOS_EXPERTROLES_DOTSOURCE) { return }
+
+# CLI: print the effective catalog as JSON.
+(Get-ExpertRoles) | ConvertTo-Json -Depth 8

--- a/plugins/agentic-board/scripts/ExpertRolesIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertRolesIo.ps1
@@ -37,6 +37,54 @@ function Read-ExpertRoleFile {
     }
 }
 
+function Merge-ExpertRoles {
+    param([hashtable]$Factory, [hashtable]$Local)
+    $factoryRoles = @($Factory.roles)
+    $quality      = @($Factory.qualityProfile)
+    if (-not $Local) { return @{ roles = $factoryRoles; qualityProfile = $quality } }
+
+    if ($Local.ContainsKey('qualityProfile') -and $null -ne $Local.qualityProfile) {
+        $quality = @($Local.qualityProfile)
+    }
+
+    $merged  = [System.Collections.Generic.List[object]]::new()
+    $claimed = [System.Collections.Generic.HashSet[string]]::new()
+
+    foreach ($l in @($Local.roles)) {
+        $f = $factoryRoles | Where-Object { $_.name -eq $l.name } | Select-Object -First 1
+        if ($f -and -not $l.replace) {
+            # Union the list fields; the pointer fields replace wholesale.
+            $role = @{
+                name     = $l.name
+                keywords = @(@(@($f.keywords) + @($l.keywords)) | Where-Object { $_ } | Select-Object -Unique)
+                skills   = @(@(@($f.skills)   + @($l.skills))   | Where-Object { $_ } | Select-Object -Unique)
+            }
+            foreach ($k in 'agent','standards','knowledgeDomain') {
+                if ($l.ContainsKey($k) -and $null -ne $l[$k]) { $role[$k] = $l[$k] }
+                elseif ($f.ContainsKey($k) -and $null -ne $f[$k]) { $role[$k] = $f[$k] }
+            }
+            # An explicit agent supersedes inherited prose, so the two never both apply.
+            if ($l.ContainsKey('agent') -and $l.agent) { $role.Remove('standards') }
+        } else {
+            $role = @{}
+            foreach ($k in $l.Keys) { if ($k -ne 'replace') { $role[$k] = $l[$k] } }
+        }
+        $merged.Add($role) | Out-Null
+        $claimed.Add($l.name) | Out-Null
+    }
+    foreach ($f in $factoryRoles) {
+        if (-not $claimed.Contains($f.name)) { $merged.Add($f) | Out-Null }
+    }
+    @{ roles = $merged.ToArray(); qualityProfile = $quality }
+}
+
+function Get-ExpertRoleLocalPath {
+    . (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')
+    $dir = Get-AbiosStateDir
+    if (-not $dir) { return $null }
+    Join-Path $dir 'roles.json'
+}
+
 function Get-ExpertRoles {
     param([string]$PresetPath, [string]$LocalPath, [switch]$NoCache)
     $usingDefaults = -not $PresetPath -and -not $PSBoundParameters.ContainsKey('LocalPath')
@@ -48,10 +96,9 @@ function Get-ExpertRoles {
     $factory = Read-ExpertRoleFile -Path $PresetPath
     if (-not $factory) { throw "roles: the shipped preset is missing or unreadable at '$PresetPath' - this is a broken install." }
 
-    $catalog = @{
-        roles          = @($factory.roles)
-        qualityProfile = @($factory.qualityProfile)
-    }
+    if (-not $PSBoundParameters.ContainsKey('LocalPath')) { $LocalPath = Get-ExpertRoleLocalPath }
+    $local = Read-ExpertRoleFile -Path $LocalPath
+    $catalog = Merge-ExpertRoles -Factory $factory -Local $local
     if ($usingDefaults) { $script:ExpertRolesCache = $catalog }
     $catalog
 }

--- a/plugins/agentic-board/scripts/ExpertRolesIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertRolesIo.ps1
@@ -102,6 +102,23 @@ function Merge-ExpertRoles {
     @{ roles = $merged.ToArray(); qualityProfile = $quality }
 }
 
+function Add-ExpertRole {
+    # Writing a role changes how every future plan is classified, so callers must confirm first.
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][hashtable]$Role, [string]$Path)
+    if (-not $Path) { $Path = Get-ExpertRoleLocalPath }
+    if (-not $Path) { throw "roles: could not resolve a local catalog path." }
+    $doc = Read-ExpertRoleFile -Path $Path
+    if (-not $doc) { $doc = @{ version = $script:ExpertRolesSchemaVersion; roles = @() } }
+    $kept = @(@($doc.roles) | Where-Object { $_.name -ne $Role.name })
+    $doc.roles = @($kept + @($Role))
+    $dir = Split-Path $Path -Parent
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $doc | ConvertTo-Json -Depth 8 | Set-Content -Path $Path -Encoding utf8
+    Clear-ExpertRolesCache
+    $Path
+}
+
 function Get-ExpertRoleLocalPath {
     . (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')
     $dir = Get-AbiosStateDir

--- a/plugins/agentic-board/skills/board-expert/SKILL.md
+++ b/plugins/agentic-board/skills/board-expert/SKILL.md
@@ -24,6 +24,18 @@ typed with a slash.
 Show the role preview and let the user edit before running `auto`. See `references/contract.md`
 for every contract field and its default.
 
+If `config` reports **NO ROLE MATCHED**, research the plan's domain (via `/knowledge`, and
+`/tools` for ready-made agent definitions such as `wshobson/agents`), then propose a complete
+role — `name`, `keywords`, `skills`, and an `agent` pointer when a fitting definition exists.
+Show it to the user and persist it **only on their confirmation**, with `Add-ExpertRole`: writing
+a role changes how every future plan is classified, so it is never a silent side effect of
+`config`.
+
+### roles — see and debug the catalog
+`scripts/Expert-Roles.ps1 -List` prints the effective catalog (factory + local, with each role's
+source and how many installed skills it really hooks); `-Why "<plan text>"` explains which keyword
+in which role decided a match. Schema and merge rules: `references/roles.md`.
+
 ### auto — run it
 `scripts/Expert-Auto.ps1 -Issue <n> -ProjectNum <n>`:
 1. Reads the contract; composes the autonomous brief.

--- a/plugins/agentic-board/skills/board-expert/references/contract.md
+++ b/plugins/agentic-board/skills/board-expert/references/contract.md
@@ -5,7 +5,9 @@ on read (`ExpertContractIo.Read-ExpertContract`), so `auto` never hits a missing
 
 | Key | Default | Meaning |
 |---|---|---|
-| `role` | *(synthesized)* | The role-as-objective the auto-expert adopts (`Expert-RoleSynthesis`). |
+| `role` | *(rendered)* | The role-as-objective the auto-expert adopts. Rendered from the role catalog (`presets/roles.json` + `.agentic-board/roles.json`) — to change it, edit the catalog, not this value. See `roles.md`. |
+| `roleMatched` | *(computed)* | `false` when no role matched the plan, so `config` can offer to synthesize one instead of silently running as `generic`. |
+| `roleAgent` | *(computed)* | The agent definition the matched role names, if any — passed to the launched run as its agent type. |
 | `autonomy.irreversible` | `merge, deploy, refresh, publish, delete` | The ONLY actions that stop the run for the human. Anything not here and not explicitly safe is treated as irreversible (fail-safe). |
 | `dod` | `ci, build, lint, tests, bpa, tmdlBreaking` all `true` | The definition of done the loop drives toward ("everything passes"). |
 | `evidence.pr` / `.issueComment` / `.file` | all `true` | The three destinations the evidence block is written to. |

--- a/plugins/agentic-board/skills/board-expert/references/roles.md
+++ b/plugins/agentic-board/skills/board-expert/references/roles.md
@@ -1,0 +1,84 @@
+# The expert role catalog
+
+Two files, one effective catalog:
+
+| File | Ships with | Edited by | In git |
+|---|---|---|---|
+| `presets/roles.json` | the plugin | nobody (upgrades replace it) | plugin repo |
+| `.agentic-board/roles.json` | the project | you | **yes** — roles are team knowledge |
+
+> If your project's `.gitignore` excludes `.agentic-board/`, `roles.json` cannot be versioned:
+> git **cannot re-include** a file whose parent directory is excluded, so a plain
+> `!.agentic-board/roles.json` would be dead config that looks like it works. Exclude the
+> directory's *contents* instead:
+> ```gitignore
+> .agentic-board/*
+> !.agentic-board/roles.json
+> ```
+
+## Schema
+
+```json
+{
+  "version": 1,
+  "qualityProfile": ["skill-creator", "writing-skills"],
+  "roles": [
+    { "name": "infra",
+      "keywords": ["terraform", "helm", "kubernetes"],
+      "skills":   ["iac", "k8s"],
+      "agent":    "infra-reviewer",
+      "knowledgeDomain": "Infrastructure" }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Identity, and the merge key against the factory catalog. |
+| `keywords` | yes | Matched (lowercase, substring) against the plan text to select the role. |
+| `skills` | yes | Matched against installed skill **names** — never the plugin namespace — to build the toolset. |
+| `agent` | no | An installed agent definition (`agents/*.md`, the same registry the Agent tool resolves). Its body becomes the role's standards. Preferred over `standards`. |
+| `standards` | no | Inline prose, for when no agent definition is worth creating. Ignored when `agent` is set. |
+| `knowledgeDomain` | no | A domain in `knowledge/registry.json` whose references the expert reads before building. |
+| `replace` | no | `true` makes every field replace the factory role's instead of unioning. The way to *remove* factory keywords. |
+
+`qualityProfile` sits at the top level, not inside `roles`: it is engaged for every role and has
+no keywords, so it never competes for a match. A local one replaces the factory list wholesale —
+that is what lets you shrink it.
+
+## Why `agent` rather than more prose
+
+Claude Code already defines expert personas natively: `agents/*.md`, frontmatter plus a body that
+is the system prompt, shipped by plugins and overridable per project. Restating that format inside
+a role would duplicate it, so a role **points at** one. Ready-made definitions can be installed
+with `/tools` — for instance `wshobson/agents` or `VoltAgent/awesome-claude-code-subagents`
+(both unlicensed, so they are referenced and installed, never copied into your repo).
+
+## Merge rules
+
+- Local roles are evaluated **before** factory roles; within each group, file order wins. A merged
+  role takes the **local** position — declaring it locally is what places it.
+- `keywords` and `skills` **union** with the factory role of the same name, so "we also call it
+  `metabase`" does not require redeclaring the role.
+- `agent`, `standards`, `knowledgeDomain` and `qualityProfile` **replace** wholesale. Setting
+  `agent` locally clears any inherited `standards`, so the two never both apply.
+
+## When it goes wrong
+
+A broken local file never leaves the expert worse off than the factory catalog:
+
+| Condition | Behavior |
+|---|---|
+| No local file | Factory catalog. Normal, not a warning. |
+| Invalid JSON, or an unknown `version` | Warn; continue with the factory catalog. |
+| A role missing `name`, `keywords` or `skills` | Warn; skip **that role only**. |
+| Duplicate `name` in the local file | Warn; the last declaration wins. |
+| `agent` names something not installed | Warn; the role survives and falls back to `standards`, then to the generic paragraph. |
+| `knowledgeDomain` names a missing domain | Warn; the role survives without the knowledge line. |
+| The shipped preset is missing | Hard error — that is a broken install, not a misconfiguration. |
+
+Every warning goes to the warning stream, never to stdout: `config` and `roles list` have parsed
+output.
+
+Run `/board expert roles why "<plan text>"` to see exactly which keyword decided a match, and
+`/board expert roles` to see which roles hook zero skills.

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -52,3 +52,16 @@ Describe 'Get-BudgetVerdict' {
         Get-BudgetVerdict -ElapsedMinutes 5 -Iterations 8 -Contract $script:Contract | Should -Be 'handoff'
     }
 }
+
+Describe 'Agent type in the autonomous brief' {
+    It 'names the role agent when the contract carries one' {
+        $c = $script:Contract.Clone()
+        $c.roleAgent = 'infra-reviewer'
+        $brief = Format-AutoBrief -Contract $c -PlanBody 'do the thing' -RoleObjective 'You are an expert in infra.'
+        $brief | Should -Match 'infra-reviewer'
+    }
+    It 'omits the agent line when the contract names none' {
+        $brief = Format-AutoBrief -Contract $script:Contract -PlanBody 'do the thing' -RoleObjective 'You are an expert.'
+        $brief | Should -Not -Match 'Adopt the agent type'
+    }
+}

--- a/plugins/agentic-board/tests/Expert-Config.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Config.Tests.ps1
@@ -33,6 +33,26 @@ Describe 'New-ExpertConfig' {
     }
 }
 
+Describe 'New-ExpertConfig role selection' {
+    It 'uses a role that exists only in a supplied catalog' {
+        $cat = @{ qualityProfile=@(); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@('iac') }) }
+        $c = New-ExpertConfig -PlanText 'Refactor the terraform modules' -PlanGoal 'g' `
+                              -Inventory @('team:iac-helpers') -Catalog $cat
+        $c.role | Should -Match 'infra'
+        $c.role | Should -Match 'team:iac-helpers'
+    }
+    It 'reports when no role matched, so config can offer to synthesize one' {
+        $cat = @{ qualityProfile=@(); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        $c = New-ExpertConfig -PlanText 'Write a haiku' -PlanGoal 'g' -Inventory @() -Catalog $cat
+        $c.roleMatched | Should -BeFalse
+    }
+    It 'reports a match when one was found' {
+        $cat = @{ qualityProfile=@(); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        $c = New-ExpertConfig -PlanText 'terraform work' -PlanGoal 'g' -Inventory @() -Catalog $cat
+        $c.roleMatched | Should -BeTrue
+    }
+}
+
 Describe 'Expert-Config.ps1 (CLI wiring)' {
     # The unit tests above call New-ExpertConfig directly, so they never exercise the script's own
     # argument handling or inventory resolution — where both #441 and #442 lived.

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -66,6 +66,34 @@ Describe 'Get-HookedSkills' {
     }
 }
 
+Describe 'Catalog-driven matching' {
+    It 'matches a role that exists only in a supplied catalog' {
+        $cat = @{
+            qualityProfile = @()
+            roles = @(
+                @{ name='infra'; keywords=@('terraform','helm'); skills=@('iac') },
+                @{ name='generic'; keywords=@(); skills=@() }
+            )
+        }
+        Get-DomainFromPlan -Text 'Refactor the terraform modules' -Catalog $cat | Should -Be 'infra'
+    }
+    It 'falls back to generic when no role in the catalog matches' {
+        $cat = @{ qualityProfile=@(); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        Get-DomainFromPlan -Text 'Write a haiku' -Catalog $cat | Should -Be 'generic'
+    }
+    It 'hooks skills from the supplied catalog role' {
+        $cat = @{ qualityProfile=@(); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@('iac') }) }
+        Get-HookedSkills -Domain 'infra' -Inventory @('team:iac-helpers','unrelated') -Catalog $cat |
+            Should -Contain 'team:iac-helpers'
+    }
+    It 'takes the quality profile from the catalog, not from code' {
+        $cat = @{ qualityProfile=@('second-opinion'); roles=@(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        $h = Get-HookedSkills -Domain 'infra' -Inventory @('second-opinion','skill-creator') -Catalog $cat
+        $h | Should -Contain 'second-opinion'
+        $h | Should -Not -Contain 'skill-creator'   # not in this catalog's quality profile
+    }
+}
+
 Describe 'Resolve-SkillInventory' {
     BeforeAll {
         # A real fixture tree — Get-SkillInventory.ps1 is run for real against it, no mocks.

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -134,6 +134,63 @@ Body.
     }
 }
 
+Describe 'Resolve-RolePersona' {
+    BeforeAll {
+        $script:AgentRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("agents-" + [guid]::NewGuid().ToString('N'))
+        $d = Join-Path $script:AgentRoot 'agents'
+        New-Item -ItemType Directory -Path $d -Force | Out-Null
+        Set-Content -Path (Join-Path $d 'deneb-reviewer.md') -Encoding utf8 -Value @"
+---
+name: deneb-reviewer
+description: Review a Deneb visual spec before presenting it.
+---
+You never invent a field or dataset. You read the real data first.
+"@
+    }
+    AfterAll { if (Test-Path $script:AgentRoot) { Remove-Item $script:AgentRoot -Recurse -Force } }
+
+    It 'renders the agent body when the role names an installed agent' {
+        $p = Resolve-RolePersona -Role @{ name='r'; agent='deneb-reviewer' } -SearchRoots @($script:AgentRoot)
+        $p | Should -Match 'never invent a field'
+    }
+    It 'resolves a namespaced agent name by its file stem' {
+        $p = Resolve-RolePersona -Role @{ name='r'; agent='reports:deneb-reviewer' } -SearchRoots @($script:AgentRoot)
+        $p | Should -Match 'never invent a field'
+    }
+    It 'strips the frontmatter out of the persona' {
+        $p = Resolve-RolePersona -Role @{ name='r'; agent='deneb-reviewer' } -SearchRoots @($script:AgentRoot)
+        $p | Should -Not -Match 'description:'
+    }
+    It 'falls back to inline standards when the agent is not installed' {
+        $p = Resolve-RolePersona -Role @{ name='r'; agent='nope'; standards=@('Be careful.') } -SearchRoots @($script:AgentRoot) -WarningAction SilentlyContinue
+        $p | Should -Match 'Be careful'
+    }
+    It 'warns when the named agent is not installed' {
+        $w = @()
+        Resolve-RolePersona -Role @{ name='r'; agent='nope' } -SearchRoots @($script:AgentRoot) -WarningVariable w -WarningAction SilentlyContinue | Out-Null
+        $w.Count | Should -BeGreaterThan 0
+    }
+    It 'prefers the agent over inline standards when both are set' {
+        $p = Resolve-RolePersona -Role @{ name='r'; agent='deneb-reviewer'; standards=@('Be careful.') } -SearchRoots @($script:AgentRoot)
+        $p | Should -Match 'never invent a field'
+        $p | Should -Not -Match 'Be careful'
+    }
+    It 'returns empty for a role with neither agent nor standards' {
+        Resolve-RolePersona -Role @{ name='r' } -SearchRoots @($script:AgentRoot) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Format-RoleObjective persona' {
+    It 'renders the supplied persona instead of the generic paragraph' {
+        $b = Format-RoleObjective -Domain 'r' -HookedSkills @('x') -PlanGoal 'g' -Persona 'You read the data first.'
+        $b | Should -Match 'You read the data first'
+    }
+    It 'renders the generic paragraph when no persona is supplied' {
+        $b = Format-RoleObjective -Domain 'r' -HookedSkills @('x') -PlanGoal 'g'
+        $b | Should -Match 'you research prior-art before building'
+    }
+}
+
 Describe 'Format-RoleObjective' {
     It 'embeds the goal and the hooked skills' {
         $block = Format-RoleObjective -Domain 'powerbi-report' `

--- a/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules Pester
+<#  Tests for Expert-Roles.ps1 — the `roles list` / `roles why` verb: show the effective catalog
+    and explain which role a plan resolves to. Pure behind ABIOS_EXPERTROLESCMD_DOTSOURCE. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Expert-Roles.ps1' | Resolve-Path
+    $env:ABIOS_EXPERTROLESCMD_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_EXPERTROLESCMD_DOTSOURCE = ''
+    $script:Factory = @{ qualityProfile=@(); roles=@(
+        @{ name='powerbi-report'; keywords=@('deneb'); skills=@('report') },
+        @{ name='generic'; keywords=@(); skills=@() }) }
+}
+
+Describe 'Get-RoleSource' {
+    It 'labels a role only the factory declares' {
+        $local = @{ roles=@() }
+        Get-RoleSource -Role @{name='powerbi-report'} -Factory $script:Factory -Local $local | Should -Be 'factory'
+    }
+    It 'labels a role only the project declares' {
+        $local = @{ roles=@(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        Get-RoleSource -Role @{name='infra'} -Factory $script:Factory -Local $local | Should -Be 'local'
+    }
+    It 'labels a role the project overrides' {
+        $local = @{ roles=@(@{ name='powerbi-report'; keywords=@('metabase'); skills=@() }) }
+        Get-RoleSource -Role @{name='powerbi-report'} -Factory $script:Factory -Local $local |
+            Should -Be 'local (overrides factory)'
+    }
+}
+
+Describe 'Get-RoleMatchTrace' {
+    It 'names the role and the exact keyword that decided the match' {
+        $t = Get-RoleMatchTrace -Text 'Build a Deneb chart' -Catalog $script:Factory
+        $t.role    | Should -Be 'powerbi-report'
+        $t.keyword | Should -Be 'deneb'
+    }
+    It 'reports generic with no keyword when nothing matches' {
+        $t = Get-RoleMatchTrace -Text 'Write a haiku' -Catalog $script:Factory
+        $t.role    | Should -Be 'generic'
+        $t.keyword | Should -BeNullOrEmpty
+    }
+    It 'lists the roles it evaluated, in precedence order' {
+        $t = Get-RoleMatchTrace -Text 'Write a haiku' -Catalog $script:Factory
+        $t.evaluated | Should -Be @('powerbi-report','generic')
+    }
+    It 'stops evaluating at the first hit' {
+        $t = Get-RoleMatchTrace -Text 'Build a Deneb chart' -Catalog $script:Factory
+        $t.evaluated | Should -Be @('powerbi-report')
+    }
+}

--- a/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
@@ -112,3 +112,56 @@ Describe 'Merge-ExpertRoles' {
         @($m.roles).Count | Should -Be 2
     }
 }
+
+Describe 'Select-ValidExpertRoles' {
+    It 'keeps a well-formed role' {
+        @(Select-ValidExpertRoles -Roles @(@{ name='a'; keywords=@('k'); skills=@() })).Count | Should -Be 1
+    }
+    It 'drops a role with no name and warns' {
+        $w = @()
+        @(Select-ValidExpertRoles -Roles @(@{ keywords=@('k'); skills=@() }) -WarningVariable w 3>$null).Count | Should -Be 0
+        $w.Count | Should -BeGreaterThan 0
+    }
+    It 'drops a role missing keywords but keeps its siblings' {
+        $r = @(@{ name='bad' }, @{ name='good'; keywords=@('k'); skills=@() })
+        $kept = @(Select-ValidExpertRoles -Roles $r 3>$null)
+        $kept.Count | Should -Be 1
+        $kept[0].name | Should -Be 'good'
+    }
+    It 'keeps the last of two roles sharing a name' {
+        $r = @(@{ name='dup'; keywords=@('one'); skills=@() }, @{ name='dup'; keywords=@('two'); skills=@() })
+        $kept = @(Select-ValidExpertRoles -Roles $r 3>$null)
+        $kept.Count | Should -Be 1
+        $kept[0].keywords | Should -Be @('two')
+    }
+}
+
+Describe 'Get-ExpertRoles (degraded local file)' {
+    BeforeEach {
+        Clear-ExpertRolesCache
+        $script:Bad = Join-Path ([System.IO.Path]::GetTempPath()) ("roles-bad-" + [guid]::NewGuid().ToString('N') + ".json")
+    }
+    AfterEach { if (Test-Path $script:Bad) { Remove-Item $script:Bad -Force } }
+
+    It 'falls back to the factory catalog when the local file is invalid JSON' {
+        Set-Content -Path $script:Bad -Value '{ this is not json' -Encoding utf8
+        $c = Get-ExpertRoles -LocalPath $script:Bad -NoCache 3>$null
+        @($c.roles).Count | Should -Be 5
+    }
+    It 'falls back to the factory catalog on an unknown schema version' {
+        Set-Content -Path $script:Bad -Encoding utf8 -Value '{ "version": 99, "roles": [ { "name": "x", "keywords": ["x"], "skills": [] } ] }'
+        $c = Get-ExpertRoles -LocalPath $script:Bad -NoCache 3>$null
+        @($c.roles.name) | Should -Not -Contain 'x'
+        @($c.roles).Count | Should -Be 5
+    }
+    It 'keeps the valid roles of a file that also contains a broken one' {
+        Set-Content -Path $script:Bad -Encoding utf8 -Value '{ "version": 1, "roles": [ { "name": "broken" }, { "name": "ok", "keywords": ["k"], "skills": [] } ] }'
+        $c = Get-ExpertRoles -LocalPath $script:Bad -NoCache 3>$null
+        @($c.roles.name) | Should -Contain 'ok'
+        @($c.roles.name) | Should -Not -Contain 'broken'
+    }
+    It 'throws when the shipped preset itself is missing' {
+        { Get-ExpertRoles -PresetPath 'C:\no\such\preset.json' -LocalPath 'C:\no\such\local.json' -NoCache } |
+            Should -Throw '*broken install*'
+    }
+}

--- a/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
@@ -44,3 +44,71 @@ Describe 'Get-ExpertRoles (factory only)' {
         $pbi.keywords | Should -Be @('deneb','visual','chart','dashboard','report','pbir','svg')
     }
 }
+
+Describe 'Merge-ExpertRoles' {
+    BeforeAll {
+        $script:Factory = @{
+            qualityProfile = @('skill-creator','second-opinion')
+            roles = @(
+                @{ name='powerbi-report'; keywords=@('deneb','chart'); skills=@('report') },
+                @{ name='generic';        keywords=@();               skills=@() }
+            )
+        }
+    }
+
+    It 'adds a role the factory does not know' {
+        $local = @{ roles = @(@{ name='infra'; keywords=@('terraform'); skills=@('iac') }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        @($m.roles.name) | Should -Contain 'infra'
+        @($m.roles.name) | Should -Contain 'powerbi-report'
+    }
+    It 'places local roles before factory roles' {
+        $local = @{ roles = @(@{ name='infra'; keywords=@('terraform'); skills=@('iac') }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        @($m.roles.name)[0] | Should -Be 'infra'
+    }
+    It 'unions keywords and skills into a factory role of the same name' {
+        $local = @{ roles = @(@{ name='powerbi-report'; keywords=@('metabase'); skills=@('viz') }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        $r = $m.roles | Where-Object { $_.name -eq 'powerbi-report' }
+        $r.keywords | Should -Contain 'deneb'      # factory kept
+        $r.keywords | Should -Contain 'metabase'   # local added
+        $r.skills   | Should -Contain 'report'
+        $r.skills   | Should -Contain 'viz'
+    }
+    It 'gives the merged role the local position, not the factory one' {
+        $local = @{ roles = @(@{ name='powerbi-report'; keywords=@('metabase'); skills=@() }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        @($m.roles.name)[0] | Should -Be 'powerbi-report'
+        @($m.roles).Count   | Should -Be 2          # merged, not duplicated
+    }
+    It 'replace:true drops the factory keywords instead of unioning' {
+        $local = @{ roles = @(@{ name='powerbi-report'; keywords=@('metabase'); skills=@('viz'); replace=$true }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        $r = $m.roles | Where-Object { $_.name -eq 'powerbi-report' }
+        $r.keywords | Should -Be @('metabase')
+        $r.keywords | Should -Not -Contain 'deneb'
+    }
+    It 'replaces agent, standards and knowledgeDomain wholesale' {
+        $f = @{ qualityProfile=@(); roles=@(@{ name='r'; keywords=@('k'); skills=@(); standards=@('old') }) }
+        $local = @{ roles = @(@{ name='r'; keywords=@(); skills=@(); agent='my-agent' }) }
+        $m = Merge-ExpertRoles -Factory $f -Local $local
+        $r = $m.roles | Where-Object { $_.name -eq 'r' }
+        $r.agent | Should -Be 'my-agent'
+        $r.standards | Should -BeNullOrEmpty      # setting agent clears inherited standards
+    }
+    It 'lets a local qualityProfile replace the factory one entirely' {
+        $local = @{ roles=@(); qualityProfile = @('second-opinion') }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        $m.qualityProfile | Should -Be @('second-opinion')
+    }
+    It 'keeps the factory qualityProfile when the local file is silent about it' {
+        $local = @{ roles = @(@{ name='infra'; keywords=@('terraform'); skills=@() }) }
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $local
+        $m.qualityProfile | Should -Contain 'skill-creator'
+    }
+    It 'returns the factory catalog untouched when there is no local file' {
+        $m = Merge-ExpertRoles -Factory $script:Factory -Local $null
+        @($m.roles).Count | Should -Be 2
+    }
+}

--- a/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules Pester
+<#  Tests for ExpertRolesIo.ps1 — loads the shipped role preset plus the optional project-local
+    roles.json, validates both, and merges them into the effective catalog. Pure filesystem IO
+    (no gh) behind ABIOS_EXPERTROLES_DOTSOURCE. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'ExpertRolesIo.ps1' | Resolve-Path
+    $env:ABIOS_EXPERTROLES_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_EXPERTROLES_DOTSOURCE = ''
+}
+
+Describe 'Get-ExpertRolePresetPath' {
+    It 'points at a preset file that exists' {
+        Test-Path (Get-ExpertRolePresetPath) | Should -BeTrue
+    }
+}
+
+Describe 'Get-ExpertRoles (factory only)' {
+    BeforeEach { Clear-ExpertRolesCache }
+
+    It 'returns the five factory roles' {
+        $c = Get-ExpertRoles -LocalPath 'C:\does\not\exist\roles.json'
+        @($c.roles).Count | Should -Be 5
+        @($c.roles.name) | Should -Contain 'powerbi-report'
+        @($c.roles.name) | Should -Contain 'semantic-model'
+        @($c.roles.name) | Should -Contain 'fabric'
+        @($c.roles.name) | Should -Contain 'extension'
+        @($c.roles.name) | Should -Contain 'generic'
+    }
+    It 'preserves the declared order, most specific first' {
+        $c = Get-ExpertRoles -LocalPath 'C:\does\not\exist\roles.json'
+        @($c.roles.name)[0] | Should -Be 'powerbi-report'
+        @($c.roles.name)[-1] | Should -Be 'generic'
+    }
+    It 'carries the quality profile out of the preset, not out of code' {
+        $c = Get-ExpertRoles -LocalPath 'C:\does\not\exist\roles.json'
+        $c.qualityProfile | Should -Contain 'skill-creator'
+        $c.qualityProfile | Should -Contain 'second-opinion'
+    }
+    It 'keeps the factory keywords byte-for-byte' {
+        $c = Get-ExpertRoles -LocalPath 'C:\does\not\exist\roles.json'
+        $pbi = $c.roles | Where-Object { $_.name -eq 'powerbi-report' }
+        $pbi.keywords | Should -Be @('deneb','visual','chart','dashboard','report','pbir','svg')
+    }
+}

--- a/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
@@ -136,6 +136,42 @@ Describe 'Select-ValidExpertRoles' {
     }
 }
 
+Describe 'Add-ExpertRole' {
+    BeforeEach {
+        Clear-ExpertRolesCache
+        $script:New = Join-Path ([System.IO.Path]::GetTempPath()) ("roles-new-" + [guid]::NewGuid().ToString('N') + ".json")
+    }
+    AfterEach { if (Test-Path $script:New) { Remove-Item $script:New -Force } }
+
+    It 'creates the file with the current schema version when it does not exist' {
+        Add-ExpertRole -Role @{ name='infra'; keywords=@('terraform'); skills=@('iac') } -Path $script:New | Out-Null
+        $j = Get-Content -Raw $script:New | ConvertFrom-Json
+        $j.version | Should -Be 1
+        @($j.roles).Count | Should -Be 1
+    }
+    It 'round-trips: what it writes, the loader reads back identically' {
+        Add-ExpertRole -Role @{ name='infra'; keywords=@('terraform','helm'); skills=@('iac') } -Path $script:New | Out-Null
+        $c = Get-ExpertRoles -LocalPath $script:New -NoCache
+        $r = $c.roles | Where-Object { $_.name -eq 'infra' }
+        $r.keywords | Should -Be @('terraform','helm')
+        $r.skills   | Should -Be @('iac')
+    }
+    It 'appends to an existing file without losing the roles already there' {
+        Add-ExpertRole -Role @{ name='one'; keywords=@('a'); skills=@() } -Path $script:New | Out-Null
+        Add-ExpertRole -Role @{ name='two'; keywords=@('b'); skills=@() } -Path $script:New | Out-Null
+        $c = Get-ExpertRoles -LocalPath $script:New -NoCache
+        @($c.roles.name) | Should -Contain 'one'
+        @($c.roles.name) | Should -Contain 'two'
+    }
+    It 'replaces a role of the same name rather than duplicating it' {
+        Add-ExpertRole -Role @{ name='one'; keywords=@('a'); skills=@() } -Path $script:New | Out-Null
+        Add-ExpertRole -Role @{ name='one'; keywords=@('z'); skills=@() } -Path $script:New | Out-Null
+        $j = Get-Content -Raw $script:New | ConvertFrom-Json
+        @($j.roles).Count | Should -Be 1
+        @($j.roles)[0].keywords | Should -Be @('z')
+    }
+}
+
 Describe 'Get-ExpertRoles (degraded local file)' {
     BeforeEach {
         Clear-ExpertRolesCache


### PR DESCRIPTION
Closes #444

Removes the hardcoded five-role limit in `/agentic-board:expert`. Implements epic #444 (sub-issues #445-#454).

> Supersedes #455, which GitHub auto-closed when its base branch was deleted by the squash-merge of #443. Same work, rebased onto `main`; the two commits that belonged to #443 are gone from this branch.

## The problem

`Expert-RoleSynthesis.ps1` decided who the expert becomes from two hashtables hardcoded in PowerShell. Five roles, fixed at build time. Any project outside Power BI / semantic models / Fabric / plugin-development resolved to `generic`, whose skill list is literally empty - and the only fix was editing the plugin's source, which a consumer cannot do and would lose on the next `plugin update`. The contract stored the *rendered text* of the role, not its definition, so editing it fixed one run and was overwritten by the next `config`.

## What changed

The catalog is now data: `presets/roles.json` (factory, shipped alongside the fields/labels/toolkit presets) merged with `.agentic-board/roles.json` (project, versioned in git).

- `keywords` / `skills` **union** with the factory role of the same name - "we also call it `metabase`" does not require redeclaring the role.
- `agent` / `standards` / `knowledgeDomain` / `qualityProfile` **replace** wholesale.
- `"replace": true` drops the factory values entirely - the way to *remove* a factory keyword.
- Local roles evaluate first, and a merged role takes the **local** position: declaring it locally is what places it.

## Prior art changed the design

Claude Code already defines expert personas natively - `agents/*.md`, frontmatter plus a body that is the system prompt, shipped by plugins and overridable per project. An earlier draft gave each role a `standards` prose block, which reinvented that format in parallel. A role now **points at** an agent definition instead (`Resolve-RolePersona`), with inline `standards` kept as the shortcut. Ready-made definitions install via `/tools` (`wshobson/agents` 38.3k, `VoltAgent/awesome-claude-code-subagents` 23.8k - both unlicensed, so referenced, never vendored).

What the native mechanism does **not** do, and stays ours: deterministic keyword-based role *selection* (a subagent is chosen by the model reading its `description`; selection here must be reproducible and testable without an LLM) and skill hooking against the live inventory.

## New verb

`/agentic-board:expert roles` - `list` prints the effective catalog with each role's source and **how many installed skills it actually hooks** (a role hooking zero looks fine on paper and gives the expert no toolset); `why "<text>"` names the exact keyword in the exact role that decided a match.

## Failure behavior

A broken local catalog never leaves the expert worse off than the factory roles: invalid JSON or an unknown `version` warns and the file is ignored; a role missing `name`/`keywords`/`skills` costs only itself; an uninstalled `agent` or a stale `knowledgeDomain` warns and the role survives without it; a missing shipped preset still throws, because that is a broken install rather than a misconfiguration. Warnings go to the warning stream, never stdout.

## Found while building, not in the plan

- **`.gitignore` made the design impossible.** `.agentic-board/` was excluded wholesale, and git **cannot re-include** a file whose parent directory is excluded - a plain `!.agentic-board/roles.json` would have been dead config that looks like it works. Now the directory's *contents* are excluded instead, so `roles.json` is versionable while `expert.json` stays ignored. Verified in both directions with `git add --dry-run`, since `git check-ignore -v` returns exit 0 even when the matching pattern is the negation.
- **`Select-ValidExpertRoles` was not an advanced function.** Without `[CmdletBinding()]`, `-WarningVariable` and `-WarningAction` are silently inert - callers could neither capture nor silence its warnings. Caught by a test; fixed in the code, not the test.
- **The plan named a function that does not exist** (`Format-ExpertBrief`; the real one is `Format-AutoBrief`). The plan's own self-review claimed type consistency and missed it.

## Verification

- **Full suite: 1239 passed, 0 failed** (from 1184 - about 55 new tests).
- The nine pre-existing matching tests pass **unedited** - the proof that moving the data changed no behavior.
- RED verified before every change; each failure failed for its real reason.
- End to end:

```
no local catalog     -> terraform: NO MATCH -> generic      (the old behavior)
local `infra` role   -> MATCH 'infra' on keyword 'terraform'
broken local catalog -> WARNING + MATCH 'powerbi-report'    (never worse than factory)
```

Closes #444
Closes #445
Closes #446
Closes #447
Closes #448
Closes #449
Closes #450
Closes #451
Closes #452
Closes #453
Closes #454