### PR TITLE
Board-Work: item reads are capped at 200, so a mature board falsely reports 'Sin pendientes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- **A mature board no longer reports itself empty** (#484). `Board-Work.ps1` read board items with
+  `gh project item-list --limit 200`. That call returns exit 0 and exactly 200 items on a bigger
+  board — **oldest-first**, so on a mature board the cap fills with Done work and the Backlog falls
+  off the end. Against the tool's own 291-item board, `/board work` printed
+  `Sin pendientes. Todo el board esta en progreso o terminado.` over **37 open Backlog items**.
+  Not a truncation warning — a confident **false all-clear**, landing precisely on the mature boards
+  where the stakes are highest, and it silently under-counted the `-ListBoards` board picker the
+  same way.
+  Board reads now go through `Get-BoardItems.ps1`, which returns `{ Items; Read; Limit; Truncated }`
+  and treats a read that reached its cap as **possibly short**. Callers may no longer state an
+  absence off one: `/board work` says how many items it actually saw instead of "sin pendientes",
+  the board picker renders capped counts as `N+` with an explicit `TRUNCADO` line,
+  `Assert-BoardComplete` **fails closed** (a `PASS` is exactly the absence a short read cannot
+  support, and CI would read it as ground truth), and `/board update` publishes the caveat rather
+  than a clean-looking lie. The shared ceiling is 2000 and costs nothing: `gh` pages the underlying
+  GraphQL 100 at a time, so request count tracks the items that exist, not the cap — the old 200
+  bought no savings and cost the truth. A regression test asserts no script returns to a 200-item
+  cap.
+  This is the same defect class `Invoke-Gh.ps1` was written for (#303): a read consumed as fact.
+  `Invoke-Gh` made a **failed** read loud; this makes a **short** one loud. Neither substitutes for
+  the other — a truncated read succeeds.
+
 ## [0.28.0] - 2026-07-28
 ### Added
 - **`/board telemetry` — the tool now measures how it actually behaved in real use** (#476;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,30 @@
   where the stakes are highest, and it silently under-counted the `-ListBoards` board picker the
   same way.
   Board reads now go through `Get-BoardItems.ps1`, which returns `{ Items; Read; Limit; Truncated }`
-  and treats a read that reached its cap as **possibly short**. Callers may no longer state an
-  absence off one: `/board work` says how many items it actually saw instead of "sin pendientes",
-  the board picker renders capped counts as `N+` with an explicit `TRUNCADO` line,
-  `Assert-BoardComplete` **fails closed** (a `PASS` is exactly the absence a short read cannot
-  support, and CI would read it as ground truth), and `/board update` publishes the caveat rather
-  than a clean-looking lie. The shared ceiling is 2000 and costs nothing: `gh` pages the underlying
-  GraphQL 100 at a time, so request count tracks the items that exist, not the cap — the old 200
-  bought no savings and cost the truth. A regression test asserts no script returns to a 200-item
-  cap.
+  and treats a read that reached its cap as **possibly short**. No caller may state an absence off
+  one. Every board reader was audited, not just the two in the bug report — the caps ranged from 200
+  to 1000 and **six** surfaces were asserting things a short read cannot support:
+  - `/board work` says how many items it actually saw instead of "sin pendientes"; the board picker
+    renders capped counts as `N+` with an explicit `TRUNCADO` line.
+  - `/board complete` **fails closed** — a `PASS` is exactly the absence a short read cannot
+    support, and CI would read it as ground truth.
+  - `/board triage` no longer prints "(no hay items pendientes)" over an untriaged board.
+  - **`/board field apply --merge-conflicts` no longer deletes an option on an unproven verification.**
+    The worst of the six: it moves items off a legacy option, checks that none remain, then deletes
+    it — and its own comment names the stake ("an item silently losing its Status is data loss").
+    The check read with a bare `gh ... --limit 800` and no cap test, so "0 left" could be an
+    artifact of the cap. A truncated verification now aborts on the same grounds as a found item.
+  - `Backup-Board` refuses to write a partial snapshot: it is the safety net taken *before* a
+    destructive operation, so a partial one is worse than none — it would license the delete it
+    exists to make reversible.
+  - `Export-BoardSnapshot` refuses to publish a truncated `N of M`, and `/board update` publishes
+    floors (`N+`) rather than stating a count and retracting it in a footnote.
+  - `Set-BoardField` warns *before* its sweep that the pass is partial, instead of printing a
+    `set=N` summary that reads like a complete one.
+  The shared ceiling is 2000 and costs nothing: `gh` pages the underlying GraphQL 100 at a time, so
+  request count tracks the items that exist, not the cap — the old 200 bought no savings and cost
+  the truth. Regression tests assert that no script hardcodes its own `item-list` cap and that every
+  board reader pulls in the shared one.
   This is the same defect class `Invoke-Gh.ps1` was written for (#303): a read consumed as fact.
   `Invoke-Gh` made a **failed** read loud; this makes a **short** one loud. Neither substitutes for
   the other — a truncated read succeeds.

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -91,6 +91,9 @@ if ($MergeConflicts -and $NoMigrate) { Write-Error "-MergeConflicts y -NoMigrate
 # A gh failure on the field-list read below must THROW, not read as "the board has no fields":
 # that empty result is exactly the premise this script would then CREATE every field from (#303).
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# ...and a CAPPED item read must not read as "the option is empty" - that empty result is the
+# premise --merge-conflicts DELETES an option from, losing those items' field value (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
 if (-not $PresetPath) { $PresetPath = Join-Path $PSScriptRoot "..\presets\fields.$Lang.json" }
 # Show the RESOLVED file path, not the raw -Lang/-Preset value: "Preset not found: en" reads as
@@ -143,11 +146,19 @@ function Get-ProjectId {
 # The items currently assigned to $optionName on $fieldName. Always read fresh: this is
 # both the pre-move list and the post-move verification, and a stale answer here is what
 # would let the delete run over items that never moved.
+#
+# Returns { Items; Truncated } rather than a bare array, because the caller uses an EMPTY result
+# as proof that nothing is left before deleting the option - and a capped read cannot prove that
+# (#484). It used to read with a bare `gh ... --limit 800`: on a board whose matching items sit
+# past the cap, "0 left" was a false all-clear licensing a destructive delete.
 function Get-ItemsOnOption($fieldName, $optionName) {
   $key  = ($fieldName -replace '[^A-Za-z0-9]','').ToLower()   # item-list lowercases/strips field names
-  $json = gh project item-list $Number --owner $Owner --format json --limit 800
-  if ($LASTEXITCODE -ne 0) { throw "no pude listar los items del project #$Number (gh exit $LASTEXITCODE)" }
-  return @(($json | ConvertFrom-Json).items | Where-Object { $_.$key -eq $optionName })
+  $read = Get-BoardItems -Number $Number -Owner $Owner `
+                         -What "listar los items del project #$Number"
+  [pscustomobject]@{
+    Items     = @($read.Items | Where-Object { $_.$key -eq $optionName })
+    Truncated = $read.Truncated
+  }
 }
 
 # Collapse a legacy option onto its canonical one: move the items, verify, delete the option.
@@ -156,7 +167,8 @@ function Invoke-OptionMerge($merge) {
   $proj  = Get-ProjectId
   $field = Get-SingleSelectField $merge.Field
   if (-not $field.id) { Write-Host "  (no pude leer '$($merge.Field)' para fusionar)" -ForegroundColor DarkYellow; return $false }
-  $items = @(Get-ItemsOnOption $merge.Field $merge.FromName)
+  $preRead = Get-ItemsOnOption $merge.Field $merge.FromName
+  $items   = @($preRead.Items)
   Write-Host ("  merge: {0} '{1}' -> '{2}' ({3} item(s))" -f $merge.Field, $merge.FromName, $merge.ToName, $items.Count) -ForegroundColor Cyan
 
   # 1. MOVE. This must happen before the delete: GitHub does not reassign the items of a
@@ -176,9 +188,17 @@ function Invoke-OptionMerge($merge) {
 
   # 2. VERIFY before destroying anything. One un-moved item is enough to abort: the option
   #    staying is a cosmetic annoyance, an item silently losing its Status is data loss.
-  $left = @(Get-ItemsOnOption $merge.Field $merge.FromName)
+  $postRead = Get-ItemsOnOption $merge.Field $merge.FromName
+  $left     = @($postRead.Items)
   if ($left.Count -gt 0) {
     Write-Host ("    ABORT: quedan {0} item(s) en '{1}' - NO borro la opcion (se quedarian sin {2})." -f $left.Count, $merge.FromName, $merge.Field) -ForegroundColor Red
+    return $false
+  }
+  # An EMPTY result only proves "nothing left" when the read saw the whole board. If it stopped at
+  # the cap, the items that would lose their $($merge.Field) could be exactly the ones past it - so
+  # a truncated verification aborts on the same grounds as a found item, and for the same stake (#484).
+  if ($postRead.Truncated) {
+    Write-Host ("    ABORT: la verificacion se corto en el tope de lectura - no puedo probar que '{0}' quedo vacia, asi que NO borro la opcion." -f $merge.FromName) -ForegroundColor Red
     return $false
   }
 

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -315,7 +315,13 @@ if ($DryRun -or ($Migrate -and ($renames.Count -gt 0 -or $merges.Count -gt 0))) 
       # Show the blast radius BEFORE the prompt: a merge moves every item off the legacy
       # option and then destroys it, so "how many items" is the whole decision.
       foreach ($m in $merges) {
-        $n = try { @(Get-ItemsOnOption $m.Field $m.FromName).Count } catch { '?' }
+        # .Items, not the whole object: Get-ItemsOnOption returns { Items; Truncated }, and
+        # @(<object>).Count is 1 - which would report "1 item(s)" for EVERY merge, on the one
+        # line whose entire job is telling the user how big the destructive move is.
+        $n = try {
+          $r = Get-ItemsOnOption $m.Field $m.FromName
+          "$(@($r.Items).Count)$(if ($r.Truncated) { '+ (lectura truncada - puede haber mas)' } else { '' })"
+        } catch { '?' }
         Write-Host ("  merge:  {0} '{1}' -> '{2}'  ({3} item(s) se mueven, luego se borra '{1}')" -f $m.Field, $m.FromName, $m.ToName, $n) -ForegroundColor Yellow
       }
     } else {

--- a/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
+++ b/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
@@ -79,8 +79,10 @@ $boardUrl = "https://github.com/users/$Owner/projects/$ProjectNum"
 $truncWarn = Get-BoardTruncationWarning $read
 if ($truncWarn -and $result.Complete) {
     if ($Json) {
-        [pscustomobject]@{ complete = $false; pendingCount = $null; truncated = $true
-                           itemsRead = $read.Read; reason = $truncWarn; board = $boardUrl } | ConvertTo-Json -Depth 6
+        [pscustomobject]@{
+            complete = $false; pendingCount = $null; truncated = $true
+            itemsRead = $read.Read; reason = $truncWarn; board = $boardUrl
+        } | ConvertTo-Json -Depth 6
         exit 1
     }
     Write-Host "=== Board complete?  #$ProjectNum de $Owner ===" -ForegroundColor Cyan
@@ -101,6 +103,9 @@ if ($result.Complete) {
     exit 0
 }
 Write-Host ("  FAIL  quedan {0} item(s) pendiente(s):" -f $result.PendingCount) -ForegroundColor Red
+# Already failing, so the verdict does not change - but the COUNT does: a capped read makes this
+# list a floor, and "quedan 37" would otherwise read as exact.
+if ($truncWarn) { Write-Host "  (al menos: $truncWarn)" -ForegroundColor Yellow }
 foreach ($p in $result.Pending) {
     Write-Host ("    #{0,-4} {1}  (Status: {2})" -f $p.number, $p.title, $(if ($p.status) { $p.status } else { '(vacio)' })) -ForegroundColor DarkYellow
 }

--- a/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
+++ b/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
@@ -92,7 +92,13 @@ if ($truncWarn -and $result.Complete) {
 }
 
 if ($Json) {
-    [pscustomobject]@{ complete = $result.Complete; pendingCount = $result.PendingCount; pending = $result.Pending; board = $boardUrl } | ConvertTo-Json -Depth 6
+    # `truncated`/`itemsRead` ride on EVERY response, not just the fail-closed one above. A capped
+    # read that DID find pending items still falls through to here, and a consumer reading
+    # `pendingCount` with no truncation field would take a floor for an exact count (#484).
+    [pscustomobject]@{
+        complete  = $result.Complete; pendingCount = $result.PendingCount; pending = $result.Pending
+        truncated = [bool]$truncWarn;  itemsRead    = $read.Read;           board   = $boardUrl
+    } | ConvertTo-Json -Depth 6
     if ($result.Complete) { exit 0 } else { exit 1 }
 }
 

--- a/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
+++ b/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
@@ -61,15 +61,33 @@ if ($env:ABIOS_BOARDCOMPLETE_DOTSOURCE) { return }
 
 # ── Side-effecting from here ──────────────────────────────────────────────────
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# Board reads that report their own truncation (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
 if (-not $env:GH_TOKEN) { $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, 'User') }
 if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (and GH_TOKEN empty)." }
 
 # Fail closed: a gh error must THROW, never read as an empty board that falsely reports "complete".
-$items = (Invoke-Gh -GhArgs @('project','item-list',"$ProjectNum",'--owner',$Owner,'--format','json','--limit','800') `
-                    -What "listar los items del board #$ProjectNum de $Owner" -Json).items
-$result   = Get-BoardCompletion -Items @($items)
+$read     = Get-BoardItems -Number $ProjectNum -Owner $Owner `
+                           -What "listar los items del board #$ProjectNum de $Owner"
+$result   = Get-BoardCompletion -Items $read.Items
 $boardUrl = "https://github.com/users/$Owner/projects/$ProjectNum"
+
+# A capped read cannot license a PASS. This gate exists to ASSERT an absence ("0 pendientes"), which
+# is exactly the claim a short read cannot support - and CI would read that PASS as ground truth.
+# So truncation fails closed: exit 1 with the reason, never a green "el board esta full" (#484).
+$truncWarn = Get-BoardTruncationWarning $read
+if ($truncWarn -and $result.Complete) {
+    if ($Json) {
+        [pscustomobject]@{ complete = $false; pendingCount = $null; truncated = $true
+                           itemsRead = $read.Read; reason = $truncWarn; board = $boardUrl } | ConvertTo-Json -Depth 6
+        exit 1
+    }
+    Write-Host "=== Board complete?  #$ProjectNum de $Owner ===" -ForegroundColor Cyan
+    Write-Host "  FAIL  no puedo verificarlo: $truncWarn" -ForegroundColor Red
+    Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+    exit 1
+}
 
 if ($Json) {
     [pscustomobject]@{ complete = $result.Complete; pendingCount = $result.PendingCount; pending = $result.Pending; board = $boardUrl } | ConvertTo-Json -Depth 6

--- a/plugins/agentic-board/scripts/Backup-Board.ps1
+++ b/plugins/agentic-board/scripts/Backup-Board.ps1
@@ -17,6 +17,8 @@ $dash = [char]0x2014
 # This script is the LAST line of defence before a delete, so it must never mistake a 401
 # for an empty board and write a plausible-looking empty snapshot.
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# ...nor mistake a CAPPED read for a whole board and write a plausible-looking PARTIAL one (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 if (-not $BackupDir) {
   $BackupDir = if ($env:ABIOS_BACKUP_DIR) { $env:ABIOS_BACKUP_DIR } else { Join-Path (Get-AbiosStateDir -Root $HOME) 'backups' }
 }
@@ -36,11 +38,21 @@ $meta   = Invoke-Gh -GhArgs @('project', 'view',       "$Number", '--owner', $Ow
                     -What "leer el board #$Number de $Owner" -RawJson -Retries 2
 $fields = Invoke-Gh -GhArgs @('project', 'field-list', "$Number", '--owner', $Owner, '--format', 'json') `
                     -What "leer los campos del board #$Number" -RawJson -Retries 2
-$items  = Invoke-Gh -GhArgs @('project', 'item-list',  "$Number", '--owner', $Owner, '--format', 'json', '--limit', '1000') `
+$itemLimit = Get-BoardItemReadLimit
+$items  = Invoke-Gh -GhArgs @('project', 'item-list',  "$Number", '--owner', $Owner, '--format', 'json', '--limit', "$itemLimit") `
                     -What "leer los items del board #$Number" -RawJson -Retries 2
 
 $title  = ($meta | ConvertFrom-Json).title
 if (-not $title) { throw "El board #$Number no devolvio un titulo - no hago un backup de algo que no pude leer." }
+
+# This snapshot is the safety net taken BEFORE a destructive board operation, so a partial one is
+# worse than none: it would license the delete it exists to make reversible. A read that stopped at
+# the cap cannot be called a backup, so refuse to write one (#484). Checked on the raw text rather
+# than through Get-BoardItems because the snapshot must keep gh's own bytes unreshaped.
+$itemCount = @(($items | ConvertFrom-Json).items | Where-Object { $null -ne $_ }).Count
+if ($itemCount -ge $itemLimit) {
+    throw "No escribo el backup del board #$Number - la lectura de items se corto en $itemCount (el tope de lectura), y un backup parcial no es un backup."
+}
 $safe   = ($title -replace '[^\w\-]+', '_').Trim('_')
 $base   = Join-Path $BackupDir ("{0}_{1}" -f $safe, $stamp)
 

--- a/plugins/agentic-board/scripts/Board-Triage.ps1
+++ b/plugins/agentic-board/scripts/Board-Triage.ps1
@@ -105,6 +105,8 @@ if ($env:ABIOS_TRIAGE_DOTSOURCE) { return }
 
 # ── Side-effecting from here ──────────────────────────────────────────────────
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# Board reads that report their own truncation (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
 if (-not $env:GH_TOKEN) {
     $env:GH_TOKEN = [System.Environment]::GetEnvironmentVariable($TokenVar, 'User')
@@ -143,8 +145,11 @@ $fields = (Invoke-Gh -GhArgs @('project','field-list',"$Number",'--owner',$Owner
                      -What "leer los campos del board #$Number" -Json).fields
 $proj   = (Invoke-Gh -GhArgs @('project','view',"$Number",'--owner',$Owner,'--format','json') `
                      -What "leer el board #$Number" -Json).id
-$items  = (Invoke-Gh -GhArgs @('project','item-list',"$Number",'--owner',$Owner,'--format','json','--limit','800') `
-                     -What "listar los items del board #$Number" -Json).items
+# A capped read here would print "(no hay items pendientes)" over a board full of untriaged work -
+# the same false all-clear /board work shipped (#484). Get-BoardItems reports the cut.
+$itemRead = Get-BoardItems -Number $Number -Owner $Owner `
+                           -What "listar los items del board #$Number"
+$items    = $itemRead.Items
 
 function Get-FieldDef([string]$name) { $fields | Where-Object { $_.name -eq $name } | Select-Object -First 1 }
 function Get-FieldKey([string]$name) { ($name -replace '[^A-Za-z0-9]','').ToLower() }   # how item-list surfaces the value
@@ -161,8 +166,16 @@ if ($Issue -le 0) {
     $pendingStatuses = @('Backlog', 'In Progress', 'Todo', 'To Do')   # legacy names included
     $pend = @($items | Where-Object { $pendingStatuses -contains "$($_.status)" -and $_.content.number })
     Write-Host "=== Triage: pendientes del board #$Number de $Owner ===" -ForegroundColor Cyan
-    if (-not $pend.Count) { Write-Host "  (no hay items pendientes)" -ForegroundColor DarkGray; Write-Host "Board: $boardUrl" -ForegroundColor Cyan; exit 0 }
-    Write-Host ("  {0} item(s) pendiente(s). Faltantes marcados con []." -f $pend.Count) -ForegroundColor DarkGray
+    $itemTrunc = Get-BoardTruncationWarning $itemRead
+    if (-not $pend.Count) {
+        # Zero matches inside a partial list is no evidence of zero matches on the board (#484).
+        if ($itemTrunc) { Write-Host "  $itemTrunc" -ForegroundColor Yellow }
+        else            { Write-Host "  (no hay items pendientes)" -ForegroundColor DarkGray }
+        Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+        exit $(if ($itemTrunc) { 1 } else { 0 })
+    }
+    if ($itemTrunc) { Write-Host "  $itemTrunc" -ForegroundColor Yellow }
+    Write-Host ("  {0}{1} item(s) pendiente(s). Faltantes marcados con []." -f $pend.Count, $(if ($itemTrunc) { '+' } else { '' })) -ForegroundColor DarkGray
     Write-Host ""
     foreach ($it in ($pend | Sort-Object { [int]$_.content.number })) {
         $v    = Get-ItemTriageValues $it

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -2783,7 +2783,9 @@ if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0) {
         }
     }
     Write-Host ""
-    Write-Host ("Total: {0} pendiente(s)." -f $pending.Count) -ForegroundColor Yellow
+    # "Total" is an exact claim, and a capped read cannot make one - the warning above says the
+    # list may be short, so the number that closes it must agree with the warning, not contradict it.
+    Write-Host ("Total: {0}{1} pendiente(s)." -f $pending.Count, $(if ($truncWarn) { '+ (vistos; la lectura se corto)' } else { '' })) -ForegroundColor Yellow
 
     # Multi-session: show what other LIVE local sessions are working right now.
     # NOT named $sessions: at SCRIPT scope that is the [switch]$Sessions parameter

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -190,6 +190,9 @@ $ErrorActionPreference = "Stop"
 # not read as an empty board or a write that silently no-op'd. Pure at load; dot-sourced before
 # the guard so unit tests get the seam. Session-monitor reads deliberately stay best-effort.
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# Board reads that report their own truncation (#484). A capped item-list returns exit 0 and a
+# SHORT list, which this script used to print as "sin pendientes" over a board full of Backlog.
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 # owner/name resolver from origin (dot-safe regex) - cerrar-ciclo (#302) resolves the current repo.
 . (Join-Path $PSScriptRoot 'Get-RepoFromOrigin.ps1')
 
@@ -2653,20 +2656,24 @@ query($o:String!, $r:String!) {
     $rows = @()
     foreach ($b in $boards) {
         try {
-            # -Json throws on a failed read (caught below -> honest "?"): a bare read would yield
-            # $null under pwsh 7 and print "pendientes: 0", a false clean for that board (#314).
-            $items   = (Invoke-Gh -GhArgs @('project','item-list',"$($b.number)",'--owner',$b.ownerLogin,'--format','json','--limit','200') `
-                                  -What "listar los items del board #$($b.number)" -Json).items
-            $pending = @($items | Where-Object { Test-Pending $_ }).Count
-            $total   = @($items).Count
+            # Get-BoardItems throws on a failed read (caught below -> honest "?"): a bare read would
+            # yield $null under pwsh 7 and print "pendientes: 0", a false clean for that board (#314).
+            # It ALSO reports a capped read, which the old --limit 200 swallowed: this picker
+            # under-counted every board past the cap and so looked emptier than it was (#484).
+            $read    = Get-BoardItems -Number $b.number -Owner $b.ownerLogin `
+                                      -What "listar los items del board #$($b.number)"
+            $pending = @($read.Items | Where-Object { Test-Pending $_ }).Count
+            $total   = $read.Read
+            $trunc   = $read.Truncated
         } catch {
-            $pending = "?"; $total = "?"
+            $pending = "?"; $total = "?"; $trunc = $false
         }
         $rows += [PSCustomObject]@{
             Num       = $b.number
             Titulo    = $b.title
             Pendientes = $pending
             Items     = $total
+            Trunc     = $trunc
             Url       = "https://github.com/users/$($b.ownerLogin)/projects/$($b.number)"
         }
     }
@@ -2676,8 +2683,16 @@ query($o:String!, $r:String!) {
 
     foreach ($r in $rows) {
         $color = if ($r.Pendientes -is [int] -and $r.Pendientes -gt 0) { "Yellow" } else { "DarkGray" }
-        Write-Host ("  #{0,-3} {1,-45} pendientes: {2,-4} items: {3}" -f $r.Num, $r.Titulo, $r.Pendientes, $r.Items) -ForegroundColor $color
+        # A capped read makes both numbers a FLOOR, not a count - so they are rendered as "N+".
+        # Printing a bare "pendientes: 0" off a short read is the whole bug (#484).
+        $sfx   = if ($r.Trunc) { "+" } else { "" }
+        Write-Host ("  #{0,-3} {1,-45} pendientes: {2,-4} items: {3}" -f `
+                    $r.Num, $r.Titulo, "$($r.Pendientes)$sfx", "$($r.Items)$sfx") -ForegroundColor $color
         Write-Host ("        {0}" -f $r.Url) -ForegroundColor DarkCyan
+    }
+    if (@($rows | Where-Object { $_.Trunc }).Count -gt 0) {
+        Write-Host ""
+        Write-Host "TRUNCADO: los boards marcados con '+' tienen mas items de los que pude leer - sus cuentas son un minimo, no un total." -ForegroundColor Yellow
     }
     Write-Host ""
     Write-Host "Siguiente paso: Board-Work.ps1 -ProjectNum <num> para ver los pendientes de un board." -ForegroundColor Cyan
@@ -2707,10 +2722,15 @@ if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0) {
     $statusOpts = Get-StatusOptionNames $ProjectNum
     Show-StatusSchemaWarning $statusOpts $ProjectNum
 
-    # -Json fails closed: a read failure must THROW, not yield an empty list the script then
-    # reports as "Sin pendientes" - the green all-clear over a board full of open issues (#278/#314).
-    $items   = (Invoke-Gh -GhArgs @('project','item-list',"$ProjectNum",'--owner',$Owner,'--format','json','--limit','200') `
-                          -What "listar los items del board #$ProjectNum" -Json).items
+    # Fails closed TWICE over. A read failure THROWS rather than yielding an empty list the script
+    # would report as "Sin pendientes" (#278/#314) - and a read that hit the cap is flagged, because
+    # `gh project item-list` returns items OLDEST-FIRST: on a mature board the cap fills with Done
+    # work and the Backlog falls off the end. At --limit 200 against a 291-item board this printed a
+    # confident "Sin pendientes" over 37 open Backlog items (#484).
+    $read    = Get-BoardItems -Number $ProjectNum -Owner $Owner `
+                              -What "listar los items del board #$ProjectNum"
+    $items   = $read.Items
+    $truncWarn = Get-BoardTruncationWarning $read
     $pending = @($items | Where-Object { Test-Pending $_ })
 
     if ($pending.Count -eq 0) {
@@ -2718,8 +2738,13 @@ if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0) {
         # understands. If ANY item sits in a vocabulary we cannot read, 0 matches means
         # "I cannot tell", not "the board is clean" - say that instead of the green
         # all-clear the script used to print over dozens of open issues (#278).
+        # A truncated read means the same thing for a different reason, and outranks both:
+        # zero matches inside a partial list is no evidence of zero matches on the board.
         $unknown = Get-UnknownStatusValues $items
-        if ($unknown.Count -gt 0) {
+        if ($truncWarn) {
+            Write-Host $truncWarn -ForegroundColor Yellow
+            Write-Host "No hay pendientes ENTRE LOS $($read.Read) items que lei - no afirmo que el board este limpio." -ForegroundColor Yellow
+        } elseif ($unknown.Count -gt 0) {
             Write-Host "No puedo saber que hay pendiente: 0 items en Backlog, pero el board usa estados que no reconozco ($($unknown -join ', '))." -ForegroundColor Yellow
             Write-Host "No afirmo que no haya pendientes - revisa el board, o estandarizalo con /board field apply en --migrate." -ForegroundColor DarkGray
         } else {
@@ -2728,6 +2753,14 @@ if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0) {
         Write-Host ""
         Write-Host "Board: $boardUrl" -ForegroundColor Cyan
         exit 0
+    }
+
+    # A truncated read still lists what it found - but the list is a FLOOR, and saying so before it
+    # matters more than after: the user picks an issue off the top of this list.
+    if ($truncWarn) {
+        Write-Host $truncWarn -ForegroundColor Yellow
+        Write-Host "Los pendientes de abajo son los que alcance a ver; pueden faltar." -ForegroundColor Yellow
+        Write-Host ""
     }
 
     # Sort: priority name ascending (P0 < P1 < P2), empty priority last

--- a/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
+++ b/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
@@ -12,8 +12,12 @@ $ErrorActionPreference = 'Stop'
 # Unchecked, a 401 made this publish a snapshot reading "0 of 0 tracked items done." - a
 # document that looks like a finished board rather than a failed read.
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# ...and a CAPPED read is the same failure with a different cause: this document states "N of M
+# tracked items done", so a short read publishes a finished-looking board that never existed (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
-$resp  = Invoke-Gh -GhArgs @('project', 'item-list', "$Number", '--owner', $Owner, '--format', 'json', '--limit', '500') `
+$itemLimit = Get-BoardItemReadLimit
+$resp  = Invoke-Gh -GhArgs @('project', 'item-list', "$Number", '--owner', $Owner, '--format', 'json', '--limit', "$itemLimit") `
                    -What "leer los items del board #$Number de $Owner" -Json -Retries 2
 
 # -Json covers a non-zero exit, an empty body and an unparseable body - but NOT "parsed
@@ -21,10 +25,19 @@ $resp  = Invoke-Gh -GhArgs @('project', 'item-list', "$Number", '--owner', $Owne
 # That case must fail here, because @($null).Count is 1, not 0: `@($resp.items)` on a
 # missing property yields a one-element array holding $null, and the report would claim
 # "0 of 1 tracked items done" over an empty table - a document that contradicts itself.
+# Kept as its own check: Get-BoardItems cannot tell a wrong SHAPE from an empty board, so
+# reading through it here would trade this guard for the truncation one instead of adding it.
 if (-not $resp.PSObject.Properties['items']) {
     throw "No pude leer los items del board #$Number - gh devolvio JSON sin 'items'."
 }
 $items = @($resp.items | Where-Object { $null -ne $_ })
+
+# The third way this document can lie: a read that stopped at the cap. The snapshot's headline is
+# "N of M tracked items done", so a short read publishes a finished-looking board that never
+# existed - the same false document a 401 used to produce, from a call that SUCCEEDED (#484).
+if ($items.Count -ge $itemLimit) {
+    throw "No publico el snapshot del board #$Number - la lectura se corto en $($items.Count) items (el tope de lectura), asi que el 'N de M' del documento seria falso."
+}
 
 $rank  = @{ 'Backlog' = 0; 'In Progress' = 1; 'In Review' = 2; 'Done' = 3 }
 $sorted = $items | Sort-Object `

--- a/plugins/agentic-board/scripts/Get-BoardItems.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardItems.ps1
@@ -1,0 +1,92 @@
+<#  Get-BoardItems.ps1 - read EVERY item of a board, or say out loud that it could not (#484).
+
+    Why this exists. `gh project item-list` takes a `--limit` and, on reaching it, returns exactly
+    that many items with no warning, no error and exit 0. It also returns them OLDEST-FIRST, so on a
+    mature board the first N are dominated by Done work and everything past the cap is invisible.
+    Board-Work read with `--limit 200` against a 291-item board and printed:
+
+        Sin pendientes. Todo el board esta en progreso o terminado.
+
+    over 37 real Backlog items. That is not a truncation - it is a confident FALSE ALL-CLEAR, and it
+    lands precisely on the mature boards where the stakes are highest.
+
+    This is the same class of defect Invoke-Gh.ps1 exists to kill (#303): a read that fails silently
+    and is then consumed as fact. Invoke-Gh made a FAILED read loud; this makes a SHORT one loud.
+    The two are complementary and neither substitutes for the other - a truncated read succeeds.
+
+    The contract:
+      * the read returns fewer items than the cap  -> complete, Truncated = $false.
+      * the read returns exactly the cap           -> possibly short, Truncated = $true. The caller
+                                                      must NOT state an absence ("sin pendientes",
+                                                      "0 Backlog", "PASS") off a truncated read.
+      * gh fails                                   -> Invoke-Gh throws, as always.
+
+    Why assert-under-the-cap rather than cross-check `gh project view`'s items.totalCount. The
+    totalCount would give an exact "N of M", but it costs a SECOND request per board - and
+    -ListBoards loops over every board of the account, so it doubles the request volume of the one
+    command already known to exhaust the rate limit (#414). The cap assertion buys the same
+    guarantee - never assert an absence off a possibly-short read - for zero extra requests.
+
+    Why a high ceiling is free: gh pages the underlying GraphQL 100 items at a time, so the request
+    count scales with the items that actually exist, not with `--limit`. Reading a 291-item board
+    costs 3 requests whether the cap is 200 or 2000. The old 200 bought nothing and cost the truth.
+
+    Pure at load: dot-source it, it defines functions only (no gh, no output).
+      . (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
+
+    Usage:
+      $read = Get-BoardItems -Number 13 -Owner CSalcedoDataBI
+      $warn = Get-BoardTruncationWarning $read
+      if ($warn) { Write-Host $warn -ForegroundColor Yellow }
+      foreach ($i in $read.Items) { ... }
+#>
+
+. (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+
+# Well past any realistic board, and free (see the header: cost tracks real items, not the cap).
+# Named rather than inlined so every call site shares ONE ceiling - the 200/500/800/1000 spread
+# across this repo's scripts is how a cap gets forgotten until it lies.
+$script:BoardItemReadLimit = 2000
+
+# Read a board's items and report whether the read could have been cut short.
+# Returns { Items; Read; Limit; Truncated } - never a bare array, because the caller has to be
+# handed the truncation flag alongside the data it would otherwise read as complete.
+function Get-BoardItems {
+    param(
+        [Parameter(Mandatory)][int]   $Number,
+        [Parameter(Mandatory)][string]$Owner,
+        [int]   $Limit = 0,
+        [string]$What
+    )
+    if ($Limit -le 0) { $Limit = $script:BoardItemReadLimit }
+    if (-not $What)   { $What  = "listar los items del board #$Number" }
+
+    # -Json fails closed: a read failure THROWS rather than yielding an empty list the caller
+    # would report as "sin pendientes" - the green all-clear over a full board (#278/#303/#314).
+    # The Where-Object is load-bearing, not defensive noise: gh emits `[]` for an empty board and
+    # `'[]' | ConvertFrom-Json` yields $null - and @($null) is an array of ONE $null, so a plain
+    # @(...) would report an empty board as holding 1 item and hand callers a null to iterate.
+    $items = @((Invoke-Gh -GhArgs @('project','item-list',"$Number",'--owner',$Owner,
+                                    '--format','json','--limit',"$Limit") `
+                          -What $What -Json).items | Where-Object { $null -ne $_ })
+
+    [pscustomobject]@{
+        Items     = $items
+        Read      = $items.Count
+        Limit     = $Limit
+        # -ge, not -gt: gh stops AT the cap, so "read == cap" IS the truncation signature. A board
+        # holding exactly $Limit items reports Truncated anyway - a false alarm that costs a warning,
+        # against a false all-clear that costs the user's trust. The asymmetry is deliberate.
+        Truncated = ($items.Count -ge $Limit)
+    }
+}
+
+# The message for a short read. Pure (no gh, no host) so the wording is pinned by tests: this is
+# the "no silent caps" line the project requires, and it must name the number actually read.
+# Returns $null when the read was complete, so a call site is one `if ($warn)` away from honest.
+function Get-BoardTruncationWarning {
+    param([Parameter(Mandatory)][object]$Read)
+    if (-not $Read.Truncated) { return $null }
+    "TRUNCADO: lei $($Read.Read) items, que es el tope de la lectura - puede haber mas que no vi. " +
+    "NO puedo afirmar que no queden pendientes; revisa el board directamente."
+}

--- a/plugins/agentic-board/scripts/Get-BoardItems.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardItems.ps1
@@ -48,6 +48,11 @@
 # across this repo's scripts is how a cap gets forgotten until it lies.
 $script:BoardItemReadLimit = 2000
 
+# Accessor, for the callers that cannot use Get-BoardItems itself. Backup-Board needs gh's RAW
+# text (re-serialising a snapshot would reshape it), so it reads with -RawJson and checks the cap
+# by hand - but it must check against the SAME ceiling, not a second copy of the number.
+function Get-BoardItemReadLimit { return $script:BoardItemReadLimit }
+
 # Read a board's items and report whether the read could have been cut short.
 # Returns { Items; Read; Limit; Truncated } - never a bare array, because the caller has to be
 # handed the truncation flag alongside the data it would otherwise read as complete.

--- a/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
+++ b/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
@@ -79,12 +79,15 @@ if (-not $Body) {
                  if ($_.content.number) { "#$($_.content.number) $($_.title)" } else { $_.title }
              }) -join "; "
 
-    $Body = "**Progreso:** $done Done / $inProg In Progress / $($pending.Count) Backlog ($total items)."
+    # Render the counts as FLOORS when the read hit its cap, rather than stating them and
+    # retracting afterwards: "0 Backlog" followed by a footnote has already made the claim. The
+    # "+" carries the caveat inside every number it applies to, and the note explains it (#484).
+    $sfx  = if ($read.Truncated) { "+" } else { "" }
+    $Body = "**Progreso:** $done$sfx Done / $inProg$sfx In Progress / $($pending.Count)$sfx Backlog ($total$sfx items)."
     if ($next) { $Body += "`n**Siguiente:** $next" }
-    # Publish the caveat rather than a clean-looking lie: these counts are a floor when the read
-    # hit its cap, and the reader of a status update has no way to know that otherwise (#484).
     if ($read.Truncated) {
-        $Body += "`n_Nota: solo pude leer $($read.Read) items del board; las cuentas de arriba son un minimo, no un total._"
+        $Body += "`n_Nota: solo pude leer $($read.Read) items del board, que es el tope de la lectura; " +
+                 "las cuentas de arriba son un minimo (de ahi el '+'), no un total._"
     }
 }
 

--- a/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
+++ b/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
@@ -48,6 +48,9 @@ if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (
 # its exit code - either way an unchecked read here would post a status update off a misread board
 # (a wrong "0 Done" body, or the mutation's own silent failure). -Graphql fails closed on both (#303).
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# ...and a CAPPED read is the other half (#484): this body is PUBLISHED, so "0 Backlog" computed
+# from a short list is a false public statement about the project's progress.
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
 $boardUrl = "https://github.com/users/$Owner/projects/$ProjectNum"
 
@@ -63,8 +66,9 @@ if (-not $projectId) { throw "Board #$ProjectNum no encontrado para $Owner." }
 
 # Auto-generate the body from live board data when not given
 if (-not $Body) {
-    $items = (Invoke-Gh -GhArgs @('project','item-list',"$ProjectNum",'--owner',$Owner,'--format','json','--limit','200') `
-                        -What "listar los items del board #$ProjectNum" -Json).items
+    $read  = Get-BoardItems -Number $ProjectNum -Owner $Owner `
+                            -What "listar los items del board #$ProjectNum"
+    $items = $read.Items
     $done    = @($items | Where-Object { $_.status -eq "Done" }).Count
     $inProg  = @($items | Where-Object { $_.status -eq "In Progress" }).Count
     $pending = @($items | Where-Object { (-not $_.status) -or ($_.status -eq "Backlog") })
@@ -77,6 +81,11 @@ if (-not $Body) {
 
     $Body = "**Progreso:** $done Done / $inProg In Progress / $($pending.Count) Backlog ($total items)."
     if ($next) { $Body += "`n**Siguiente:** $next" }
+    # Publish the caveat rather than a clean-looking lie: these counts are a floor when the read
+    # hit its cap, and the reader of a status update has no way to know that otherwise (#484).
+    if ($read.Truncated) {
+        $Body += "`n_Nota: solo pude leer $($read.Read) items del board; las cuentas de arriba son un minimo, no un total._"
+    }
 }
 
 $updQuery = '

--- a/plugins/agentic-board/scripts/Set-BoardField.ps1
+++ b/plugins/agentic-board/scripts/Set-BoardField.ps1
@@ -35,7 +35,7 @@ param(
   [string]$TextTemplate,                           # text fields: template with {title} placeholder
   [string]$PrefixMap,                              # single-select: JSON {"prefix-":"OptionName",...,"*":"Default"}
   [string]$Filter = '^[a-z0-9]+(-[a-z0-9]+)*$',    # only items whose title matches (default: skill-name shape; skips long-titled issues)
-  [int]$Limit = 800,
+  [int]$Limit = 0,                                 # 0 = the shared board-read ceiling (Get-BoardItems)
   [switch]$Force                                   # re-set even when the current value already matches
 )
 $ErrorActionPreference = 'Stop'
@@ -44,6 +44,9 @@ $ErrorActionPreference = 'Stop'
 # reports a false "set=0" success, and an empty $proj/$fields would drive the item-edit
 # writes with a bad project id (#303).
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
+# ...and a CAPPED read silently narrows the sweep: this script claims to fill a field across EVERY
+# item, so items past the cap go untouched while the summary reads like a complete pass (#484).
+. (Join-Path $PSScriptRoot 'Get-BoardItems.ps1')
 
 function Resolve-FieldValue([string]$title) {
   if ($TextTemplate) { return $TextTemplate.Replace('{title}', $title) }
@@ -70,8 +73,15 @@ $isSelect = [bool]$fdef.options
 $optById  = @{}; if ($isSelect) { foreach ($o in $fdef.options) { $optById[$o.name] = $o.id } }
 $fieldKey = ($Field -replace '[^A-Za-z0-9]','').ToLower()   # how item-list surfaces the value
 
-$items = (Invoke-Gh -GhArgs @('project','item-list',"$Number",'--owner',$Owner,'--format','json','--limit',"$Limit") `
-                    -What "listar los items del board #$Number" -Json).items
+$itemRead = Get-BoardItems -Number $Number -Owner $Owner -Limit $Limit `
+                           -What "listar los items del board #$Number"
+$items    = $itemRead.Items
+# Say it BEFORE the sweep, not after: the user needs to know the pass was partial while the
+# "set=N" summary is still ahead of them, not once it already reads like a full sweep.
+if ($itemRead.Truncated) {
+  Write-Host (Get-BoardTruncationWarning $itemRead) -ForegroundColor Yellow
+  Write-Host "  El barrido de abajo cubre solo esos items - los demas quedan sin tocar. Sube -Limit para cubrirlos." -ForegroundColor Yellow
+}
 $set=0; $skip=0; $fail=0
 foreach ($it in $items) {
   if ($it.title -notmatch $Filter) { $skip++; continue }

--- a/plugins/agentic-board/scripts/Set-BoardField.ps1
+++ b/plugins/agentic-board/scripts/Set-BoardField.ps1
@@ -104,6 +104,13 @@ foreach ($it in $items) {
   if ($ok) { $set++ } else { $fail++; Write-Warning "failed: $($it.title)" }
 }
 Write-Host "Field '$Field' -> set=$set  skipped=$skip  failed=$fail  (of $($items.Count) items)"
+# The summary above is the line a human (or a CI log) reads as "the sweep is done". It cannot say
+# that off a capped read: the items past the cap were never even considered, so the pass covered a
+# subset while reading like a full one. Repeat it here, after the numbers, and exit non-zero - a
+# partial sweep is not a success for a command whose contract is "every item on the board" (#484).
+if ($itemRead.Truncated) {
+  Write-Warning "BARRIDO PARCIAL: solo lei $($itemRead.Read) items (el tope de lectura), asi que los que estan mas alla NO se tocaron. Sube -Limit y re-corre para cubrirlos."
+}
 
 # Post-fill visibility check — the #1 "the tool didn't work" false alarm: the field IS filled but
 # the board's VIEW doesn't display that column, so the user sees blanks. GitHub Projects view
@@ -126,3 +133,6 @@ try {
 Write-Host "Note: GitHub system columns (Assignees, Linked pull requests, Sub-issues progress, Milestone, Repository, Labels) are auto-derived from real issues/PRs — they stay blank for draft cards and cannot be filled by any tool."
 
 if ($fail -gt 0) { exit 1 }
+# A truncated sweep exits non-zero too: automation asking "did the field get filled across the
+# board?" must not read exit 0 over items this run never looked at.
+if ($itemRead.Truncated) { exit 1 }

--- a/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
@@ -112,17 +112,79 @@ Describe 'Get-BoardTruncationWarning' {
     }
 }
 
-Describe 'Regression: no board read may go back to a 200-item cap' {
-    <#  The bug was one literal in two call sites. Scripts read boards for different reasons, but
-        NONE of them may cap at 200 again — this asserts it across the whole script directory rather
-        than trusting that the next reader remembers why. #>
-    It 'no script asks gh project item-list with --limit 200' {
-        $scripts = Get-ChildItem (Join-Path $PSScriptRoot '..' 'scripts') -Filter '*.ps1'
-        $bad = @()
-        foreach ($s in $scripts) {
+Describe 'Regression: every board item read must go through the shared reader' {
+    <#  The narrow version of this test banned the literal `'--limit', '200'` and nothing else — it
+        would have passed on `--limit 200` unquoted, on a variable defaulting to 200, and on all the
+        500/800/1000 readers that were STILL asserting absences when this was first written (one of
+        them gating a destructive option delete). The invariant worth pinning is not "not 200", it is
+        "no script hardcodes its own item-list cap": every board read either goes through
+        Get-BoardItems or asks Get-BoardItemReadLimit for the shared ceiling. #>
+
+    BeforeDiscovery {
+        $script:ScriptDir = Join-Path $PSScriptRoot '..' 'scripts'
+        # Get-BoardItems itself is where the one legitimate item-list call lives.
+        $script:ReaderFile = 'Get-BoardItems.ps1'
+    }
+
+    It 'no script hardcodes a numeric --limit on gh project item-list' {
+        $offenders = @()
+        foreach ($s in (Get-ChildItem $script:ScriptDir -Filter '*.ps1')) {
+            if ($s.Name -eq $script:ReaderFile) { continue }
             $text = Get-Content $s.FullName -Raw
-            if ($text -match "item-list" -and $text -match "'--limit'\s*,\s*'200'") { $bad += $s.Name }
+            if ($text -notmatch 'item-list') { continue }
+            # Any literal digit run following --limit, quoted or not, single or double.
+            if ($text -match "--limit'?\s*,?\s*[`"']?\d") { $offenders += $s.Name }
         }
-        $bad -join ', ' | Should -BeNullOrEmpty
+        $offenders -join ', ' | Should -BeNullOrEmpty
+    }
+
+    It 'every script that reads board items pulls in the shared reader' {
+        $missing = @()
+        foreach ($s in (Get-ChildItem $script:ScriptDir -Filter '*.ps1')) {
+            if ($s.Name -eq $script:ReaderFile) { continue }
+            $text = Get-Content $s.FullName -Raw
+            if ($text -notmatch 'item-list') { continue }
+            if ($text -notmatch 'Get-BoardItems\.ps1') { $missing += $s.Name }
+        }
+        $missing -join ', ' | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Regression: no caller may state an absence off a possibly-short read' {
+    <#  The user-visible half of the bug: each of these files prints a sentence asserting that
+        nothing is there, and each must consult the truncation flag before doing so.
+
+        These are COARSE checks — presence of the guard in the same file, not proof that it wraps
+        the right branch. That limit is deliberate: the first version of this block matched the
+        DISTANCE between the guard and the message, which broke the moment a branch grew a line and
+        would have trained the next reader to loosen the assertion rather than fix the code. Branch
+        placement is covered by the helper's own behavioural tests above plus the live check on the
+        291-item board; what these add is "nobody deleted the guard". #>
+
+    It 'Board-Work consults the truncation flag before its "Sin pendientes"' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Board-Work.ps1') -Raw
+        $t | Should -Match 'Sin pendientes'          # the all-clear still exists...
+        $t | Should -Match 'if \(\$truncWarn\)'      # ...and so does the guard on it
+    }
+    It 'Board-Triage consults it before its "(no hay items pendientes)"' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Board-Triage.ps1') -Raw
+        $t | Should -Match 'no hay items pendientes'
+        $t | Should -Match 'if \(\$itemTrunc\)'
+    }
+    It 'Assert-BoardComplete refuses to PASS on a truncated read' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Assert-BoardComplete.ps1') -Raw
+        $t | Should -Match '\$truncWarn -and \$result\.Complete'
+    }
+    It 'Apply-FieldPreset refuses to DELETE an option verified by a truncated read' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Apply-FieldPreset.ps1') -Raw
+        $t | Should -Match '\$postRead\.Truncated'
+    }
+    It 'Backup-Board refuses to write a partial snapshot' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Backup-Board.ps1') -Raw
+        $t | Should -Match 'un backup parcial no es un backup'
+    }
+    It 'Export-BoardSnapshot refuses to publish a truncated "N of M"' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Export-BoardSnapshot.ps1') -Raw
+        $t | Should -Match '\$items\.Count -ge \$itemLimit'
     }
 }

--- a/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
@@ -1,0 +1,128 @@
+#Requires -Modules Pester
+<#  Tests for Get-BoardItems.ps1 — the board read that reports its own truncation (#484).
+
+    The bug being pinned here is not an off-by-N. `gh project item-list --limit 200` returns exit 0
+    and exactly 200 items on a bigger board, oldest-first, so the Backlog falls off the end and the
+    caller prints "Sin pendientes" over a board full of open work. The read SUCCEEDS at lying.
+
+    So two things must hold, and the pair is the contract:
+      * a read under the cap is complete           -> Truncated $false, callers may assert an absence.
+      * a read that reaches the cap is suspect     -> Truncated $true, callers may NOT.
+    If those ever collapse into each other the helper has failed at its only job.
+#>
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' 'scripts' 'Get-BoardItems.ps1')
+
+    # N items shaped like `gh project item-list --format json` emits them.
+    function script:Items([int]$n) {
+        1..$n | ForEach-Object { [pscustomobject]@{ content = [pscustomobject]@{ number = $_ }; status = 'Done' } }
+    }
+}
+
+Describe 'Get-BoardItems — a complete read' {
+    BeforeEach {
+        Mock Invoke-Gh { [pscustomobject]@{ items = @(script:Items 291) } }
+    }
+    It 'returns every item it read' {
+        (Get-BoardItems -Number 13 -Owner x).Read | Should -Be 291
+    }
+    It 'is NOT truncated when the read came back under the cap' {
+        (Get-BoardItems -Number 13 -Owner x).Truncated | Should -BeFalse
+    }
+    It 'hands back the items themselves, not just a count' {
+        @((Get-BoardItems -Number 13 -Owner x).Items).Count | Should -Be 291
+    }
+}
+
+Describe 'Get-BoardItems — a capped read is truncated, not complete' {
+    It 'flags a read that came back at exactly the cap' {
+        Mock Invoke-Gh { [pscustomobject]@{ items = @(script:Items 50) } }
+        $r = Get-BoardItems -Number 13 -Owner x -Limit 50
+        $r.Truncated | Should -BeTrue
+        $r.Read      | Should -Be 50
+    }
+    It 'flags it even when the board holds EXACTLY the cap — a false alarm is cheaper than a false all-clear' {
+        Mock Invoke-Gh { [pscustomobject]@{ items = @(script:Items 10) } }
+        (Get-BoardItems -Number 13 -Owner x -Limit 10).Truncated | Should -BeTrue
+    }
+    It 'the 291-item board that shipped the bug is NOT truncated at the new default' {
+        Mock Invoke-Gh { [pscustomobject]@{ items = @(script:Items 291) } }
+        (Get-BoardItems -Number 13 -Owner x).Truncated | Should -BeFalse
+    }
+}
+
+Describe 'Get-BoardItems — an empty board is empty, not broken' {
+    It 'reads 0 items without claiming truncation' {
+        Mock Invoke-Gh { [pscustomobject]@{ items = @() } }
+        $r = Get-BoardItems -Number 13 -Owner x
+        $r.Read      | Should -Be 0
+        $r.Truncated | Should -BeFalse
+    }
+    It 'survives gh returning $null for an empty array (ConvertFrom-Json emits nothing for [])' {
+        Mock Invoke-Gh { [pscustomobject]@{ items = $null } }
+        (Get-BoardItems -Number 13 -Owner x).Read | Should -Be 0
+    }
+}
+
+Describe 'Get-BoardItems — the cap it actually sends to gh' {
+    BeforeEach {
+        $script:sent = $null
+        Mock Invoke-Gh { $script:sent = $GhArgs; [pscustomobject]@{ items = @(script:Items 5) } }
+    }
+    It 'defaults well past 200 — the cap that produced the false all-clear' {
+        $null = Get-BoardItems -Number 13 -Owner x
+        $i = [array]::IndexOf($script:sent, '--limit')
+        $i | Should -BeGreaterThan -1
+        [int]$script:sent[$i + 1] | Should -BeGreaterOrEqual 1000
+    }
+    It 'asks gh for the board and owner it was given' {
+        $null = Get-BoardItems -Number 13 -Owner CSalcedoDataBI
+        $script:sent | Should -Contain 'item-list'
+        $script:sent | Should -Contain '13'
+        $script:sent | Should -Contain 'CSalcedoDataBI'
+    }
+    It 'honors an explicit -Limit' {
+        $null = Get-BoardItems -Number 13 -Owner x -Limit 777
+        $i = [array]::IndexOf($script:sent, '--limit')
+        $script:sent[$i + 1] | Should -Be '777'
+    }
+}
+
+Describe 'Get-BoardItems — a failed read still throws (Invoke-Gh contract preserved)' {
+    It 'does not swallow a gh failure into an empty, complete-looking read' {
+        Mock Invoke-Gh { throw 'No pude listar los items (gh exit 1): HTTP 401' }
+        { Get-BoardItems -Number 13 -Owner x } | Should -Throw
+    }
+}
+
+Describe 'Get-BoardTruncationWarning' {
+    It 'is silent on a complete read — nothing to warn about' {
+        Get-BoardTruncationWarning ([pscustomobject]@{ Truncated = $false; Read = 291; Limit = 2000 }) |
+            Should -BeNullOrEmpty
+    }
+    It 'names how many items it actually read, so the number is auditable' {
+        $w = Get-BoardTruncationWarning ([pscustomobject]@{ Truncated = $true; Read = 200; Limit = 200 })
+        $w | Should -Match 'TRUNCADO'
+        $w | Should -Match '200'
+    }
+    It 'refuses to assert an absence — the whole point of the flag' {
+        $w = Get-BoardTruncationWarning ([pscustomobject]@{ Truncated = $true; Read = 200; Limit = 200 })
+        $w | Should -Match 'NO puedo afirmar'
+    }
+}
+
+Describe 'Regression: no board read may go back to a 200-item cap' {
+    <#  The bug was one literal in two call sites. Scripts read boards for different reasons, but
+        NONE of them may cap at 200 again — this asserts it across the whole script directory rather
+        than trusting that the next reader remembers why. #>
+    It 'no script asks gh project item-list with --limit 200' {
+        $scripts = Get-ChildItem (Join-Path $PSScriptRoot '..' 'scripts') -Filter '*.ps1'
+        $bad = @()
+        foreach ($s in $scripts) {
+            $text = Get-Content $s.FullName -Raw
+            if ($text -match "item-list" -and $text -match "'--limit'\s*,\s*'200'") { $bad += $s.Name }
+        }
+        $bad -join ', ' | Should -BeNullOrEmpty
+    }
+}

--- a/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
@@ -187,4 +187,37 @@ Describe 'Regression: no caller may state an absence off a possibly-short read' 
         $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Export-BoardSnapshot.ps1') -Raw
         $t | Should -Match '\$items\.Count -ge \$itemLimit'
     }
+    It 'Set-BoardField does not exit 0 after a partial sweep' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Set-BoardField.ps1') -Raw
+        $t | Should -Match 'if \(\$itemRead\.Truncated\) \{ exit 1 \}'
+    }
+    It 'Assert-BoardComplete reports truncated on every -Json response, not just the fail-closed one' {
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Assert-BoardComplete.ps1') -Raw
+        # Two emitters: the fail-closed branch and the normal one. BOTH must carry the field, or a
+        # consumer reads a floor as an exact count on the path that still found pending items.
+        @([regex]::Matches($t, 'truncated\s*=')).Count | Should -BeGreaterOrEqual 2
+    }
+}
+
+Describe 'Regression: a wrapper return value must never be counted as one item' {
+    <#  This one exists because the fix ITSELF shipped this bug and the suite missed it.
+
+        Get-ItemsOnOption used to return a bare array; making it report truncation turned it into
+        { Items; Truncated }. Two of its three call sites were updated. The third was
+        `@(Get-ItemsOnOption ...).Count`, which counts the WRAPPER — so it reported "1 item(s)" for
+        every merge, on the pre-confirmation line whose only job is telling the user how many items
+        a destructive delete is about to move. Every test still passed: the suite covered the
+        helper's shape and the guard's presence, never a caller's arithmetic.
+
+        `@(<object>).Count -eq 1` is silent, plausible, and PowerShell-specific, so it is pinned by
+        shape rather than left to the next reader to remember. #>
+
+    It 'no call site wraps Get-ItemsOnOption in @() and counts it' {
+        # VERIFIED to fail on the real defect: the bug was reintroduced in the source and this
+        # assertion went red, which is the only reason it is trusted. A companion check that
+        # merely counted `.Items` occurrences file-wide stayed GREEN with the bug present and was
+        # deleted rather than kept as decoration.
+        $t = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'Apply-FieldPreset.ps1') -Raw
+        $t | Should -Not -Match '@\(Get-ItemsOnOption'
+    }
 }


### PR DESCRIPTION
Closes #484