### PR TITLE
Define the software-engineer role in this repo .agentic-board/roles.json

### DIFF
--- a/.agentic-board/roles.json
+++ b/.agentic-board/roles.json
@@ -1,0 +1,38 @@
+{
+  "roles": [
+    {
+      "keywords": [
+        "powershell",
+        "pester",
+        "script",
+        "worktree",
+        "briefing",
+        "launch",
+        "hook",
+        "gate",
+        "token",
+        "scope",
+        "expert",
+        "board",
+        "refactor",
+        "regression"
+      ],
+      "skills": [
+        "test-driven-development",
+        "systematic-debugging",
+        "verification-before-completion",
+        "writing-plans",
+        "executing-plans",
+        "requesting-code-review",
+        "receiving-code-review",
+        "using-git-worktrees",
+        "second-opinion",
+        "gh-cli",
+        "writing-skills"
+      ],
+      "knowledgeDomain": "Claude-Code",
+      "name": "software-engineer"
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
Closes #460