### PR TITLE
fix(expert): arm the irreversible brake in the launch briefing (#440)

### DIFF
--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -166,6 +166,12 @@ param(
     [switch]$BaseCurrent,
     [switch]$IgnoreBlocked,
     [switch]$TakeOver,
+    # Irreversible brake (#440): brief the launched session to stop at a reviewed PR instead of
+    # ordering the merge. Set by /expert auto when the contract marks `merge` as irreversible.
+    [switch]$StopAtPR,
+    # Path to the full brief for the launched session (e.g. .agentic-board/expert-brief-<n>.md),
+    # which it is told to read first and treat as overriding the generic steps.
+    [string]$BriefFile     = "",
     [string]$TokenVar      = "GITHUB_TOKEN_PERSONAL",
     # Only a plain env-var identifier - it gets interpolated into the spawned
     # -Command string, so reject anything that could inject (';', quotes, spaces).
@@ -966,15 +972,42 @@ query($o:String!, $r:String!, $n:Int!) {
 # -Cli is threaded (default 'claude') so Phase-2 adapters can specialize the leading
 # autonomy sentence per CLI without another signature change; Phase 1 keeps the
 # body text identical for every repl CLI.
+#
+# -StopAtPR is the irreversible brake (#440). The auto-expert's contract can mark `merge` as
+# irreversible, but that brake used to live ONLY in expert-brief-<n>.md - a file this launcher
+# never read - while THIS briefing ordered the merge outright and made it the completion
+# condition. A session that merged to main was obeying its brief, not defying it. With the
+# brake on, the merge step is never emitted and the finish line moves to a reviewed PR.
+# -BriefFile is the other half: it hands the session the expert brief it was never given.
 function Get-SessionBriefing {
     param(
         [int]$issueNum,
         [string]$repo,
         [string]$branch,
         [string]$workPath,
-        [string]$Cli = 'claude'
+        [string]$Cli = 'claude',
+        [switch]$StopAtPR,
+        [string]$BriefFile = ''
     )
-    return ("You are running AUTONOMOUSLY - permissions are pre-approved, so work this " +
+    # Steps after the review gate are renumbered so the brake never leaves a hole at (5).
+    $mergeStep = if ($StopAtPR) { "" } else {
+        "(5) merge it (ruleset-safe): pwsh plugins/agentic-board/scripts/Board-Merge.ps1 -PR <pr> ; "
+    }
+    $recordNum = if ($StopAtPR) { "(5)" } else { "(6)" }
+    $closing = if ($StopAtPR) {
+        "Then STOP: leave the PR open and ready for the human to merge. Your contract marks the " +
+        "merge as irreversible - do NOT merge, deploy, publish or delete anything, and do not " +
+        "treat the merge as your finish line. You are done when the PR is open, the review gate " +
+        "is green and your findings are recorded."
+    } else {
+        "When the PR is merged and your findings recorded, you are done."
+    }
+    $briefLine = if ($BriefFile) {
+        "Your full brief for this run is at $BriefFile - read it FIRST and follow it; where it " +
+        "conflicts with the generic steps below, it overrides them. "
+    } else { "" }
+    return ($briefLine +
+            "You are running AUTONOMOUSLY - permissions are pre-approved, so work this " +
             "task end-to-end WITHOUT stopping to ask for confirmation. " +
             "Pick up GitHub issue #$issueNum in $repo. It is already In Progress and claimed, " +
             "on branch $branch in this worktree ($workPath). " +
@@ -990,11 +1023,11 @@ function Get-SessionBriefing {
             "and note the PR number it prints ; " +
             "(4) pass the review gate: pwsh plugins/agentic-board/scripts/Board-ReviewGate.ps1 -PR <pr> ; " +
             "address any feedback and re-run until it is green ; " +
-            "(5) merge it (ruleset-safe): pwsh plugins/agentic-board/scripts/Board-Merge.ps1 -PR <pr> ; " +
-            "(6) record what you learned for other sessions with " +
+            $mergeStep +
+            "$recordNum record what you learned for other sessions with " +
             "'pwsh plugins/agentic-board/scripts/Fleet-Findings.ps1 -Add -Issue $issueNum -Status done -Files <files touched> -Decisions <key decisions> -Gotchas <pitfalls>' " +
             "and free your files with 'pwsh plugins/agentic-board/scripts/Fleet-Ownership.ps1 -Release -Issue $issueNum' . " +
-            "Work ONLY this issue - never touch other worktrees or issues. When the PR is merged and your findings recorded, you are done.")
+            "Work ONLY this issue - never touch other worktrees or issues. " + $closing)
 }
 
 # -- Fleet session marker (reaper fingerprint) ---------------------------------
@@ -1142,6 +1175,8 @@ function Start-WorktreeSession {
         [string]$ClaudeAuthVar = "ANTHROPIC_API_KEY",
         [string]$Cli = 'claude',
         [string]$FleetSession = '',
+        [switch]$StopAtPR,
+        [string]$BriefFile = '',
         [switch]$Preview
     )
     $abios = Get-AbiosDir
@@ -1163,7 +1198,7 @@ function Start-WorktreeSession {
         return $null
     }
     # Persist the briefing so the spawned session reads it without command-line quoting.
-    Set-Content -LiteralPath $briefingFile -Value (Get-SessionBriefing $IssueNum $Repo $Branch $WorkPath $Cli) -Encoding UTF8
+    Set-Content -LiteralPath $briefingFile -Value (Get-SessionBriefing $IssueNum $Repo $Branch $WorkPath $Cli -StopAtPR:$StopAtPR -BriefFile $BriefFile) -Encoding UTF8
     # Persist the launch script so wt/pwsh runs it via -File (no ';' on wt's command
     # line -> no stray tab-splitting). See Build-WorktreeLaunch header for the why.
     Set-Content -LiteralPath $plan.launchScriptFile -Value $plan.launchScript -Encoding UTF8
@@ -2358,7 +2393,7 @@ if ($Relaunch -gt 0) {
     $oauthPresent = [bool][System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN','User')
     $authVar      = Resolve-ClaudeAuthVar $PSBoundParameters.ContainsKey('ClaudeAuthVar') $ClaudeAuthVar $oauthPresent
     $marker       = New-FleetSessionMarker $Relaunch (New-FleetRunId)
-    $spawn = Start-WorktreeSession -IssueNum $Relaunch -Repo $sess.repo -Branch $sess.branch -WorkPath $sess.workPath -ClaudeAuthVar $authVar -Cli $cli -FleetSession $marker
+    $spawn = Start-WorktreeSession -IssueNum $Relaunch -Repo $sess.repo -Branch $sess.branch -WorkPath $sess.workPath -ClaudeAuthVar $authVar -Cli $cli -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile
     # Start-WorktreeSession returns $null on a failed/missing-worktree spawn. Registering
     # then would fall back to the coordinator PID and poison the registry - so only record a
     # session that actually launched.
@@ -2922,7 +2957,8 @@ if ($Parallel.Count -gt 0) {
                 $actualCli = Resolve-LaunchCli -Chosen $cli -Availability $availability
                 $marker    = New-FleetSessionMarker $entry.issue $runId
                 $spawn = Start-WorktreeSession -IssueNum $entry.issue -Repo $entry.repo -Branch $entry.branch `
-                                               -WorkPath $entry.workPath -ClaudeAuthVar $ClaudeAuthVar -Cli $actualCli -FleetSession $marker
+                                               -WorkPath $entry.workPath -ClaudeAuthVar $ClaudeAuthVar -Cli $actualCli -FleetSession $marker `
+                                               -StopAtPR:$StopAtPR -BriefFile $BriefFile
                 $via = if ($spawn.usesWt) { "wt" } else { "pwsh" }
                 if ($spawn.process -and -not $spawn.usesWt) {
                     Write-SessionRegistryEntry -IssueNum $entry.issue -SessionPid $spawn.process.Id -Via $via -Cli $actualCli -FleetSession $marker
@@ -2955,7 +2991,7 @@ if ($Parallel.Count -gt 0) {
                 # New-IssueWorktree / Get-IssueWorktreePath - the grouped-worktree layout).
                 $previewPath = Get-IssueWorktreePath $r.repo $r.issue (Split-Path (Get-Location) -Parent)
                 $marker = New-FleetSessionMarker $r.issue $runId
-                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -Preview | Out-Null
+                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile -Preview | Out-Null
             }
         } else {
             Write-Host "----- LANZANDO SESIONES CLAUDE -----" -ForegroundColor Cyan
@@ -2982,7 +3018,7 @@ if ($Parallel.Count -gt 0) {
             foreach ($r in $started) {
                 if ($r.workPath) {
                     $marker = New-FleetSessionMarker $r.issue $runId
-                    $spawn = Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $r.workPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker
+                    $spawn = Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $r.workPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile
                     $launched++
                     # Track the spawned session's own PID (pwsh window is reliable; a wt
                     # launcher forks and exits, so keep the host PID there).

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -135,6 +135,16 @@ if ($repo) {
 
 $brief = Format-AutoBrief -Contract $contract -PlanBody $planBody -RoleObjective $contract.role
 
+# The brake, as a CONTROL rather than prose (#440). The generic launch briefing used to order
+# the merge outright and make it the completion condition, so a session that merged to main was
+# obeying its brief while this file's "STOP before merge" sat in a document nobody handed it.
+# Ask the same gate the expert uses at runtime, then thread the answer into the launcher.
+$prevA = $env:ABIOS_EXPERTAUTONOMY_DOTSOURCE
+$env:ABIOS_EXPERTAUTONOMY_DOTSOURCE = '1'
+. (Join-Path $PSScriptRoot 'Expert-Autonomy.ps1')
+$env:ABIOS_EXPERTAUTONOMY_DOTSOURCE = $prevA
+$stopAtPR = Test-IsIrreversible -Action 'merge' -Contract $contract
+
 # Persist the brief so the launched session can read it.
 . (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')
 $stateDir = Get-AbiosStateDir
@@ -144,14 +154,21 @@ $brief | Set-Content -Path $briefPath -Encoding utf8
 Write-Host "=== /board expert auto  (issue #$Issue) ===" -ForegroundColor Cyan
 Write-Host "  Brief composed -> $briefPath" -ForegroundColor Green
 Write-Host "  Autonomy brakes only on: $($contract.autonomy.irreversible -join ', ')" -ForegroundColor DarkGray
+if ($stopAtPR) {
+    Write-Host "  Brake ARMED: the launched session is briefed to stop at a reviewed PR (no merge step)." -ForegroundColor Green
+} else {
+    Write-Host "  Brake OFF: 'merge' is not irreversible in this contract - the session WILL merge its own PR." -ForegroundColor Yellow
+}
 Write-Host ""
 
+$launchArgs = "-ProjectNum $ProjectNum -Parallel $Issue -Launch" + $(if ($stopAtPR) { " -StopAtPR -BriefFile `"$briefPath`"" } else { "" })
 if ($DryRun) {
     Write-Host "  [DryRun] would launch a dedicated session in a worktree off origin/main and monitor it." -ForegroundColor DarkYellow
-    Write-Host "  Launch:  scripts/Board-Work.ps1 -ProjectNum $ProjectNum -Parallel $Issue -Launch" -ForegroundColor DarkGray
+    Write-Host "  Launch:  scripts/Board-Work.ps1 $launchArgs" -ForegroundColor DarkGray
 } else {
     Write-Host "  Launching the autonomous session in an isolated worktree..." -ForegroundColor Cyan
-    & (Join-Path $PSScriptRoot 'Board-Work.ps1') -ProjectNum $ProjectNum -Parallel $Issue -Launch -TokenVar $TokenVar
+    & (Join-Path $PSScriptRoot 'Board-Work.ps1') -ProjectNum $ProjectNum -Parallel $Issue -Launch -TokenVar $TokenVar `
+        -StopAtPR:$stopAtPR -BriefFile $briefPath
     Write-Host ""
     Write-Host "  The launched session is briefed by $briefPath — it will research, build, test with" -ForegroundColor DarkGray
     Write-Host "  recorded evidence, self-drive the board, and STOP at 'PR ready' before merge." -ForegroundColor DarkGray

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -463,6 +463,59 @@ Describe 'Get-SessionBriefing' {
     }
 }
 
+Describe 'Get-SessionBriefing -StopAtPR (the irreversible brake, #440)' {
+    BeforeAll { $script:Braked = Get-SessionBriefing 42 'owner/repo' 'issue-42-x' 'C:\wt\path' -StopAtPR }
+
+    It 'never orders the merge' {
+        # THE bug: the default briefing commands `Board-Merge.ps1`, so a session obeying its
+        # brief merged to main (and, on a Git-integration host, deployed) while the expert
+        # contract said STOP. With the brake on, the order must not be emitted at all.
+        $script:Braked | Should -Not -Match 'Board-Merge\.ps1'
+    }
+    It 'does not make the merge the completion condition' {
+        $script:Braked | Should -Not -Match 'When the PR is merged'
+    }
+    It 'says explicitly where to stop' {
+        $script:Braked | Should -Match 'STOP'
+        $script:Braked | Should -Match 'do NOT merge'
+    }
+    It 'still delivers everything up to a reviewed PR' {
+        $script:Braked | Should -Match 'New-BoardPR\.ps1 -Issue 42'
+        $script:Braked | Should -Match 'review gate'
+        $script:Braked | Should -Match 'Fleet-Findings\.ps1 -Add'
+        $script:Braked | Should -Match 'Fleet-Ownership\.ps1 -Release'
+    }
+    It 'keeps every step numbered once, with no gap where (5) merge used to be' {
+        # Renumbering regression guard: dropping a step must not leave "(5)" missing or duped.
+        foreach ($n in 1..5) { ([regex]::Matches($script:Braked, "\($n\)")).Count | Should -Be 1 }
+        $script:Braked | Should -Not -Match '\(6\)'
+    }
+    It 'is still a single line' {
+        $script:Braked | Should -Not -Match "`n"
+    }
+    It 'leaves the default briefing untouched when the brake is off' {
+        (Get-SessionBriefing 42 'owner/repo' 'issue-42-x' 'C:\wt') | Should -Match 'Board-Merge\.ps1'
+    }
+}
+
+Describe 'Get-SessionBriefing -BriefFile (the expert brief must reach the session, #440)' {
+    It 'points the session at the brief and gives it precedence' {
+        $b = Get-SessionBriefing 42 'o/r' 'issue-42-x' 'C:\wt' -BriefFile 'C:\s\expert-brief-42.md'
+        $b | Should -Match 'expert-brief-42\.md'
+        $b | Should -Match 'read it FIRST'
+        $b | Should -Match 'overrides'
+    }
+    It 'says nothing about a brief when none is passed' {
+        (Get-SessionBriefing 42 'o/r' 'issue-42-x' 'C:\wt') | Should -Not -Match 'expert-brief'
+    }
+    It 'composes with the brake' {
+        $b = Get-SessionBriefing 42 'o/r' 'issue-42-x' 'C:\wt' -StopAtPR -BriefFile 'C:\s\expert-brief-42.md'
+        $b | Should -Not -Match 'Board-Merge\.ps1'
+        $b | Should -Match 'expert-brief-42\.md'
+        $b | Should -Not -Match "`n"
+    }
+}
+
 Describe 'Get-SessionBriefing adapter-aware' {
     It 'keeps the claude briefing unchanged' {
         (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'claude') | Should -Match 'AUTONOMOUSLY'


### PR DESCRIPTION
Cierra el punto 1 de #440 — el freno de lo irreversible.

## El problema no era que la sesión ignorara el freno

`Expert-Auto.ps1` escribía `STOP before: merge, deploy, …` en `expert-brief-<n>.md` y delegaba en `Board-Work.ps1 -Launch`, **que nunca lee ese archivo** (`grep expert-brief Board-Work.ps1` → 0 resultados). El prompt que la sesión sí recibía venía de `Get-SessionBriefing`, y ordenaba el merge:

```
(5) merge it (ruleset-safe): Board-Merge.ps1 -PR <pr>
… When the PR is merged and your findings recorded, you are done.
```

El merge no era solo un paso: era la **condición de terminación**. La sesión que mergeó su PR a `main` estaba cumpliendo su briefing. En un repo cableado a Cloudflare Pages por integración Git, ese merge además desplegó a producción. El freno era documentación; la orden era código.

## El fix

Dos interruptores lo convierten en un control:

- **`-StopAtPR`** — no emite el paso del merge, renumera los pasos siguientes (sin dejar hueco en `(5)`) y mueve la meta a *PR abierto + review gate verde + findings registrados*.
- **`-BriefFile <path>`** — le entrega a la sesión el brief que nunca recibió, con instrucción de leerlo primero y de que **prevalece** sobre los pasos genéricos.

Ambos se enhebran por `Start-WorktreeSession` hasta los cuatro sitios de lanzamiento (fleet, single, preview, relaunch). `Expert-Auto.ps1` deriva `-StopAtPR` preguntándole al mismo gate que usa el experto en runtime (`Test-IsIrreversible -Action 'merge'`), así decide **el contrato** y no un default hardcodeado — e imprime si el freno quedó `ARMED` u `OFF`.

`/board work -Launch` a secas no cambia: sin `-StopAtPR` el briefing es idéntico byte a byte.

## Verificación

TDD, rojo antes y verde después:

| | Passed | Failed |
|---|---|---|
| `Board-Work.Tests.ps1` antes del fix | 304 | **6** |
| `Board-Work.Tests.ps1` después | **310** | 0 |
| `Expert-*.Tests.ps1` | 72 | 0 |

14 casos nuevos, incluido un guard de renumeración (cada `(n)` aparece exactamente una vez y no queda un `(6)` huérfano) y la comprobación de que el briefing sigue siendo una sola línea.

Briefing real renderizado con el freno puesto — sin `Board-Merge.ps1` por ningún lado:

```
Your full brief for this run is at …\expert-brief-265.md - read it FIRST and follow it;
where it conflicts with the generic steps below, it overrides them. You are running
AUTONOMOUSLY … (4) pass the review gate: … (5) record what you learned … Then STOP:
leave the PR open and ready for the human to merge. Your contract marks the merge as
irreversible - do NOT merge, deploy, publish or delete anything, and do not treat the
merge as your finish line.
```

## Alcance

Solo el punto 1 de #440. Siguen abiertos ahí el punto 2 (no hay verificación posterior ni reporte al humano cuando el run termina) y el punto 3 (los dos footguns de lanzamiento: token peor-escoped y worktree cortado de un HEAD desactualizado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
