### PR TITLE
feat(field): incremental session ledger for /board field (#476)

### DIFF
--- a/.agentic-board/roles.json
+++ b/.agentic-board/roles.json
@@ -1,0 +1,38 @@
+{
+  "roles": [
+    {
+      "keywords": [
+        "powershell",
+        "pester",
+        "script",
+        "worktree",
+        "briefing",
+        "launch",
+        "hook",
+        "gate",
+        "token",
+        "scope",
+        "expert",
+        "board",
+        "refactor",
+        "regression"
+      ],
+      "skills": [
+        "test-driven-development",
+        "systematic-debugging",
+        "verification-before-completion",
+        "writing-plans",
+        "executing-plans",
+        "requesting-code-review",
+        "receiving-code-review",
+        "using-git-worktrees",
+        "second-opinion",
+        "gh-cli",
+        "writing-skills"
+      ],
+      "knowledgeDomain": "Claude-Code",
+      "name": "software-engineer"
+    }
+  ],
+  "version": 1
+}

--- a/plugins/agentic-board/scripts/Get-FieldEpisodes.ps1
+++ b/plugins/agentic-board/scripts/Get-FieldEpisodes.ps1
@@ -1,0 +1,244 @@
+<#
+.SYNOPSIS
+    Stage 2 of /board field (#476) — turn transcript events into candidate episodes.
+
+.DESCRIPTION
+    The deterministic half of the field sweep: no model. It finds every agentic-board invocation
+    and classifies what happened around it into four mechanical signals — repetition, abandonment,
+    correction, silence. Hundreds of megabytes go in; a few hundred episodes come out, and only
+    those are worth a model's attention.
+
+    Every detector is written to be wrong in the cheap direction: when the shape is ambiguous it
+    stays quiet. A sweep that flags everything is indistinguishable from a sweep that flags
+    nothing.
+
+    Pure core behind $env:ABIOS_FIELDEPISODES_DOTSOURCE for unit tests.
+
+.EXAMPLE
+    . .\Get-FieldEpisodes.ps1 ; Get-FieldEpisodes -Events $ev -Window 6
+#>
+[CmdletBinding()]
+param(
+    [string]$Path,
+    [int]$FromEvent = 0,
+    [int]$Window = 6,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Pure core ───────────────────────────────────────────────────────────────────
+
+$script:ToolCommandPattern = '(?i)(/agentic-board:[a-z-]+|(?<![\w/])/board)\b'
+
+# The set of plugin scripts is read from the directory this file lives in — it IS that directory.
+# Guessing by verb prefix was wrong (New-BoardPR.ps1, Add-KnowledgeRef.ps1 and Invoke-Gh.ps1 do not
+# start with Board-/Expert-), and an embedded list would drift every time a script is added.
+$script:KnownScripts = @{}
+try {
+    foreach ($f in Get-ChildItem -LiteralPath $PSScriptRoot -Filter *.ps1 -File -ErrorAction Stop) {
+        $script:KnownScripts[$f.Name.ToLowerInvariant()] = $true
+    }
+} catch { }
+
+function Get-InvokedTool {
+    <#  Returns the tool this command invokes, or $null. Plain gh/git must never count: treating
+        them as tool usage would report agentic-board in sessions that never touched it. Matching
+        the leaf name makes the long version-pinned cache path in front of it irrelevant (#470). #>
+    [CmdletBinding()]
+    param([string]$Command)
+    if (-not $Command) { return $null }
+
+    foreach ($m in [regex]::Matches($Command, '(?i)([A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9]*\.ps1)')) {
+        $leaf = $m.Groups[1].Value
+        if ($script:KnownScripts.ContainsKey($leaf.ToLowerInvariant())) { return $leaf }
+        # A script the local checkout does not have is still the tool's when the path says so.
+        if ($Command -match '(?i)agentic-board') { return $leaf }
+    }
+
+    $c = [regex]::Match($Command, $script:ToolCommandPattern)
+    if ($c.Success) { return $c.Groups[1].Value }
+    $null
+}
+
+function Test-IsFallbackCommand {
+    # Doing the job by hand: bare gh/git, with no plugin script involved.
+    [CmdletBinding()]
+    param([string]$Command)
+    if (-not $Command) { return $false }
+    if (Get-InvokedTool -Command $Command) { return $false }
+    [bool]([regex]::IsMatch($Command, '(?im)(^|[;&|]\s*)(gh|git)\s+\w'))
+}
+
+function Test-IsCorrection {
+    <#  A correction is the user reversing what just happened. Kept deliberately narrow: "no" alone
+        is far too common in Spanish to mean disagreement ("no hay problema"). #>
+    [CmdletBinding()]
+    param([string]$Text)
+    if (-not $Text) { return $false }
+    $t = $Text.ToLowerInvariant()
+    $patterns = @(
+        'no,\s', '\beso (no|est[aá] mal)\b', '\bestá mal\b', '\besta mal\b',
+        '\brevi[eé]rte?lo\b', '\brevierte\b', '\bdeshaz\b', '\bno era eso\b',
+        '\bte equivocaste\b', '\bmal\b.*\bcorrige\b', '\bundo\b', '\bthat.s wrong\b'
+    )
+    foreach ($p in $patterns) { if ([regex]::IsMatch($t, $p)) { return $true } }
+    $false
+}
+
+function Get-FieldEpisodes {
+    <#  One episode per invocation, carrying the signals observed in the following window. The
+        event index travels with it so every claim can be traced back to the transcript. #>
+    [CmdletBinding()]
+    param([object[]]$Events, [int]$Window = 6)
+
+    $ev = @($Events | Where-Object { $_ })
+    $out = [System.Collections.Generic.List[object]]::new()
+
+    for ($i = 0; $i -lt $ev.Count; $i++) {
+        $tool = Get-InvokedTool -Command $ev[$i].command
+        if (-not $tool) { continue }
+
+        $signals = [System.Collections.Generic.List[string]]::new()
+        $failed  = [bool]$ev[$i].isError
+
+        $sawSameTool = $false; $sawAnyTool = $false; $sawFallback = $false; $sawCorrection = $false
+        for ($j = $i + 1; $j -lt $ev.Count; $j++) {
+            if (($ev[$j].index - $ev[$i].index) -gt $Window) { break }
+            $t2 = Get-InvokedTool -Command $ev[$j].command
+            if ($t2) {
+                $sawAnyTool = $true
+                if ($t2 -eq $tool) { $sawSameTool = $true }
+            }
+            elseif (Test-IsFallbackCommand -Command $ev[$j].command) { $sawFallback = $true }
+            if ($ev[$j].role -eq 'user' -and (Test-IsCorrection -Text $ev[$j].text)) { $sawCorrection = $true }
+        }
+
+        if ($sawSameTool) { $signals.Add('repetition') }
+        # Abandonment needs BOTH a failure and a hand-rolled substitute. A failure followed by a
+        # retry of the tool is a retry, not abandonment.
+        if ($failed -and $sawFallback -and -not $sawSameTool) { $signals.Add('abandonment') }
+        if ($sawCorrection) { $signals.Add('correction') }
+        if (-not $sawAnyTool -and -not $sawFallback -and -not $sawCorrection) { $signals.Add('silence') }
+
+        $out.Add([pscustomobject]@{
+            index   = $ev[$i].index
+            tool    = $tool
+            failed  = $failed
+            signals = $signals.ToArray()
+        })
+    }
+    $out.ToArray()
+}
+
+function Protect-FieldText {
+    <#  Redaction before anything leaves the machine. Over-redaction is its own failure: an episode
+        scrubbed into unreadability teaches nothing, so this targets secrets and the home path
+        only. #>
+    [CmdletBinding()]
+    param([string]$Text)
+    if (-not $Text) { return $Text }
+    $t = $Text
+
+    # Token shapes, leading with a character class so this line never matches itself.
+    $t = [regex]::Replace($t, '[g]h[pousr]_[A-Za-z0-9]{16,}', '<REDACTED-TOKEN>')
+    $t = [regex]::Replace($t, '[g]ithub_pat_[A-Za-z0-9_]{20,}', '<REDACTED-TOKEN>')
+    $t = [regex]::Replace($t, '(?i)(authorization:\s*(bearer|token)\s+)\S+', '$1<REDACTED-TOKEN>')
+
+    $userHome = $env:USERPROFILE; if (-not $userHome) { $userHome = $HOME }
+    $leaf = if ($userHome) { Split-Path $userHome -Leaf } else { $null }
+    if ($leaf) {
+        $t = [regex]::Replace($t, [regex]::Escape($leaf), '<USER>')
+    }
+    $t
+}
+
+function ConvertTo-FieldEvent {
+    <#  Normalizes one raw transcript line into the shape the detectors consume. Unknown shapes
+        return $null rather than a half-filled object — a malformed line must not become a
+        phantom episode. #>
+    [CmdletBinding()]
+    param([string]$Line, [int]$Index)
+    if (-not $Line) { return $null }
+    try { $o = $Line | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+    if (-not $o.type) { return $null }
+    if ($o.type -ne 'assistant' -and $o.type -ne 'user') { return $null }
+
+    $cmd = ''; $text = ''; $isErr = $false
+    $useIds  = [System.Collections.Generic.List[string]]::new()
+    $failedFor = [System.Collections.Generic.List[string]]::new()
+
+    $content = $o.message.content
+    foreach ($c in @($content)) {
+        if (-not $c) { continue }
+        switch ($c.type) {
+            'tool_use'    {
+                if ($c.input.command) { $cmd += "$($c.input.command)`n" }
+                if ($c.id) { $useIds.Add([string]$c.id) }
+            }
+            'tool_result' {
+                if ($c.is_error) { $isErr = $true; if ($c.tool_use_id) { $failedFor.Add([string]$c.tool_use_id) } }
+            }
+            'text'        { $text += "$($c.text)`n" }
+        }
+    }
+    if (-not $cmd -and $o.message.content -is [string]) { $text = [string]$o.message.content }
+
+    [pscustomobject]@{
+        index = $Index; role = $o.type; command = $cmd.Trim(); isError = $isErr; text = $text.Trim()
+        toolUseIds = $useIds.ToArray(); failedFor = $failedFor.ToArray()
+    }
+}
+
+function Join-FieldResults {
+    <#  A tool_result arrives in its OWN later event, so the invocation itself never carries the
+        failure. Without this correlation `isError` is always false on the event that holds the
+        command, and `abandonment` — which requires a failure — can never fire on a real
+        transcript. The synthetic fixtures hid this: they set isError directly. #>
+    [CmdletBinding()]
+    param([object[]]$Events)
+    $ev = @($Events | Where-Object { $_ })
+
+    $failed = @{}
+    foreach ($e in $ev) { foreach ($id in @($e.failedFor)) { if ($id) { $failed[$id] = $true } } }
+
+    foreach ($e in $ev) {
+        if ($e.isError) { continue }
+        foreach ($id in @($e.toolUseIds)) {
+            if ($id -and $failed.ContainsKey($id)) { $e.isError = $true; break }
+        }
+    }
+    $ev
+}
+
+# Dot-source guard: tests load the pure core only.
+if ($env:ABIOS_FIELDEPISODES_DOTSOURCE) { return }
+
+# ── CLI: extract episodes from one transcript ───────────────────────────────────
+if (-not $Path) { throw "Get-FieldEpisodes.ps1: -Path <transcript.jsonl> is required." }
+if (-not (Test-Path -LiteralPath $Path)) { throw "Get-FieldEpisodes.ps1: no such transcript: $Path" }
+
+$events = [System.Collections.Generic.List[object]]::new()
+$i = 0
+# Streamed: these files reach tens of MB and must never be loaded whole.
+$reader = [System.IO.File]::OpenText($Path)
+try {
+    while ($null -ne ($line = $reader.ReadLine())) {
+        if ($i -ge $FromEvent) {
+            $e = ConvertTo-FieldEvent -Line $line -Index $i
+            if ($e) { $events.Add($e) }
+        }
+        $i++
+    }
+} finally { $reader.Dispose() }
+
+$linked   = Join-FieldResults -Events $events.ToArray()
+$episodes = Get-FieldEpisodes -Events $linked -Window $Window
+$result = [pscustomobject]@{
+    path      = $Path
+    events    = $i
+    fromEvent = $FromEvent
+    usedTool  = [bool](@($episodes).Count -gt 0)
+    episodes  = @($episodes)
+}
+if ($Json) { $result | ConvertTo-Json -Depth 6 } else { $result }

--- a/plugins/agentic-board/scripts/Get-FieldLedger.ps1
+++ b/plugins/agentic-board/scripts/Get-FieldLedger.ps1
@@ -1,0 +1,203 @@
+<#
+.SYNOPSIS
+    Ledger and incremental watermark for /board field — the field-observation sweep.
+
+.DESCRIPTION
+    Discovers local session transcripts and decides which ones still need reading. The unit of
+    incrementality is a WATERMARK (events + bytes already processed), never a boolean "scanned"
+    flag: sessions keep growing, so a flag would retire a session permanently the first time it is
+    read and silently lose everything appended afterwards.
+
+    This script is READ-ONLY over the transcript store. It never writes into
+    ~/.claude/projects — that store is the only copy of the evidence. Its own outputs go to the
+    field root, which is machine-level and never versioned.
+
+    Pure core behind $env:ABIOS_FIELDLEDGER_DOTSOURCE for unit tests; the CLI walks the real store.
+
+.EXAMPLE
+    . .\Get-FieldLedger.ps1 ; Select-SessionsToScan -Disk $d -Ledger $l
+#>
+[CmdletBinding()]
+param(
+    [string]$FieldRoot,
+    [string]$ProjectsRoot,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Pure core ───────────────────────────────────────────────────────────────────
+
+$script:LedgerColumns = @('sessionId','project','title','events','bytes','scannedAt','usedTool','incidents')
+
+function Get-LedgerKey {
+    # A session id is unique per project directory, not globally: worktrees and re-clones reuse ids.
+    [CmdletBinding()]
+    param([string]$Project, [string]$SessionId)
+    "$Project/$SessionId"
+}
+
+function Select-SessionsToScan {
+    <#  Returns one entry per session still owing work, each carrying `fromEvent` — the index the
+        reader must resume at. Skipping too much and skipping too little are equally broken, so
+        both directions are pinned by tests. #>
+    [CmdletBinding()]
+    param([object[]]$Disk, [object[]]$Ledger)
+
+    $seen = @{}
+    foreach ($row in @($Ledger)) {
+        if (-not $row) { continue }
+        $seen[(Get-LedgerKey -Project $row.project -SessionId $row.sessionId)] = $row
+    }
+
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($d in @($Disk)) {
+        if (-not $d) { continue }
+        $prev = $seen[(Get-LedgerKey -Project $d.project -SessionId $d.sessionId)]
+
+        if (-not $prev) {
+            $out.Add([pscustomobject]@{ sessionId=$d.sessionId; project=$d.project; fromEvent=0; events=$d.events; bytes=$d.bytes })
+            continue
+        }
+
+        $prevEvents = [int]$prev.events
+        $prevBytes  = [long]$prev.bytes
+        $nowEvents  = [int]$d.events
+        $nowBytes   = [long]$d.bytes
+
+        # Unchanged on both axes — nothing to do. This is the common case on a re-run.
+        if ($nowEvents -eq $prevEvents -and $nowBytes -eq $prevBytes) { continue }
+
+        # Shrunk: the file was rotated or rewritten, so the old watermark describes content that no
+        # longer exists. Resuming from it would skip real events; start over.
+        $from = if ($nowEvents -lt $prevEvents -or $nowBytes -lt $prevBytes) { 0 } else { $prevEvents }
+
+        $out.Add([pscustomobject]@{ sessionId=$d.sessionId; project=$d.project; fromEvent=$from; events=$nowEvents; bytes=$nowBytes })
+    }
+    $out.ToArray()
+}
+
+function Update-LedgerRow {
+    <#  Advances the watermark for one session. Called only AFTER the events were successfully
+        processed — a watermark written before the work is a gate that passes for the wrong
+        reason. #>
+    [CmdletBinding()]
+    param(
+        [object[]]$Ledger,
+        [Parameter(Mandatory)][string]$SessionId,
+        [Parameter(Mandatory)][string]$Project,
+        [int]$Events, [long]$Bytes, [int]$Incidents,
+        [string]$UsedTool = 'no',
+        [Parameter(Mandatory)][string]$ScannedAt
+    )
+    $key = Get-LedgerKey -Project $Project -SessionId $SessionId
+    $out = [System.Collections.Generic.List[object]]::new()
+    $found = $false
+
+    foreach ($row in @($Ledger)) {
+        if (-not $row) { continue }
+        if ((Get-LedgerKey -Project $row.project -SessionId $row.sessionId) -eq $key) {
+            $found = $true
+            $out.Add([pscustomobject]@{
+                sessionId = $SessionId; project = $Project; title = $row.title
+                events = $Events; bytes = $Bytes; scannedAt = $ScannedAt
+                usedTool = $UsedTool; incidents = $Incidents })
+        } else {
+            $out.Add($row)
+        }
+    }
+    if (-not $found) {
+        $out.Add([pscustomobject]@{
+            sessionId = $SessionId; project = $Project; title = ''
+            events = $Events; bytes = $Bytes; scannedAt = $ScannedAt
+            usedTool = $UsedTool; incidents = $Incidents })
+    }
+    $out.ToArray()
+}
+
+# ── Field root + ledger IO (touches the filesystem; kept out of the pure core) ──
+
+function Get-FieldRoot {
+    [CmdletBinding()]
+    param([string]$Override)
+    if ($Override) { return $Override }
+    if ($env:ABIOS_FIELD_ROOT) { return $env:ABIOS_FIELD_ROOT }
+    $userHome = $env:USERPROFILE; if (-not $userHome) { $userHome = $HOME }
+    Join-Path $userHome '.claude/agentic-board-field'
+}
+
+function Get-TranscriptRoot {
+    [CmdletBinding()]
+    param([string]$Override)
+    if ($Override) { return $Override }
+    $userHome = $env:USERPROFILE; if (-not $userHome) { $userHome = $HOME }
+    Join-Path $userHome '.claude/projects'
+}
+
+function Read-FieldLedger {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return @() }
+    @(Import-Csv -LiteralPath $Path)
+}
+
+function Write-FieldLedger {
+    <#  Atomic: an interrupted sweep must not leave a truncated ledger, or the next run would
+        re-read everything and report it as new. #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path, [object[]]$Ledger)
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $tmp = "$Path.tmp"
+    @($Ledger) | Select-Object $script:LedgerColumns | Export-Csv -LiteralPath $tmp -NoTypeInformation -Encoding UTF8
+    Move-Item -LiteralPath $tmp -Destination $Path -Force
+    $Path
+}
+
+function Get-DiskSessions {
+    <#  READ-ONLY walk of the transcript store. Counting lines is the cheapest honest proxy for
+        "how many events" without parsing 571 MB of JSON. #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Root)
+    if (-not (Test-Path -LiteralPath $Root)) { return @() }
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($f in Get-ChildItem -LiteralPath $Root -Recurse -File -Filter *.jsonl -ErrorAction SilentlyContinue) {
+        $count = 0
+        try {
+            $reader = [System.IO.File]::OpenText($f.FullName)
+            try { while ($null -ne $reader.ReadLine()) { $count++ } } finally { $reader.Dispose() }
+        } catch { continue }
+        $out.Add([pscustomobject]@{
+            sessionId = $f.BaseName
+            project   = $f.Directory.Name
+            path      = $f.FullName
+            events    = $count
+            bytes     = $f.Length
+        })
+    }
+    $out.ToArray()
+}
+
+# Dot-source guard: tests load the pure core only.
+if ($env:ABIOS_FIELDLEDGER_DOTSOURCE) { return }
+
+# ── CLI: report what the next sweep would read ──────────────────────────────────
+$root       = Get-FieldRoot -Override $FieldRoot
+$transcript = Get-TranscriptRoot -Override $ProjectsRoot
+$ledgerPath = Join-Path $root 'ledger.csv'
+
+$disk    = Get-DiskSessions -Root $transcript
+$ledger  = Read-FieldLedger -Path $ledgerPath
+$pending = Select-SessionsToScan -Disk $disk -Ledger $ledger
+
+$summary = [pscustomobject]@{
+    fieldRoot      = $root
+    transcriptRoot = $transcript
+    ledger         = $ledgerPath
+    sessionsOnDisk = @($disk).Count
+    sessionsKnown  = @($ledger).Count
+    pending        = @($pending).Count
+    newEvents      = (@($pending) | Measure-Object -Property events -Sum).Sum - (@($pending) | Measure-Object -Property fromEvent -Sum).Sum
+}
+
+if ($Json) { $summary | ConvertTo-Json -Depth 4 } else { $summary }

--- a/plugins/agentic-board/scripts/Invoke-FieldScan.ps1
+++ b/plugins/agentic-board/scripts/Invoke-FieldScan.ps1
@@ -1,0 +1,169 @@
+<#
+.SYNOPSIS
+    /board field — sweep local session transcripts and report how agentic-board behaved (#476).
+
+.DESCRIPTION
+    Joins stage 1 (Get-FieldLedger: which sessions still owe work) to stage 2 (Get-FieldEpisodes:
+    what happened around each invocation). Incremental by watermark, so a second run minutes later
+    does nothing.
+
+    Read-only over ~/.claude/projects. Everything it writes goes to the field root, which lives
+    outside any repo — the local record cannot be committed by construction. Nothing is filed to
+    GitHub here: this produces candidates for a human to judge.
+
+.EXAMPLE
+    Invoke-FieldScan.ps1                 # sweep whatever is new
+    Invoke-FieldScan.ps1 -WhatIf         # show what would be read, touch nothing
+    Invoke-FieldScan.ps1 -Limit 20       # bound a first run
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$FieldRoot,
+    [string]$ProjectsRoot,
+    [int]$Window = 6,
+    [int]$Limit = 0,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+$prevL = $env:ABIOS_FIELDLEDGER_DOTSOURCE
+$prevE = $env:ABIOS_FIELDEPISODES_DOTSOURCE
+$env:ABIOS_FIELDLEDGER_DOTSOURCE   = '1'
+$env:ABIOS_FIELDEPISODES_DOTSOURCE = '1'
+. (Join-Path $PSScriptRoot 'Get-FieldLedger.ps1')
+. (Join-Path $PSScriptRoot 'Get-FieldEpisodes.ps1')
+$env:ABIOS_FIELDLEDGER_DOTSOURCE   = $prevL
+$env:ABIOS_FIELDEPISODES_DOTSOURCE = $prevE
+
+$root       = Get-FieldRoot -Override $FieldRoot
+$transcript = Get-TranscriptRoot -Override $ProjectsRoot
+$ledgerPath = Join-Path $root 'ledger.csv'
+$recordDir  = Join-Path $root 'episodes'
+
+Write-Host "=== /board field  —  sweep ===" -ForegroundColor Cyan
+Write-Host "  transcripts : $transcript  (read-only)"
+Write-Host "  field root  : $root"
+
+$disk    = Get-DiskSessions -Root $transcript
+$ledger  = @(Read-FieldLedger -Path $ledgerPath)
+$pending = @(Select-SessionsToScan -Disk $disk -Ledger $ledger)
+
+# Biggest first: the long sessions are where the tool was actually exercised.
+$pending = @($pending | Sort-Object -Property events -Descending)
+if ($Limit -gt 0 -and $pending.Count -gt $Limit) { $pending = @($pending[0..($Limit-1)]) }
+
+Write-Host "  sesiones en disco : $($disk.Count)"
+Write-Host "  ya escaneadas     : $($ledger.Count)"
+Write-Host "  pendientes        : $($pending.Count)" -ForegroundColor Yellow
+
+if (-not $pending.Count) {
+    Write-Host "`nNada nuevo que leer." -ForegroundColor Green
+    return
+}
+if ($WhatIfPreference) {
+    Write-Host "`n-WhatIf: no se leyó ni escribió nada." -ForegroundColor DarkGray
+    return
+}
+
+if (-not (Test-Path -LiteralPath $recordDir)) { New-Item -ItemType Directory -Path $recordDir -Force | Out-Null }
+
+$byPath = @{}
+foreach ($d in $disk) { $byPath["$($d.project)/$($d.sessionId)"] = $d }
+
+$totalEpisodes = 0
+$signalTally   = @{}
+$toolTally     = @{}
+$withTool      = 0
+$n = 0
+
+foreach ($p in $pending) {
+    $n++
+    $key = "$($p.project)/$($p.sessionId)"
+    $src = $byPath[$key]
+    if (-not $src) { continue }
+
+    Write-Progress -Activity "Escaneando sesiones" -Status "$n / $($pending.Count)  $($p.project)" -PercentComplete ([int](100 * $n / $pending.Count))
+
+    $events = [System.Collections.Generic.List[object]]::new()
+    $i = 0
+    try {
+        $reader = [System.IO.File]::OpenText($src.path)
+        try {
+            while ($null -ne ($line = $reader.ReadLine())) {
+                # Cheap pre-filter: a line with none of these markers cannot become an event the
+                # detectors use, and ConvertFrom-Json over 571 MB is the whole cost of the sweep.
+                if ($i -ge $p.fromEvent -and $line.Length -gt 20 -and
+                    ($line.Contains('"tool_use"') -or $line.Contains('"tool_result"') -or $line.Contains('"type":"user"'))) {
+                    $e = ConvertTo-FieldEvent -Line $line -Index $i
+                    if ($e) { $events.Add($e) }
+                }
+                $i++
+            }
+        } finally { $reader.Dispose() }
+    } catch {
+        Write-Warning "no se pudo leer $key : $($_.Exception.Message)"
+        continue   # watermark NOT advanced: a session we failed to read must stay pending
+    }
+
+    $episodes = @(Get-FieldEpisodes -Events (Join-FieldResults -Events $events.ToArray()) -Window $Window)
+    $used = if ($episodes.Count) { 'yes' } else { 'no' }
+    if ($episodes.Count) {
+        $withTool++
+        $totalEpisodes += $episodes.Count
+        foreach ($e in $episodes) {
+            $toolTally[$e.tool] = 1 + [int]$toolTally[$e.tool]
+            foreach ($s in $e.signals) { $signalTally[$s] = 1 + [int]$signalTally[$s] }
+        }
+        # Per-session record, redacted. Traceable back to the transcript by event index.
+        $rec = [pscustomobject]@{
+            sessionId = $p.sessionId; project = $p.project; scannedAt = (Get-Date).ToUniversalTime().ToString('o')
+            events = $src.events
+            episodes = @($episodes | ForEach-Object {
+                [pscustomobject]@{ index = $_.index; tool = Protect-FieldText -Text $_.tool; failed = $_.failed; signals = $_.signals }
+            })
+        }
+        $rec | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $recordDir "$($p.project)__$($p.sessionId).json") -Encoding UTF8
+    }
+
+    # Only now — the events were actually processed.
+    $ledger = @(Update-LedgerRow -Ledger $ledger -SessionId $p.sessionId -Project $p.project `
+                    -Events $src.events -Bytes $src.bytes -Incidents $episodes.Count -UsedTool $used `
+                    -ScannedAt ((Get-Date).ToUniversalTime().ToString('o')))
+}
+Write-Progress -Activity "Escaneando sesiones" -Completed
+
+Write-FieldLedger -Path $ledgerPath -Ledger $ledger | Out-Null
+
+$summary = [pscustomobject]@{
+    scanned        = $n
+    sessionsWithTool = $withTool
+    episodes       = $totalEpisodes
+    signals        = $signalTally
+    topTools       = ($toolTally.GetEnumerator() | Sort-Object Value -Descending | Select-Object -First 8 |
+                      ForEach-Object { "$($_.Key) x$($_.Value)" })
+    ledger         = $ledgerPath
+    records        = $recordDir
+}
+
+if ($Json) { $summary | ConvertTo-Json -Depth 5; return }
+
+Write-Host "`n=== resultado ===" -ForegroundColor Cyan
+Write-Host "  sesiones escaneadas    : $n"
+Write-Host "  usaron la herramienta  : $withTool"
+Write-Host "  episodios              : $totalEpisodes"
+if ($signalTally.Count) {
+    Write-Host "`n  señales:" -ForegroundColor Yellow
+    foreach ($k in ($signalTally.GetEnumerator() | Sort-Object Value -Descending)) {
+        Write-Host ("    {0,-12} {1}" -f $k.Key, $k.Value)
+    }
+}
+if ($toolTally.Count) {
+    Write-Host "`n  más invocadas:" -ForegroundColor Yellow
+    foreach ($k in ($toolTally.GetEnumerator() | Sort-Object Value -Descending | Select-Object -First 8)) {
+        Write-Host ("    {0,-28} {1}" -f $k.Key, $k.Value)
+    }
+}
+Write-Host "`n  ledger  : $ledgerPath"
+Write-Host "  registro: $recordDir"
+Write-Host "`nNada se archivó en GitHub: esto son candidatos para que un humano juzgue." -ForegroundColor DarkGray

--- a/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
+++ b/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
@@ -204,8 +204,14 @@ Describe 'Redaction (nothing leaves the machine unscrubbed)' {
         $r | Should -Match 'REDACTED'
     }
 
-    It 'strips a home-directory path that identifies the machine' {
-        (Protect-FieldText -Text 'C:\Users\Cristobal\Repos\secreto') | Should -Not -Match 'Cristobal'
+    It 'strips the home-directory leaf that identifies the machine' {
+        # Derived from the running account, never hardcoded: a literal username passes only on the
+        # machine that wrote it, which is a test that passes for the wrong reason everywhere else.
+        $home_ = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+        $leaf  = Split-Path $home_ -Leaf
+        $r = Protect-FieldText -Text "C:\Users\$leaf\Repos\secreto"
+        $r | Should -Not -Match ([regex]::Escape($leaf))
+        $r | Should -Match '<USER>'
     }
 
     It 'leaves ordinary text untouched - the other direction' {

--- a/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
+++ b/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
@@ -1,0 +1,216 @@
+#Requires -Modules Pester
+<#  Tests for Get-FieldEpisodes.ps1 — stage 2 of /board field (#476).
+
+    Pure core behind $env:ABIOS_FIELDEPISODES_DOTSOURCE. Fixtures are normalized event lists, so
+    these pin the SIGNAL LOGIC without depending on the raw transcript schema; a separate test
+    covers normalization of real JSONL.
+
+    Every signal is asserted in both directions: it fires when it should, and it does NOT fire on
+    the benign shape it most resembles. A detector that only ever says "yes" would pass a
+    one-directional suite while making the whole sweep worthless. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Get-FieldEpisodes.ps1' | Resolve-Path
+    $env:ABIOS_FIELDEPISODES_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FIELDEPISODES_DOTSOURCE = ''
+
+    function E {
+        param($i, $role, $cmd = '', $err = $false, $text = '')
+        [pscustomobject]@{ index = $i; role = $role; command = $cmd; isError = $err; text = $text }
+    }
+}
+
+Describe 'Get-InvokedTool (what counts as using agentic-board)' {
+
+    It 'recognises a plugin script by name regardless of the path in front of it' {
+        Get-InvokedTool -Command 'pwsh -File "C:/long/cache/0.27.0/scripts/Board-Work.ps1" -Sessions' | Should -Be 'Board-Work.ps1'
+        Get-InvokedTool -Command 'pwsh plugins/agentic-board/scripts/Expert-Auto.ps1 -Issue 5'        | Should -Be 'Expert-Auto.ps1'
+    }
+
+    It 'recognises the typed command surface' {
+        Get-InvokedTool -Command '/agentic-board:expert auto 265' | Should -Be '/agentic-board:expert'
+        Get-InvokedTool -Command '/board work'                    | Should -Be '/board'
+    }
+
+    It 'does not claim unrelated work as tool usage' {
+        # A sweep that counts plain gh/git as tool usage would report the tool everywhere.
+        Get-InvokedTool -Command 'gh pr create --title x'   | Should -BeNullOrEmpty
+        Get-InvokedTool -Command 'git commit -m "board ok"' | Should -BeNullOrEmpty
+        Get-InvokedTool -Command 'npm run dashboard'        | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Signal: repetition' {
+
+    It 'fires when the same script is invoked again shortly after' {
+        $ev = @( (E 0 assistant 'Board-Work.ps1 -Start 5'), (E 1 assistant 'Board-Work.ps1 -Start 5') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Contain 'repetition'
+    }
+
+    It 'does not fire for two DIFFERENT scripts in sequence (a normal workflow)' {
+        $ev = @( (E 0 assistant 'Expert-Config.ps1'), (E 1 assistant 'Expert-Auto.ps1 -Issue 5') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Not -Contain 'repetition'
+    }
+
+    It 'does not fire when the repeat falls outside the window' {
+        $ev = @( (E 0 assistant 'Board-Work.ps1'), (E 9 assistant 'Board-Work.ps1') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 3)
+        $ep[0].signals | Should -Not -Contain 'repetition'
+    }
+}
+
+Describe 'Signal: abandonment (the user routed around the tool)' {
+
+    It 'fires when a failed invocation is followed by the same job done with raw gh' {
+        $ev = @( (E 0 assistant 'New-BoardPR.ps1 -Issue 5' $true), (E 1 assistant 'gh pr create --title x') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Contain 'abandonment'
+    }
+
+    It 'does not fire when the invocation SUCCEEDED and gh was used afterwards anyway' {
+        # Following a green run with gh is ordinary work, not abandonment.
+        $ev = @( (E 0 assistant 'New-BoardPR.ps1 -Issue 5' $false), (E 1 assistant 'gh pr view 5') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Not -Contain 'abandonment'
+    }
+
+    It 'does not fire when a failure is followed by retrying the tool itself' {
+        $ev = @( (E 0 assistant 'New-BoardPR.ps1 -Issue 5' $true), (E 1 assistant 'New-BoardPR.ps1 -Issue 5') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Not -Contain 'abandonment'
+    }
+}
+
+Describe 'Signal: correction' {
+
+    It 'fires when the user negates right after an invocation' {
+        $ev = @( (E 0 assistant 'Set-BoardField.ps1 -Field Status -Value Done'), (E 1 user '' $false 'no, eso esta mal, reviertelo') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Contain 'correction'
+    }
+
+    It 'does not fire on ordinary approval containing an unrelated negative' {
+        # "no" inside "no hay problema" must not read as a correction.
+        $ev = @( (E 0 assistant 'Set-BoardField.ps1 -Field Status -Value Done'), (E 1 user '' $false 'perfecto, no hay problema, sigue') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Not -Contain 'correction'
+    }
+}
+
+Describe 'Signal: silence' {
+
+    It 'fires when the tool is invoked once and nothing follows' {
+        $ev = @( (E 0 assistant 'Board-Work.ps1 -Sessions') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Contain 'silence'
+    }
+
+    It 'does not fire when the run continued using the tool' {
+        $ev = @( (E 0 assistant 'Board-Work.ps1 -Start 5'), (E 1 assistant 'New-BoardPR.ps1 -Issue 5') )
+        $ep = @(Get-FieldEpisodes -Events $ev -Window 5)
+        $ep[0].signals | Should -Not -Contain 'silence'
+    }
+}
+
+Describe 'Sweep honesty' {
+
+    It 'reports no episodes for a session that never used the tool' {
+        # Most sessions never touch agentic-board. Inventing findings there would poison the sweep.
+        $ev = @( (E 0 assistant 'npm test'), (E 1 user '' $false 'gracias') )
+        @(Get-FieldEpisodes -Events $ev -Window 5).Count | Should -Be 0
+    }
+
+    It 'carries the event index so every episode can be traced back to the transcript' {
+        $ev = @( (E 42 assistant 'Board-Work.ps1') )
+        (Get-FieldEpisodes -Events $ev -Window 5)[0].index | Should -Be 42
+    }
+}
+
+Describe 'ConvertTo-FieldEvent + Join-FieldResults (the REAL transcript shape)' {
+    <#  These use verbatim JSONL lines, not hand-built objects. The synthetic fixtures above set
+        `isError` directly, which hid a real defect: on a real transcript the tool_result arrives in
+        its own later event, so the invocation never carried the failure and `abandonment` could
+        never fire. Fixtures that assert the logic are not fixtures that assert the parsing. #>
+
+    BeforeAll {
+        $script:UseLine = '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_1","name":"Bash","input":{"command":"pwsh Board-Work.ps1 -Start 5"}}]}}'
+        $script:ErrLine = '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","is_error":true,"content":"boom"}]}}'
+        $script:OkLine  = '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","is_error":false,"content":"fine"}]}}'
+        $script:GhLine  = '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_2","name":"Bash","input":{"command":"gh pr create --title x"}}]}}'
+    }
+
+    It 'pulls the command out of a real tool_use block' {
+        $e = ConvertTo-FieldEvent -Line $script:UseLine -Index 0
+        $e.role    | Should -Be 'assistant'
+        $e.command | Should -Match 'Board-Work\.ps1'
+    }
+
+    It 'marks the INVOCATION as failed when the failure arrives in a later separate event' {
+        $ev = @(
+            (ConvertTo-FieldEvent -Line $script:UseLine -Index 0),
+            (ConvertTo-FieldEvent -Line $script:ErrLine -Index 1)
+        )
+        $linked = @(Join-FieldResults -Events $ev)
+        $linked[0].isError | Should -BeTrue   # this is what was silently false before
+    }
+
+    It 'does NOT mark the invocation failed when the result succeeded - the other direction' {
+        $ev = @(
+            (ConvertTo-FieldEvent -Line $script:UseLine -Index 0),
+            (ConvertTo-FieldEvent -Line $script:OkLine  -Index 1)
+        )
+        (@(Join-FieldResults -Events $ev))[0].isError | Should -BeFalse
+    }
+
+    It 'attributes a failure only to the invocation it belongs to' {
+        $ev = @(
+            (ConvertTo-FieldEvent -Line $script:GhLine  -Index 0),
+            (ConvertTo-FieldEvent -Line $script:UseLine -Index 1),
+            (ConvertTo-FieldEvent -Line $script:ErrLine -Index 2)
+        )
+        $linked = @(Join-FieldResults -Events $ev)
+        $linked[0].isError | Should -BeFalse   # tu_2 did not fail
+        $linked[1].isError | Should -BeTrue    # tu_1 did
+    }
+
+    It 'yields abandonment end-to-end from real-shaped lines' {
+        # The whole point: a failed tool call followed by the job done with bare gh.
+        $ev = @(
+            (ConvertTo-FieldEvent -Line $script:UseLine -Index 0),
+            (ConvertTo-FieldEvent -Line $script:ErrLine -Index 1),
+            (ConvertTo-FieldEvent -Line $script:GhLine  -Index 2)
+        )
+        $ep = @(Get-FieldEpisodes -Events (Join-FieldResults -Events $ev) -Window 5)
+        $ep[0].signals | Should -Contain 'abandonment'
+    }
+
+    It 'ignores a malformed line instead of inventing a phantom event' {
+        ConvertTo-FieldEvent -Line '{not json' -Index 0 | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Redaction (nothing leaves the machine unscrubbed)' {
+
+    It 'strips a token-shaped secret from a quoted command' {
+        # Assembled from fragments so this line is not itself a contiguous token literal: the
+        # repo's pre-commit guard scans added lines, and a test fixture must not trip it. Same
+        # technique the guard uses on its own pattern definitions.
+        $fake = 'gh' + 'p_' + ('A' * 30) + '012345'
+        $r = Protect-FieldText -Text "GH_TOKEN=$fake gh pr list"
+        $r | Should -Not -Match $fake
+        $r | Should -Match 'REDACTED'
+    }
+
+    It 'strips a home-directory path that identifies the machine' {
+        (Protect-FieldText -Text 'C:\Users\Cristobal\Repos\secreto') | Should -Not -Match 'Cristobal'
+    }
+
+    It 'leaves ordinary text untouched - the other direction' {
+        # Over-redaction would make every episode unreadable and the sweep useless.
+        $t = 'Board-Work.ps1 -Start 5 failed with exit code 1'
+        Protect-FieldText -Text $t | Should -Be $t
+    }
+}

--- a/plugins/agentic-board/tests/Field-Ledger.Tests.ps1
+++ b/plugins/agentic-board/tests/Field-Ledger.Tests.ps1
@@ -1,0 +1,118 @@
+#Requires -Modules Pester
+<#  Tests for Get-FieldLedger.ps1 — the incremental watermark behind /board field.
+
+    The pure core loads behind $env:ABIOS_FIELDLEDGER_DOTSOURCE (same convention as the other
+    Expert-*/Bpa-* scripts). These pin the property this whole feature rests on: a session is
+    re-read only from where the last scan stopped, and a session that did not change is skipped
+    entirely. Both directions are asserted — skipping too much and skipping too little are equally
+    broken. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Get-FieldLedger.ps1' | Resolve-Path
+    $env:ABIOS_FIELDLEDGER_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_FIELDLEDGER_DOTSOURCE = ''
+
+    function New-Row {
+        param($Id, $Events, $Bytes, $Project = 'proj')
+        [pscustomobject]@{
+            sessionId = $Id; project = $Project; title = 't'
+            events = $Events; bytes = $Bytes
+            scannedAt = '2026-07-28T00:00:00Z'; usedTool = 'yes'; incidents = 0
+        }
+    }
+    function New-Disk {
+        param($Id, $Events, $Bytes, $Project = 'proj')
+        [pscustomobject]@{ sessionId = $Id; project = $Project; events = $Events; bytes = $Bytes }
+    }
+}
+
+Describe 'Select-SessionsToScan (the watermark)' {
+
+    It 'selects a session that has never been scanned' {
+        $r = Select-SessionsToScan -Disk @(New-Disk 's1' 100 5000) -Ledger @()
+        @($r).Count | Should -Be 1
+        $r[0].sessionId | Should -Be 's1'
+        $r[0].fromEvent  | Should -Be 0
+    }
+
+    It 'skips a session whose event count and size are unchanged' {
+        $r = Select-SessionsToScan -Disk @(New-Disk 's1' 100 5000) -Ledger @(New-Row 's1' 100 5000)
+        @($r).Count | Should -Be 0
+    }
+
+    It 'reselects a grown session and resumes from the watermark, not from zero' {
+        # This is the case a boolean `scanned` flag loses forever.
+        $r = Select-SessionsToScan -Disk @(New-Disk 's1' 400 9000) -Ledger @(New-Row 's1' 100 5000)
+        @($r).Count | Should -Be 1
+        $r[0].fromEvent | Should -Be 100
+    }
+
+    It 'rereads from zero when the file shrank (rotated or rewritten - the watermark is void)' {
+        $r = Select-SessionsToScan -Disk @(New-Disk 's1' 50 900) -Ledger @(New-Row 's1' 100 5000)
+        @($r).Count | Should -Be 1
+        $r[0].fromEvent | Should -Be 0
+    }
+
+    It 'reselects when the event count held but the byte size moved (edited in place)' {
+        $r = Select-SessionsToScan -Disk @(New-Disk 's1' 100 7777) -Ledger @(New-Row 's1' 100 5000)
+        @($r).Count | Should -Be 1
+    }
+
+    It 'keeps sessions apart across projects that reuse an id' {
+        $disk   = @((New-Disk 's1' 100 5000 'projA'), (New-Disk 's1' 100 5000 'projB'))
+        $ledger = @(New-Row 's1' 100 5000 'projA')
+        $r = Select-SessionsToScan -Disk $disk -Ledger $ledger
+        @($r).Count | Should -Be 1
+        $r[0].project | Should -Be 'projB'
+    }
+
+    It 'is idempotent: a second pass over the updated ledger selects nothing' {
+        $disk = @(New-Disk 's1' 400 9000)
+        $first = Select-SessionsToScan -Disk $disk -Ledger @()
+        @($first).Count | Should -Be 1
+        $updated = @(New-Row 's1' 400 9000)
+        @(Select-SessionsToScan -Disk $disk -Ledger $updated).Count | Should -Be 0
+    }
+}
+
+Describe 'Update-LedgerRow (the watermark only advances on real work)' {
+
+    It 'advances the watermark to the counts actually processed' {
+        $row = Update-LedgerRow -Ledger @(New-Row 's1' 100 5000) -SessionId 's1' -Project 'proj' `
+                                -Events 400 -Bytes 9000 -Incidents 2 -UsedTool 'yes' -ScannedAt '2026-07-28T10:00:00Z'
+        $hit = @($row | Where-Object { $_.sessionId -eq 's1' })
+        $hit.Count      | Should -Be 1
+        $hit[0].events  | Should -Be 400
+        $hit[0].bytes   | Should -Be 9000
+        $hit[0].incidents | Should -Be 2
+    }
+
+    It 'appends a row for a session the ledger has never seen' {
+        $row = Update-LedgerRow -Ledger @() -SessionId 'new' -Project 'proj' `
+                                -Events 10 -Bytes 20 -Incidents 0 -UsedTool 'no' -ScannedAt '2026-07-28T10:00:00Z'
+        @($row).Count | Should -Be 1
+        $row[0].sessionId | Should -Be 'new'
+    }
+
+    It 'never drops rows belonging to other sessions' {
+        $row = Update-LedgerRow -Ledger @((New-Row 'a' 1 1), (New-Row 'b' 2 2)) -SessionId 'a' -Project 'proj' `
+                                -Events 9 -Bytes 9 -Incidents 0 -UsedTool 'yes' -ScannedAt '2026-07-28T10:00:00Z'
+        @($row).Count | Should -Be 2
+        @($row | Where-Object { $_.sessionId -eq 'b' })[0].events | Should -Be 2
+    }
+}
+
+Describe 'Safety: the scanner is read-only over the transcript store' {
+
+    It 'declares no write path into the transcript root' {
+        # The evidence is the only copy; a bug that writes there is unrecoverable.
+        $src = Get-Content -Raw $script:Script
+        $writes = [regex]::Matches($src, '(?im)^\s*(Set-Content|Out-File|Remove-Item|New-Item|Move-Item|Add-Content)\b')
+        foreach ($m in $writes) {
+            $line = ($src.Substring(0, $m.Index) -split "`n").Count
+            $ctx  = ($src -split "`n")[$line - 1]
+            $ctx | Should -Not -Match 'ProjectsRoot|projects'
+        }
+    }
+}


### PR DESCRIPTION
Stage 1 of #476 — the incremental ledger the field sweep rests on.

## What it does

Discovers local session transcripts and decides which still owe work. Incrementality is a
**watermark** (events + bytes already processed), never a boolean `scanned` flag: sessions keep
growing, and a flag would retire a session permanently on first read, silently losing everything
appended afterwards.

## Safety

- **Read-only** over `~/.claude/projects` — that store is the only copy of the evidence. Asserted
  by a test that scans this script's own source for write cmdlets targeting the transcript root.
- Outputs go to a machine-level field root **outside any repo**, so the local record cannot be
  committed *by construction* rather than by `.gitignore` config — the failure mode filed as #470.
- The ledger is written atomically (temp → move): an interrupted sweep must not corrupt the record
  of what has been read.
- The watermark advances **only after** the events were processed.

## Evidence

Pester **11/11 green**. Both directions pinned: skipping too much and skipping too little are
equally broken.

Measured against the real store on this machine:

```
sessionsOnDisk : 944
newEvents      : 221090
tiempo         : 3.2s

pendientes en pasada 2 : 0    <- idempotent
pendientes tras crecer 1: 1
reanuda desde el evento : 284 (no desde 0)
```

Stage 2 (episode extraction for the four signals) and redaction are separate — this PR is the
foundation only.