### PR TITLE
review gate: raise the reviewer's turn cap to a measured value

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -43,8 +43,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Publicar el review es parte del trabajo, no un efecto secundario: sin la herramienta
           # para comentar, el job corría, salía limpio y no dejaba nada (#510).
+          #
+          # --max-turns MEDIDO, no estimado (#543). Con el tope en 20, los runs que SÍ publicaron
+          # consumieron 4 / 13 / 17 / 18 / 19 turnos: el margen real era de UN turno, así que
+          # cualquier PR mediano lo agotaba. Los tres runs de un PR grande (#539) murieron los tres
+          # en 21. El tiempo no es la restricción — esos runs tardan 2-4 min contra un
+          # timeout-minutes de 20 — así que subirlo no alarga nada; solo deja de matar revisiones
+          # a un turno de terminar. 40 da algo más del doble del máximo observado.
+          #
+          # Por qué importa más de lo que parece: un run agotado NO deja review, y el paso de
+          # verificación de abajo lo pone en rojo con razón (#510). Sin holgura, el gate de review
+          # bloquea PRs legítimos y empuja a saltárselo — que es como se desactiva un control.
           claude_args: |
-            --max-turns 20
+            --max-turns 40
             --allowedTools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
           prompt: |
             Revisa este pull request como un senior engineer. Enfócate en:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 ### Fixed
+- **The reviewer's turn cap sat one turn above what a real review needs** (#543). Measured across
+  recent runs: reviews that actually published consumed 4 / 13 / 17 / 18 / **19** turns against a
+  cap of **20**, and three consecutive runs on a large PR died at 21. A run that hits the cap leaves
+  no review, so the verification added in #510 fails the check — correctly — and the review gate
+  ends up blocking legitimate PRs on an infrastructure limit. That is how a control gets switched
+  off: not by argument, but by being wrong often enough. Raised to 40, a little over twice the
+  observed maximum; time was never the constraint (those runs finish in 2-4 minutes against a
+  20-minute job timeout).
 - **`-EndToEnd` shipped inert in 0.29.0, and after five review findings it is staying inert — on
   purpose** (#536, #541). Field-testing the autonomy boundary found the ordered end-to-end close
   could refuse but never allow. Three separate blockers were fixed; then three rounds of external


### PR DESCRIPTION
Closes #543.

`--max-turns 20` sat **one turn** above what a real review needs. Measured, not estimated:

| Outcome | turns |
|---|---|
| published a review | 4 · 13 · 17 · 18 · **19** |
| died at the cap | 21 · 21 · 21 (three consecutive runs on #539) |

A medium PR exhausts that margin; a large one has no chance. Time was never the constraint — the successful runs finish in 2-4 minutes against a `timeout-minutes: 20` — so raising it costs nothing and stops killing reviews a turn from done. **40** is a little over twice the observed maximum.

## Why this is not cosmetic

A run that hits the cap leaves **no review**, and the verification step from #510 then fails the check — correctly, because a green tick with zero reviews is the exact defect #510 removed. The practical effect is that the review gate blocks legitimate PRs on an infrastructure limit, and the workaround becomes "record an external review by hand" or "merge past it". That is how a control gets switched off: not by argument, but by being wrong often enough. It happened three times on #539 in one session.

It also breaks the autonomy story this repo is building. A run that reaches "PR ready" and sees `claude-review` red cannot tell *"the reviewer ran out of turns"* from *"the reviewer rejected my work"*.

## This is a prerequisite, not a side quest

The design for #541 (making the ordered end-to-end close safe) rests on requiring review evidence from a **login that is not the PR author** — the one signal an autonomous run cannot mint, since it holds the repo token and everything it posts is authored by the repo owner. Verified on #539: the CI reviewer comments as `claude`, while a hand-recorded external review comes out as `CSalcedoDataBI`, the same login as the PR author.

That makes the CI reviewer the **only** automatic source of valid review evidence — so it has to actually work before #541 can be built on it.

## Validation — stated plainly, because it cannot happen here

A PR touching `pr-review.yml` cannot exercise this change: `anthropics/claude-code-action` skips itself on PRs that modify its own workflow (GitHub's protection against a PR rewriting its own reviewer), so `claude-review` is red **by construction** on this one. Do not read that red as a verdict on the change.

The real test is the first unrelated PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)