### PR TITLE
brake: a push to the default branch IS a merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@
   unbounded nested quantifier over adversarial input is a stall waiting to happen (measured: 1 ms
   against a command carrying 200 flag-like tokens).
 
+  **Round four found two more in that fix — and measuring the repair found a third nobody had
+  seen.** The flag allowance was capped at five, which was itself a bypass: six `-c` flags and the
+  rule stopped matching, and chaining `-c` is ordinary scripting. And `[:/]` treated `/` as a
+  refspec separator, which it is not — `release/master`, `team/main` and `HEAD:team/main` were all
+  refused for merely *ending* in the default branch's name.
+
+  Removing the cap came with an argument, made by the reviewer and accepted by me, that the
+  repetition could not blow up because its character classes are disjoint. **The argument was
+  wrong and only the stopwatch said so:** `--flag` repeated 1000 times ran the matcher past three
+  minutes, because `-{1,2}` and `[^\s;|&]+` can both consume the second dash — two readings per
+  token, 2^1000 for a thousand of them. This code runs on *every tool call*, so that is not a slow
+  path, it is a wedged session, and a wedged guard is a removed guard. The form now allows exactly
+  one reading per token: measured at 3 ms with no match and 334 ms in the absurd worst case, with
+  three timing tests to catch a return — the suite was green with the hang present.
+
+  Recorded in the source, because this file keeps teaching it: *"the classes are disjoint so it
+  cannot blow up" is an argument, not a measurement. Time it.*
+
   **Known and accepted:** `git push main` is read as a push to the default branch even when `main`
   is the name of a *remote*. A false positive, not a bypass, on a rare spelling — and this pattern
   deliberately errs toward refusing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,19 @@
   deletes no longer stops that command. It is a delete, and the guard follows the contract instead
   of inventing policy — the rule this file opens with. There is a test saying so.
 
+  **Round six, also no bypass**, and the last one taken: the prefix before the refspec excluded
+  only `;`, so the matcher could step past a background `&` and read a later `something:main` in
+  the same segment as the push target — `git push origin fine & echo notes:main` was refused for
+  text belonging to a different command. A false positive, never a bypass (a looser prefix can only
+  add matches), fixed because over-blocking on the run's most common command is the argument this
+  whole entry rests on. The prefix now stops at the same operators the branch-name lookahead uses.
+  The review's second example, `> log:main.txt`, did not reproduce — checked rather than assumed.
+
+  **Stopped here deliberately.** Rounds one to four found real defects — a bypass, a false
+  positive, an anchor broken for months, and a matcher that could hang the session. Rounds five and
+  six found no bypass at all: a mislabelled verb and this over-block. The curve flattened, so the
+  loop was ended on judgement rather than run until it produced nothing.
+
   **Known and accepted:** `git push main` is read as a push to the default branch even when `main`
   is the name of a *remote*. A false positive, not a bypass, on a rare spelling — and this pattern
   deliberately errs toward refusing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@
   Recorded in the source, because this file keeps teaching it: *"the classes are disjoint so it
   cannot blow up" is an argument, not a measurement. Time it.*
 
+  **Round five found no bypass at all** — the first round on this change that did not. Its one
+  finding was about honesty rather than permission: `git push origin :main` *deletes* the remote
+  default branch, but the merge rule matched it first (its source side allowed zero characters),
+  so the refusal announced "merge is marked irreversible" for a command that removes main. Not a
+  bypass — the contract filter runs per pattern, so a delete-braking contract already refused it —
+  but a control is worth exactly as much as the account it gives of itself, which is this tool's
+  founding defect. The refspec source now requires at least one character, so an empty source falls
+  through to the delete rule where it belongs.
+
+  Recorded as a decision rather than left to chance: a contract that brakes merges but **not**
+  deletes no longer stops that command. It is a delete, and the guard follows the contract instead
+  of inventing policy — the rule this file opens with. There is a test saying so.
+
   **Known and accepted:** `git push main` is read as a push to the default branch even when `main`
   is the name of a *remote*. A false positive, not a bypass, on a rare spelling — and this pattern
   deliberately errs toward refusing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,19 @@
   Now refused: refspecs onto `main`/`master` (`HEAD:main`, `branch:main`, `+HEAD:main`,
   `HEAD:refs/heads/main`) and pushing the default branch by name.
 
-  **The first cut of this pattern over-blocked, and the CI reviewer caught it** — the first review
-  it produced after #543 raised its turn cap. Ending the pattern with `` only asks that the next
-  character not be a word character, so `HEAD:main-cleanup` and `HEAD:master.bak` were refused:
-  legitimate branches, blocked, on the run's most common command — precisely the failure this entry
-  claims to guard against. The tests missed it because the case they checked, `maintenance`,
-  continues with `t` (a word character) and so passed for the wrong reason. Both patterns now end
-  at a real token boundary, so the branch name has to *be* `main`/`master`. The reviewer also noted
+  **How the branch name must end took three tries, each one a real defect — and the CI reviewer
+  caught both mistakes**, in the first two reviews it managed to publish after #543 raised its turn
+  cap. `\b` refused `HEAD:main-cleanup` and `HEAD:master.bak`: legitimate branches, blocked, on the
+  run's most common command. Replacing it with `(\s|$)` fixed that and **reopened a different
+  hole** — that only accepts a space or end-of-segment, and the segment splitter does not treat a
+  lone `&` or a redirection as a separator, so `git push origin HEAD:main&` (background the push,
+  same effect) matched nothing, a case the original `\b` had caught. It now ends at a lookahead
+  over the shell's own terminator set, which covers both directions.
+
+  The original over-block, for the record: the tests missed it because the case they checked,
+  `maintenance`, continues with `t` (a word character) and so passed **for the wrong reason** —
+  proving nothing about `-` or `.`. A green test that passes by accident is the same failure this
+  whole entry is about. The reviewer also noted
   that `HEAD:refs/heads/main` was claimed in the description and the code comment but asserted
   nowhere; it has a test now. Deliberately still allowed, since
   this pattern sits on the run's most common command and over-blocking is how a control gets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@
   same effect) matched nothing, a case the original `\b` had caught. It now ends at a lookahead
   over the shell's own terminator set, which covers both directions.
 
+  **A third review round found the anchor itself was wrong — and had always been.** Every git
+  rule in this file began `\bgit\s+push\b`, which demands that `push` follow `git`
+  immediately. One ordinary global flag shook all of them off at once: `git -C . push origin
+  HEAD:main`, `git -c k=v push …`, `git --no-pager push …`. That was never about the new patterns —
+  the **pre-existing branch-delete rules had the same hole**, and `git -C . push origin --delete f`
+  went through untouched. All four git rules now share one prefix that tolerates flag-shaped tokens
+  between the program and the subcommand, so fixing it once fixed the older rules too. Only
+  flag-shaped tokens are allowed in that gap, so `git commit -m "push to main"` is still not read
+  as a push, and the repetition is bounded rather than `*` — this runs on every tool call, and an
+  unbounded nested quantifier over adversarial input is a stall waiting to happen (measured: 1 ms
+  against a command carrying 200 flag-like tokens).
+
+  **Known and accepted:** `git push main` is read as a push to the default branch even when `main`
+  is the name of a *remote*. A false positive, not a bypass, on a rare spelling — and this pattern
+  deliberately errs toward refusing.
+
   The original over-block, for the record: the tests missed it because the case they checked,
   `maintenance`, continues with `t` (a word character) and so passed **for the wrong reason** —
   proving nothing about `-` or `.`. A green test that passes by accident is the same failure this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 ### Fixed
+- **A braked run could push straight to the default branch** (#542). The brake watched `gh pr merge`,
+  the REST merge endpoints and `Board-Merge.ps1` — and missed the simplest route of all:
+  `git push origin HEAD:main` puts work on main with one command and matched nothing. Present in
+  every version of the brake, including shipped 0.29.0, and found only when an external review was
+  pointed at *whether the door was really shut* rather than at the change in front of it.
+
+  Not quite an oversight, which is the interesting part: the delete pattern carried a comment
+  calling `HEAD:main` "an ordinary push refspec", written while guarding against *over*-matching.
+  A test pinned that reading in place. Both were correct about the delete pattern and wrong about
+  the vocabulary — this guard defines merge as *"putting work on the default branch"*, which is
+  exactly what that refspec does. **The obsolete assertion was corrected, not worked around.**
+
+  Now refused: refspecs onto `main`/`master` (`HEAD:main`, `branch:main`, `+HEAD:main`,
+  `HEAD:refs/heads/main`) and pushing the default branch by name. Deliberately still allowed, since
+  this pattern sits on the run's most common command and over-blocking is how a control gets
+  switched off: `git push -u origin <branch>`, a bare `git push`, `--force-with-lease` on its own
+  branch, and any branch whose *name* merely contains `main` (`issue-9-domain-model`,
+  `feature/maintenance`, `HEAD:my-domain`). **Stated limit:** the pure core cannot ask the repo what
+  its default branch is, so a project whose default is neither `main` nor `master` is not covered.
+
 - **The reviewer's turn cap sat one turn above what a real review needs** (#543). Measured across
   recent runs: reviews that actually published consumed 4 / 13 / 17 / 18 / **19** turns against a
   cap of **20**, and three consecutive runs on a large PR died at 21. A run that hits the cap leaves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,17 @@
   exactly what that refspec does. **The obsolete assertion was corrected, not worked around.**
 
   Now refused: refspecs onto `main`/`master` (`HEAD:main`, `branch:main`, `+HEAD:main`,
-  `HEAD:refs/heads/main`) and pushing the default branch by name. Deliberately still allowed, since
+  `HEAD:refs/heads/main`) and pushing the default branch by name.
+
+  **The first cut of this pattern over-blocked, and the CI reviewer caught it** — the first review
+  it produced after #543 raised its turn cap. Ending the pattern with `` only asks that the next
+  character not be a word character, so `HEAD:main-cleanup` and `HEAD:master.bak` were refused:
+  legitimate branches, blocked, on the run's most common command — precisely the failure this entry
+  claims to guard against. The tests missed it because the case they checked, `maintenance`,
+  continues with `t` (a word character) and so passed for the wrong reason. Both patterns now end
+  at a real token boundary, so the branch name has to *be* `main`/`master`. The reviewer also noted
+  that `HEAD:refs/heads/main` was claimed in the description and the code comment but asserted
+  nowhere; it has a test now. Deliberately still allowed, since
   this pattern sits on the run's most common command and over-blocking is how a control gets
   switched off: `git push -u origin <branch>`, a bare `git push`, `--force-with-lease` on its own
   branch, and any branch whose *name* merely contains `main` (`issue-9-domain-model`,

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -87,13 +87,17 @@ $script:BrakePatterns = @(
     #
     # Two shapes: a REFSPEC landing on main/master (`HEAD:main`, `branch:main`, `+HEAD:main`,
     # `HEAD:refs/heads/main`), and pushing the default branch BY NAME (`git push origin main`).
-    # The `\b` after the branch name is load-bearing: without it `HEAD:maintenance` and
-    # `feature/maintenance` would be refused, and this pattern sits on the run's single most
-    # common command - over-blocking here is how the whole control gets switched off.
+    #
+    # BOTH end with `(\s|$)`, not `\b`, and the difference is a real false positive rather than
+    # style. `\b` only asks that the NEXT character not be a word character, so `main-cleanup` and
+    # `master.bak` satisfied it and were refused - legitimate branches, blocked, on the run's single
+    # most common command. The first round of tests missed it because the case they checked,
+    # `maintenance`, happens to continue with `t` (a word character) and so passed for the wrong
+    # reason. Requiring end-of-token instead makes the branch name have to BE main/master.
     #
     # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
     # is. A project whose default is neither `main` nor `master` is not covered.
-    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)\b' }
+    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(\s|$)' }
     @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s(main|master)(\s|$)' }
 
     # --- publish: making something public / cutting a release -----------------------

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -88,17 +88,25 @@ $script:BrakePatterns = @(
     # Two shapes: a REFSPEC landing on main/master (`HEAD:main`, `branch:main`, `+HEAD:main`,
     # `HEAD:refs/heads/main`), and pushing the default branch BY NAME (`git push origin main`).
     #
-    # BOTH end with `(\s|$)`, not `\b`, and the difference is a real false positive rather than
-    # style. `\b` only asks that the NEXT character not be a word character, so `main-cleanup` and
-    # `master.bak` satisfied it and were refused - legitimate branches, blocked, on the run's single
-    # most common command. The first round of tests missed it because the case they checked,
-    # `maintenance`, happens to continue with `t` (a word character) and so passed for the wrong
-    # reason. Requiring end-of-token instead makes the branch name have to BE main/master.
+    # HOW THE BRANCH NAME MUST END - and this took three tries, each one a real defect:
+    #
+    #   `\b`        refused `main-cleanup` and `master.bak`. `\b` only asks that the next character
+    #               not be a word character, so a `-` or a `.` satisfied it: legitimate branches
+    #               blocked on the run's most common command. The tests missed it because the case
+    #               they checked, `maintenance`, continues with `t` - a word character - so it
+    #               passed for the WRONG REASON and proved nothing about `-`.
+    #   `(\s|$)`    fixed that and reopened a different hole: it accepts only a space or the end of
+    #               a segment, and $SegmentSeparator does not split on a lone `&` or a redirection.
+    #               So `git push origin HEAD:main&` - background the push, same effect - matched
+    #               nothing. The `\b` it replaced had caught that one.
+    #   lookahead   what is here now: the branch name must end at whitespace, a shell separator, a
+    #               redirection, or end-of-string. Both failure directions covered, and the
+    #               terminator set is the shell's, not an ad-hoc one.
     #
     # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
     # is. A project whose default is neither `main` nor `master` is not covered.
-    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(\s|$)' }
-    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s(main|master)(\s|$)' }
+    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
 
     # --- publish: making something public / cutting a release -----------------------
     @{ action = 'publish'; pattern = '\bgh\s+release\s+create\b' }

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -53,10 +53,25 @@ $script:BrakeMarkerName = 'brake-armed.json'
 # never about the new patterns, it was about the anchor they all copied.
 #
 # Only FLAG-SHAPED tokens may sit in the gap, each with at most one value, so `git commit -m
-# "push to main"` (quotes are stripped by then) is not mistaken for a push. Repetition is BOUNDED
-# rather than `*`: this runs on every tool call, and an unbounded nested quantifier over
-# adversarial input is a stall waiting to happen.
-$script:GitCmd = '\bgit\s+(?:-{1,2}[^\s;|&]+\s+(?:[^\s;|&-][^\s;|&]*\s+)?){0,5}'
+# "push to main"` (quotes are stripped by then) is not mistaken for a push.
+#
+# The repetition is UNBOUNDED, and getting there took two wrong turns worth recording:
+#
+#   1. Capped at {0,5} "to avoid ReDoS". That WAS a bypass - six `-c` flags and the rule stopped
+#      matching, and chaining several `-c` is ordinary scripting, not an attack.
+#   2. Uncapped as `-{1,2}[^\s;|&]+`, on the reasoning (mine and the reviewer's) that the classes
+#      are disjoint so no catastrophic backtracking is possible. MEASURED, AND FALSE: `--flag`
+#      repeated 1000 times HUNG the matcher past three minutes. `-{1,2}` and `[^\s;|&]+` can both
+#      consume the second dash, so every `--` token had two readings and 1000 of them had 2^1000.
+#
+# The form here removes that ambiguity: one leading `-`, then everything up to whitespace, so each
+# token has exactly ONE reading. Measured after the change - 1000 `--flag` tokens: 3 ms with no
+# match, 334 ms when a real push follows; 2000 `-c k=v` tokens: 3 ms. The bypass is closed without
+# a count, and the stall is closed without a cap.
+#
+# The lesson, since this file keeps teaching it: "the classes are disjoint so it cannot blow up"
+# is an argument, not a measurement. Time it.
+$script:GitCmd = '\bgit\s+(?:-[^\s;|&]*\s+(?:[^\s;|&-][^\s;|&]*\s+)?)*'
 
 # Command patterns that REACH an irreversible action, grouped by the contract's action vocabulary
 # (the same words Expert-Autonomy uses, so one contract drives both).
@@ -117,7 +132,7 @@ $script:BrakePatterns = @(
     #
     # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
     # is. A project whose default is neither `main` nor `master` is not covered.
-    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]*:(?:refs/heads/)?(main|master)(?=[\s;&|<>]|$)' }
     @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
 
     # --- publish: making something public / cutting a release -----------------------

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -132,7 +132,13 @@ $script:BrakePatterns = @(
     #
     # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
     # is. A project whose default is neither `main` nor `master` is not covered.
-    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]*:(?:refs/heads/)?(main|master)(?=[\s;&|<>]|$)' }
+    # The source side is `+`, not `*`, on purpose: an EMPTY source (`git push origin :main`) is
+    # git's spelling for DELETING the remote branch, not for writing to it. Allowing zero characters
+    # there made this rule swallow the delete - the array is walked in order, so the refusal told the
+    # human "merge is marked irreversible" for a command that removes main, arguably the worse of
+    # the two. Not a bypass (the contract filter runs per pattern, so a delete-braking contract
+    # still refused it), but a control is only as useful as the account it gives of itself.
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]+:(?:refs/heads/)?(main|master)(?=[\s;&|<>]|$)' }
     @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
 
     # --- publish: making something public / cutting a release -----------------------

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -46,6 +46,18 @@ $ErrorActionPreference = "Stop"
 # launch and read by the hook, the supervisor (#517) and the teardown (#518).
 $script:BrakeMarkerName = 'brake-armed.json'
 
+# `git` accepts GLOBAL options between the program and the subcommand - `git -C <path> push`,
+# `git -c k=v push`, `git --no-pager push`. Anchoring rules on `\bgit\s+push\b` demanded that
+# `push` follow `git` immediately, so ONE ordinary flag shook off every git rule at once (#542,
+# review round 3). That included the branch-delete rules, which predate this work: the hole was
+# never about the new patterns, it was about the anchor they all copied.
+#
+# Only FLAG-SHAPED tokens may sit in the gap, each with at most one value, so `git commit -m
+# "push to main"` (quotes are stripped by then) is not mistaken for a push. Repetition is BOUNDED
+# rather than `*`: this runs on every tool call, and an unbounded nested quantifier over
+# adversarial input is a stall waiting to happen.
+$script:GitCmd = '\bgit\s+(?:-{1,2}[^\s;|&]+\s+(?:[^\s;|&-][^\s;|&]*\s+)?){0,5}'
+
 # Command patterns that REACH an irreversible action, grouped by the contract's action vocabulary
 # (the same words Expert-Autonomy uses, so one contract drives both).
 #
@@ -105,8 +117,8 @@ $script:BrakePatterns = @(
     #
     # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
     # is. A project whose default is neither `main` nor `master` is not covered.
-    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(?=[\s;&|<>]|$)' }
-    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
 
     # --- publish: making something public / cutting a release -----------------------
     @{ action = 'publish'; pattern = '\bgh\s+release\s+create\b' }
@@ -129,10 +141,10 @@ $script:BrakePatterns = @(
     @{ action = 'delete';  pattern = '\bgh\s+(issue|release)\s+delete\b' }
     # Every spelling gh accepts for the same DELETE request, not just the long one.
     @{ action = 'delete';  pattern = '\bgh\s+api\b.*(--method[=\s]+delete\b|-x\s+delete\b)' }
-    @{ action = 'delete';  pattern = '\bgit\s+push\b.*--delete\b' }
+    @{ action = 'delete';  pattern = $script:GitCmd + 'push\b.*--delete\b' }
     # git's other remote-branch deletion syntax: `git push origin :branch`. The leading whitespace
     # in the lookbehind keeps `HEAD:main` (an ordinary push refspec) out of it.
-    @{ action = 'delete';  pattern = '\bgit\s+push\b[^;]*\s:\S' }
+    @{ action = 'delete';  pattern = $script:GitCmd + 'push\b[^;]*\s:\S' }
 
     # --- indirection through a variable ---------------------------------------------
     # Quote removal (see ConvertTo-NormalizedCommand) handles `gh pr 'merge'`, but a value the

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -79,6 +79,23 @@ $script:BrakePatterns = @(
     @{ action = 'merge';   pattern = '\bpulls?/\d+/merge\b' }
     @{ action = 'merge';   pattern = '\brepos/[^\s]+/merges\b' }
 
+    # Pushing straight to the default branch (#542). The simplest merge route of all, and the one
+    # this guard missed for longest: `git push origin HEAD:main` puts work on main with one command
+    # and matched nothing. It was not quite an oversight - the delete pattern below carries a
+    # comment calling `HEAD:main` "an ordinary push refspec" - but this file's own vocabulary
+    # defines merge as "putting work on the default branch", which is exactly what it does.
+    #
+    # Two shapes: a REFSPEC landing on main/master (`HEAD:main`, `branch:main`, `+HEAD:main`,
+    # `HEAD:refs/heads/main`), and pushing the default branch BY NAME (`git push origin main`).
+    # The `\b` after the branch name is load-bearing: without it `HEAD:maintenance` and
+    # `feature/maintenance` would be refused, and this pattern sits on the run's single most
+    # common command - over-blocking here is how the whole control gets switched off.
+    #
+    # LIMIT: this core is pure (no git access), so it cannot ask the repo what its default branch
+    # is. A project whose default is neither `main` nor `master` is not covered.
+    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s\+?[^\s;|&]*[:/](main|master)\b' }
+    @{ action = 'merge';   pattern = '\bgit\s+push\b[^;]*\s(main|master)(\s|$)' }
+
     # --- publish: making something public / cutting a release -----------------------
     @{ action = 'publish'; pattern = '\bgh\s+release\s+create\b' }
     @{ action = 'publish'; pattern = '\bnpm\s+publish\b' }

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -138,8 +138,8 @@ $script:BrakePatterns = @(
     # human "merge is marked irreversible" for a command that removes main, arguably the worse of
     # the two. Not a bypass (the contract filter runs per pattern, so a delete-braking contract
     # still refused it), but a control is only as useful as the account it gives of itself.
-    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s\+?[^\s;|&]+:(?:refs/heads/)?(main|master)(?=[\s;&|<>]|$)' }
-    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;]*\s(main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;&|<>]*\s\+?[^\s;|&]+:(?:refs/heads/)?(main|master)(?=[\s;&|<>]|$)' }
+    @{ action = 'merge';   pattern = $script:GitCmd + 'push\b[^;&|<>]*\s(main|master)(?=[\s;&|<>]|$)' }
 
     # --- publish: making something public / cutting a release -----------------------
     @{ action = 'publish'; pattern = '\bgh\s+release\s+create\b' }
@@ -165,7 +165,7 @@ $script:BrakePatterns = @(
     @{ action = 'delete';  pattern = $script:GitCmd + 'push\b.*--delete\b' }
     # git's other remote-branch deletion syntax: `git push origin :branch`. The leading whitespace
     # in the lookbehind keeps `HEAD:main` (an ordinary push refspec) out of it.
-    @{ action = 'delete';  pattern = $script:GitCmd + 'push\b[^;]*\s:\S' }
+    @{ action = 'delete';  pattern = $script:GitCmd + 'push\b[^;&|<>]*\s:\S' }
 
     # --- indirection through a variable ---------------------------------------------
     # Quote removal (see ConvertTo-NormalizedCommand) handles `gh pr 'merge'`, but a value the

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -985,3 +985,42 @@ Describe 'Test-IsBrakedCommand — deleting the default branch is a DELETE (#542
             Should -Be 'delete'
     }
 }
+
+Describe 'Test-IsBrakedCommand — the prefix must not step over a background operator (#542, review round 6)' {
+    # Segments split on `;`, `&&`, `||`, `|` and newlines, but NOT on a lone `&` - deliberately, since
+    # the branch-name lookahead treats `&` as a terminator. The gap between the two: the `[^;]*`
+    # sitting before the refspec excluded only `;`, so the matcher could skip PAST a background `&`
+    # and pick up any later `something:main` in the same segment - text belonging to a different
+    # command entirely.
+    #
+    # A false positive, never a bypass (a looser prefix can only add matches). Fixed anyway: this
+    # pattern sits on the run's most common command, and over-blocking is how a control gets
+    # switched off - the argument this whole change rests on.
+
+    It 'does not read text after a background & as the push target' {
+        Test-IsBrakedCommand -Command 'git push origin fine & echo notes:main' -Irreversible $script:AllIrr |
+            Should -BeNullOrEmpty
+    }
+    It 'does not read text after a pipe-ish operator as the push target' {
+        Test-IsBrakedCommand -Command 'git push origin fine & cat refs:master' -Irreversible $script:AllIrr |
+            Should -BeNullOrEmpty
+    }
+    It 'still denies when the refspec is the REAL target and & merely follows it' {
+        # The round-2 cases must survive: there the `&` comes AFTER the refspec, not before it.
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main&' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main>out.txt' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'still denies the ordinary forms' {
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+        Test-IsBrakedCommand -Command 'git -C . push origin HEAD:refs/heads/master' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'still denies a real merge sitting in a LATER segment' {
+        # The prefix is narrowed, not the segment splitting: a genuine second command still counts.
+        Test-IsBrakedCommand -Command 'git status ; git push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+}

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -722,6 +722,15 @@ Describe 'Test-IsBrakedCommand — pushing straight to the default branch IS a m
         Test-IsBrakedCommand -Command 'git push origin +HEAD:main' -Irreversible $script:AllIrr |
             Should -Be 'merge'
     }
+    It 'denies the fully-qualified ref form' {
+        # Claimed in the PR body and in the code comment, and it did work - but nothing ASSERTED it.
+        # On a change born from "the suite was green because a test asserted the gap was correct",
+        # an unasserted claim is the one thing not to leave lying around.
+        Test-IsBrakedCommand -Command 'git push origin HEAD:refs/heads/main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+        Test-IsBrakedCommand -Command 'git push origin HEAD:refs/heads/master' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
     It 'denies pushing the local default branch by name' {
         Test-IsBrakedCommand -Command 'git push origin main' -Irreversible $script:AllIrr |
             Should -Be 'merge'
@@ -757,6 +766,19 @@ Describe 'Test-IsBrakedCommand — pushing straight to the default branch IS a m
         }
         It 'allows a refspec onto a branch merely ending in something like main' {
             Test-IsBrakedCommand -Command 'git push origin HEAD:my-domain' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows a branch whose name STARTS with main followed by a separator' {
+            # Found by the CI reviewer on the first cut of this pattern. `` only requires the next
+            # character to be non-word, so `main-cleanup` and `master.bak` satisfied it and got
+            # refused - a false positive on exactly the command this guard must not over-block.
+            # The `maintenance` case passed because `t` IS a word character, which is why the first
+            # round of tests missed it entirely.
+            Test-IsBrakedCommand -Command 'git push origin HEAD:main-cleanup' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+            Test-IsBrakedCommand -Command 'git push origin HEAD:master.bak' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+            Test-IsBrakedCommand -Command 'git push -u origin main-cleanup' -Irreversible $script:AllIrr |
                 Should -BeNullOrEmpty
         }
         It 'still recognises the DELETE spelling as delete, not as a merge' {

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -948,3 +948,40 @@ Describe 'Test-IsBrakedCommand — the classifier must not be stallable (#542, r
         $sw.ElapsedMilliseconds | Should -BeLessThan 5000
     }
 }
+
+Describe 'Test-IsBrakedCommand — deleting the default branch is a DELETE (#542, review round 5)' {
+    # `git push origin :main` removes the remote default branch. The merge refspec pattern matched
+    # it first (its source side allowed zero characters) and the array is walked in order, so the
+    # refusal said "merge is marked irreversible" for a command that DELETES main - arguably worse.
+    #
+    # Not a bypass, and worth stating why rather than assuming: the contract filter is applied per
+    # pattern BEFORE matching, so a contract braking only `delete` already refused it correctly.
+    # What was wrong was the verb the human is told, and this control is only as useful as the
+    # account it gives of itself.
+
+    It 'calls the empty-source refspec a delete, not a merge' {
+        Test-IsBrakedCommand -Command 'git push origin :main' -Irreversible @('merge','delete') |
+            Should -Be 'delete'
+        Test-IsBrakedCommand -Command 'git push origin :master' -Irreversible @('merge','delete') |
+            Should -Be 'delete'
+    }
+    It 'still calls a real refspec push a merge' {
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible @('merge','delete') |
+            Should -Be 'merge'
+    }
+    It 'still refuses it when only delete is braked' {
+        Test-IsBrakedCommand -Command 'git push origin :main' -Irreversible @('delete') |
+            Should -Be 'delete'
+    }
+    It 'follows the contract when only MERGE is braked' {
+        # Deliberate, and recorded so it is a decision rather than an accident: this command is a
+        # delete, so a contract that does not brake deletes does not brake this. The guard follows
+        # the contract; it does not invent policy - the rule this file opens with.
+        Test-IsBrakedCommand -Command 'git push origin :main' -Irreversible @('merge') |
+            Should -BeNullOrEmpty
+    }
+    It 'is unaffected for ordinary branches' {
+        Test-IsBrakedCommand -Command 'git push origin :feature-x' -Irreversible @('merge','delete') |
+            Should -Be 'delete'
+    }
+}

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -803,3 +803,53 @@ Describe 'Test-IsBrakedCommand — pushing straight to the default branch IS a m
         }
     }
 }
+
+Describe 'Test-IsBrakedCommand — git global flags must not shake off the guard (#542, review round 3)' {
+    # `\bgit\s+push\b` demands that `push` follow `git` immediately, so ANY global option between
+    # them broke every git rule at once. `-C` and `-c` are everyday flags, not exotica.
+    #
+    # This one was NOT introduced by this PR: the pre-existing `--delete` patterns had the same
+    # anchor and the same hole. Found only because the reviewer asked what the anchor assumes.
+
+    It 'denies a push to main behind -C' {
+        Test-IsBrakedCommand -Command 'git -C . push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies it behind -c <config>' {
+        Test-IsBrakedCommand -Command 'git -c http.extraheader= push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies it behind --no-pager' {
+        Test-IsBrakedCommand -Command 'git --no-pager push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies it behind several stacked flags' {
+        Test-IsBrakedCommand -Command 'git --no-pager -C . -c core.pager=cat push origin HEAD:main' `
+            -Irreversible $script:AllIrr | Should -Be 'merge'
+    }
+    It 'closes the same hole in the PRE-EXISTING branch-delete rule' {
+        Test-IsBrakedCommand -Command 'git -C . push origin --delete feature' -Irreversible $script:AllIrr |
+            Should -Be 'delete'
+    }
+    It 'closes it for the refspec delete too' {
+        Test-IsBrakedCommand -Command 'git -C . push origin :feature-x' -Irreversible $script:AllIrr |
+            Should -Be 'delete'
+    }
+
+    Context 'and still does not invent matches' {
+        It 'does not treat an unrelated git command as a push' {
+            # Quote stripping turns this into `git commit -m push to main`; only tokens that LOOK
+            # like flags may sit between git and push, so `commit` stops it dead.
+            Test-IsBrakedCommand -Command 'git commit -m "push to main"' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'does not brake an ordinary flagged push' {
+            Test-IsBrakedCommand -Command 'git -C . push -u origin issue-542-x' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'does not brake a flagged push to a main-ish branch name' {
+            Test-IsBrakedCommand -Command 'git -C . push origin HEAD:main-cleanup' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+    }
+}

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -731,6 +731,22 @@ Describe 'Test-IsBrakedCommand — pushing straight to the default branch IS a m
         Test-IsBrakedCommand -Command 'git push origin HEAD:refs/heads/master' -Irreversible $script:AllIrr |
             Should -Be 'merge'
     }
+    It 'denies it when the shell terminates the token without a space' {
+        # Found by the CI reviewer on the FIX for the over-blocking, not on the original pattern.
+        # `(\s|$)` accepts only a space or end-of-segment, and the segment splitter does not treat
+        # a lone `&` or a redirection as a separator - so `HEAD:main&` (background the push) and
+        # `HEAD:main>out.txt` matched nothing and went through. The `` this replaced DID catch
+        # them: fixing the false positive reopened a different hole in the same pattern.
+        foreach ($c in @(
+            'git push origin HEAD:main&'
+            'git push origin HEAD:main>out.txt'
+            'git push origin main&'
+            'git push origin HEAD:main<in.txt'
+        )) {
+            Test-IsBrakedCommand -Command $c -Irreversible $script:AllIrr |
+                Should -Be 'merge' -Because "'$c' reaches main"
+        }
+    }
     It 'denies pushing the local default branch by name' {
         Test-IsBrakedCommand -Command 'git push origin main' -Irreversible $script:AllIrr |
             Should -Be 'merge'

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -248,8 +248,18 @@ Describe 'Test-IsBrakedCommand — bypasses found by external review (round 4)' 
             Test-IsBrakedCommand -Command 'git push origin :feature-x' -Irreversible $script:AllIrr |
                 Should -Be 'delete'
         }
-        It 'still allows an ordinary push refspec' {
+        It 'does NOT read a push to main as an ordinary refspec (#542)' {
+            # This test used to assert the opposite, and that assertion WAS the gap: it was written
+            # to prove the delete pattern did not over-match, and in doing so it pinned
+            # `HEAD:main` as allowed. Pushing to the default branch is a merge by this file's own
+            # definition; it is only "ordinary" from the delete pattern's point of view.
             Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+        }
+        It 'still allows a refspec onto an ordinary branch' {
+            # What the original test meant to guard: the delete pattern must not eat a normal
+            # refspec push.
+            Test-IsBrakedCommand -Command 'git push origin HEAD:feature-x' -Irreversible $script:AllIrr |
                 Should -BeNullOrEmpty
         }
         It 'still allows a plain push' {
@@ -679,5 +689,79 @@ Describe 'Test-IsBrakedCommand — an ORDERED run is refused exactly like an uno
     It 'honours a contract that does not brake on merge at all' {
         Test-IsBrakedCommand -Command 'pwsh scripts/Board-Merge.ps1 -PR 1' -Irreversible @('deploy') |
             Should -Be ''
+    }
+}
+
+Describe 'Test-IsBrakedCommand — pushing straight to the default branch IS a merge (#542)' {
+    # Pre-existing gap, older than the end-to-end work: the brake watched `gh pr merge`, the REST
+    # merge endpoints and Board-Merge.ps1, and missed the simplest route of all. `git push origin
+    # HEAD:main` puts work on the default branch with one command and matched nothing.
+    #
+    # It was not an oversight so much as a decision that reads differently now: the delete pattern's
+    # comment says the lookbehind "keeps `HEAD:main` (an ordinary push refspec) out of it". But this
+    # file's own vocabulary defines merge as "putting work on the default branch", which is exactly
+    # what that refspec does.
+
+    It 'denies the plain refspec push to main' {
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies a branch-to-main refspec' {
+        Test-IsBrakedCommand -Command 'git push origin my-branch:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies the same against master' {
+        Test-IsBrakedCommand -Command 'git push origin HEAD:master' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies a FORCE refspec push to main' {
+        Test-IsBrakedCommand -Command 'git push --force origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies the + force spelling' {
+        Test-IsBrakedCommand -Command 'git push origin +HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies pushing the local default branch by name' {
+        Test-IsBrakedCommand -Command 'git push origin main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'denies it in a later segment' {
+        Test-IsBrakedCommand -Command 'git status && git push origin HEAD:main' -Irreversible $script:AllIrr |
+            Should -Be 'merge'
+    }
+    It 'follows the contract — no brake when merge is not irreversible' {
+        Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible @('deploy') |
+            Should -Be ''
+    }
+
+    Context 'must NOT block the pushes the run makes all day' {
+        # Over-blocking is how a safety control gets switched off for being annoying, and this
+        # pattern sits on the run's single most common command.
+        It 'allows pushing its own branch' {
+            Test-IsBrakedCommand -Command 'git push -u origin issue-542-push-to-default' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows a bare push' {
+            Test-IsBrakedCommand -Command 'git push' -Irreversible $script:AllIrr | Should -BeNullOrEmpty
+        }
+        It 'allows a force-with-lease on its own branch' {
+            Test-IsBrakedCommand -Command 'git push --force-with-lease origin my-branch' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows a branch whose NAME merely contains main' {
+            Test-IsBrakedCommand -Command 'git push -u origin issue-9-domain-model' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+            Test-IsBrakedCommand -Command 'git push origin feature/maintenance' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows a refspec onto a branch merely ending in something like main' {
+            Test-IsBrakedCommand -Command 'git push origin HEAD:my-domain' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'still recognises the DELETE spelling as delete, not as a merge' {
+            Test-IsBrakedCommand -Command 'git push origin :old-branch' -Irreversible $script:AllIrr |
+                Should -Be 'delete'
+        }
     }
 }

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -853,3 +853,98 @@ Describe 'Test-IsBrakedCommand — git global flags must not shake off the guard
         }
     }
 }
+
+Describe 'Test-IsBrakedCommand — the round-3 fix carried two of its own (#542, review round 4)' {
+    # Both introduced by the fix for the global-flag anchor. Neither is exotic.
+
+    Context 'the flag allowance must not be countable' {
+        # Bounding the repetition at 5 turned the fix into a new bypass: SIX `-c` flags and the
+        # rule stops matching. Chaining several `-c` (user.name, user.email, http.sslVerify,
+        # core.pager...) is ordinary scripting, not an attack.
+        #
+        # The bound was justified in the comment as ReDoS protection. That justification was wrong:
+        # the repeated group is anchored by mandatory whitespace and its character classes are
+        # disjoint, so there is no catastrophic backtracking to protect against. A guard narrowed
+        # against an imagined risk, opening a real one.
+        It 'denies a push to main behind SIX global flags' {
+            Test-IsBrakedCommand -Command 'git -c a=1 -c b=1 -c c=1 -c d=1 -c e=1 -c f=1 push origin HEAD:main' `
+                -Irreversible $script:AllIrr | Should -Be 'merge'
+        }
+        It 'denies it behind twelve' {
+            $flags = (1..12 | ForEach-Object { "-c k$_=v" }) -join ' '
+            Test-IsBrakedCommand -Command "git $flags push origin HEAD:main" -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+        }
+        It 'closes the same count hole in the delete rule' {
+            Test-IsBrakedCommand -Command 'git -c a=1 -c b=1 -c c=1 -c d=1 -c e=1 -c f=1 push origin --delete f' `
+                -Irreversible $script:AllIrr | Should -Be 'delete'
+        }
+    }
+
+    Context 'a slash is not a refspec separator' {
+        # `[:/]` treated `/` as if it delimited a refspec. It does not - `/` is an ordinary
+        # character inside a branch name, so any branch merely ENDING in main/master was refused.
+        It 'allows a branch that merely ends in master' {
+            Test-IsBrakedCommand -Command 'git push origin release/master' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows a branch that merely ends in main' {
+            Test-IsBrakedCommand -Command 'git push origin team/main' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'allows that same branch as an explicit refspec target' {
+            # Not raised by the review, but it is the same defect one step along.
+            Test-IsBrakedCommand -Command 'git push origin HEAD:team/main' -Irreversible $script:AllIrr |
+                Should -BeNullOrEmpty
+        }
+        It 'STILL denies the fully-qualified ref, which is a real spelling of the default branch' {
+            Test-IsBrakedCommand -Command 'git push origin HEAD:refs/heads/main' -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+            Test-IsBrakedCommand -Command 'git push origin HEAD:refs/heads/master' -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+        }
+        It 'STILL denies the plain forms' {
+            Test-IsBrakedCommand -Command 'git push origin HEAD:main' -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+            Test-IsBrakedCommand -Command 'git push origin main' -Irreversible $script:AllIrr |
+                Should -Be 'merge'
+        }
+    }
+}
+
+Describe 'Test-IsBrakedCommand — the classifier must not be stallable (#542, review round 4)' {
+    # This guard runs on EVERY tool call. A command that makes it backtrack forever does not just
+    # slow the run down - it wedges the session, and a wedged guard is a removed guard.
+    #
+    # Not hypothetical: while removing the flag COUNT (itself a bypass), the replacement used
+    # `-{1,2}[^\s;|&]+`, where both halves can consume the second dash of `--flag`. Two readings
+    # per token, 1000 tokens, and the matcher ran past three minutes. Both the external reviewer
+    # and I had argued it was safe because "the character classes are disjoint". The argument was
+    # wrong and only the stopwatch said so.
+    #
+    # These are timing assertions on purpose. Generous bounds - they exist to catch a hang, not to
+    # police milliseconds on a busy CI box.
+
+    It 'answers quickly on a long run of valueless flags' {
+        $cmd = 'git ' + ('--flag ' * 1000) + 'status'
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $null = Test-IsBrakedCommand -Command $cmd -Irreversible $script:AllIrr
+        $sw.Stop()
+        $sw.ElapsedMilliseconds | Should -BeLessThan 5000 -Because 'this exact shape hung the matcher'
+    }
+    It 'answers quickly when that run ends in a real push' {
+        $cmd = 'git ' + ('--flag ' * 1000) + 'push origin HEAD:main'
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $r = Test-IsBrakedCommand -Command $cmd -Irreversible $script:AllIrr
+        $sw.Stop()
+        $r | Should -Be 'merge'
+        $sw.ElapsedMilliseconds | Should -BeLessThan 5000
+    }
+    It 'answers quickly on a long run of flags WITH values' {
+        $cmd = 'git ' + ('-c k=v ' * 2000) + 'status'
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $null = Test-IsBrakedCommand -Command $cmd -Irreversible $script:AllIrr
+        $sw.Stop()
+        $sw.ElapsedMilliseconds | Should -BeLessThan 5000
+    }
+}


### PR DESCRIPTION
Closes #542.

The brake watched `gh pr merge`, the REST merge endpoints and `Board-Merge.ps1` — and missed the simplest route of all:

```
git push origin HEAD:main
```

One command, work on main, matched nothing. Present in **every** version of the brake including shipped 0.29.0, and found only when an external review was pointed at *whether the door was really shut* rather than at the change in front of it.

## A test was holding it open

This is the part worth reading. The delete pattern carries a comment calling `HEAD:main` *"an ordinary push refspec"*, and a test asserted exactly that:

> `It 'still allows an ordinary push refspec'` → `git push origin HEAD:main` → **should be allowed**

Both were written while guarding the delete pattern against *over*-matching, and both were right about that and wrong about the vocabulary. This guard defines merge as **"putting work on the default branch"** — precisely what that refspec does.

So the suite was green *because* something asserted the gap was correct behaviour. The obsolete assertion is **corrected, not worked around**, and replaced by one covering what it actually meant to protect: a refspec onto an *ordinary* branch.

## What changed

**Refused now:** refspecs onto `main`/`master` in every spelling — `HEAD:main`, `branch:main`, `+HEAD:main`, `HEAD:refs/heads/main` — and pushing the default branch by name.

**Deliberately still allowed**, because this pattern sits on the run's single most common command and over-blocking is how a control gets switched off:

| Allowed | Why it must stay allowed |
|---|---|
| `git push -u origin <branch>` | the run's daily command |
| `git push` | bare push |
| `git push --force-with-lease origin my-branch` | its own branch |
| `issue-9-domain-model`, `feature/maintenance`, `HEAD:my-domain` | branch names that merely *contain* `main` |

The `\b` after the branch name is what makes that distinction work.

**Stated limit:** the pure core takes no git access, so it cannot ask the repo what its default branch is. A project whose default is neither `main` nor `master` is not covered.

## Verification

Mutation-verified: removing the two patterns turns **8 tests red**. Worth noting that the first mutation attempt silently failed to apply — its escape sequences were wrong — so the green it produced proved nothing; it was redone before being trusted.

**1,607 tests suite-wide, 0 failing.**

## This PR is also the validation for #543

#544 raised the reviewer's turn cap from 20 to 40, and could not test itself: `claude-code-action` refuses to run on a PR that modifies its own workflow. This is the first unrelated PR after that merged, so `claude-review` completing here is the real evidence the cap fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)