### PR TITLE
seo: add site link in intro — Agentic BI Ops post

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the whole issue → branch → PR → gate → merge loop.
 > **See it run on itself → [SHOWCASE.md](SHOWCASE.md)** — the tool governs its own roadmap board;
 > every fix was found while using it and tracked in the open (the dogfooding loop).
 >
-> Read the measured case study on how the tool runs a real BI project's board → **[Agentic BI Ops on the field](https://csalcedodatabi.com/blog/agentic-bi-ops/)**
+> Read the case study on running a real BI project's board with this tool → **[agentic-board: agentes de Claude Code en tu board de GitHub](https://csalcedodatabi.com/blog/agentic-bi-ops/)** (in Spanish)
 
 BI GitOps (PBIP/Fabric, TMDL diff review, semantic-model agents) is a **future module** on the
 same foundation — see the [roadmap](#module-roadmap).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ the whole issue → branch → PR → gate → merge loop.
 
 > **See it run on itself → [SHOWCASE.md](SHOWCASE.md)** — the tool governs its own roadmap board;
 > every fix was found while using it and tracked in the open (the dogfooding loop).
+>
+> Read the measured case study on how the tool runs a real BI project's board → **[Agentic BI Ops on the field](https://csalcedodatabi.com/blog/agentic-bi-ops/)**
 
 BI GitOps (PBIP/Fabric, TMDL diff review, semantic-model agents) is a **future module** on the
 same foundation — see the [roadmap](#module-roadmap).


### PR DESCRIPTION
Extends the existing SHOWCASE.md callout with a link to the companion article at `https://csalcedodatabi.com/blog/agentic-bi-ops/`. Descriptive anchor text; stays within the blockquote so the tone is consistent.

Part of CSalcedoDataBI/csalcedodatabi.com#271.