### PR TITLE
fix(roles): the plugin suite read the checkout's local role catalog, so main went red (#460)

### DIFF
--- a/.agentic-board/roles.json
+++ b/.agentic-board/roles.json
@@ -2,19 +2,13 @@
   "roles": [
     {
       "keywords": [
+        "agentic-board",
         "powershell",
         "pester",
-        "script",
         "worktree",
         "briefing",
-        "launch",
-        "hook",
-        "gate",
-        "token",
-        "scope",
-        "expert",
         "board",
-        "refactor",
+        "expert",
         "regression"
       ],
       "skills": [

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -16,20 +16,40 @@ BeforeAll {
         'fabric-cli:fabric-cli',
         'skill-creator','writing-skills','second-opinion'   # quality profile
     )
+
+    # The FACTORY catalog, explicitly. Without this these tests call Get-ExpertRoles, which merges
+    # whatever `.agentic-board/roles.json` the working directory happens to hold — so adding a
+    # local role to any project broke the plugin's own suite. A unit test of the classification
+    # logic must not depend on the checkout it runs in.
+    $presets = Join-Path $PSScriptRoot '..' 'presets' 'roles.json' | Resolve-Path
+    $pj = Get-Content -Raw -LiteralPath $presets | ConvertFrom-Json
+    $script:Factory = @{
+        qualityProfile = @($pj.qualityProfile)
+        roles = @($pj.roles | ForEach-Object {
+            @{ name = $_.name; keywords = @($_.keywords); skills = @($_.skills) }
+        })
+    }
 }
 
 Describe 'Get-DomainFromPlan' {
     It 'classifies a Power BI visual plan as powerbi-report' {
-        Get-DomainFromPlan -Text 'Build a Power BI visual extension using Deneb' | Should -Be 'powerbi-report'
+        Get-DomainFromPlan -Text 'Build a Power BI visual extension using Deneb' -Catalog $script:Factory | Should -Be 'powerbi-report'
     }
     It 'classifies a DAX/measure plan as semantic-model' {
-        Get-DomainFromPlan -Text 'Add a DAX measure to the semantic model and validate TMDL' | Should -Be 'semantic-model'
+        Get-DomainFromPlan -Text 'Add a DAX measure to the semantic model and validate TMDL' -Catalog $script:Factory | Should -Be 'semantic-model'
     }
     It 'classifies a Fabric lakehouse plan as fabric' {
-        Get-DomainFromPlan -Text 'Create a Fabric lakehouse ingestion pipeline' | Should -Be 'fabric'
+        Get-DomainFromPlan -Text 'Create a Fabric lakehouse ingestion pipeline' -Catalog $script:Factory | Should -Be 'fabric'
     }
     It 'falls back to generic for unrelated text' {
-        Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' | Should -Be 'generic'
+        Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' -Catalog $script:Factory | Should -Be 'generic'
+    }
+    It 'is unaffected by whatever local catalog the checkout holds' {
+        # The regression guard for the defect this fix answers: a local role must not be able to
+        # change the factory classification these tests assert.
+        $local = @{ roles = @(@{ name='swallow-everything'; keywords=@('refactor','the','a'); skills=@() }) }
+        Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' -Catalog $local | Should -Be 'swallow-everything'
+        Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' -Catalog $script:Factory | Should -Be 'generic'
     }
 }
 


### PR DESCRIPTION
Repairs \main\, which I turned red by committing a local role while merging over a failing check.

## The real defect

The classification tests call the domain resolver **without an explicit catalog**, so they merge whatever local role file the working directory happens to hold. A unit test of pure classification depending on the checkout it runs in — meaning **any project that defines a local role breaks the plugin's own suite**, not just this one.

The tests now build the factory catalog from the shipped presets and pass it explicitly, with a regression guard asserting **both** directions: a local catalog *does* change classification, the factory one *does not*.

## Also

Narrowed the local role from 14 keywords to 8, dropping the ordinary English words (\script\, \hook\, \gate\, \	oken\, \scope\, \efactor\) that let a high-precedence local role swallow unrelated plans. Same 15 hooked skills — keywords decide *when* a role is chosen, not what it brings. This is #474 applied to our own role.

## Evidence

Full suite **1288 passed / 0 failed** locally before pushing.