### PR TITLE
brief: fold the phase loop and the decision protocol into what the session actually receives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,25 @@
   The capability map is retained as a lookup table inside the same section, subordinate to the
   phases rather than their replacement.
 
-  Verified by four new tests that assert on the rendered brief text, not on the source documents:
-  the seven phase names are present, "research before deciding" appears explicitly, the
-  Research-Register-Decide ordering holds in the text, and "read-and-forget" is called out.
+  Verified by five tests that assert on the rendered brief text, not on the source documents: the
+  seven numbered phases are present, "research before deciding" appears explicitly, the
+  Research-Register-Decide ordering holds inside the protocol section, "read-and-forget" is called
+  out, and the no-improvise guard survives. Each was confirmed by reintroducing the defect and
+  watching the matching test go red.
+
+  **Caught by external review before merging, and worth recording.** The rewrite replaced the old
+  heading `total self-use of agentic-board (do NOT improvise your own tooling)` and never restated
+  it. Since this function composes the *only* text the launched session ever receives, deleting that
+  line deleted the instruction — a capability map lists options, it does not forbid inventing one.
+  The plan's own founding principle, dropped by the change meant to strengthen it. The guard is back
+  in the section heading and is now asserted.
+
+  Review also found the ordering test measuring the *first* occurrence of Research / Register /
+  Decide across the whole brief. "Research" already appears in phase 2, so the test could stay green
+  with the protocol steps scrambled — a test that reported a guarantee it did not hold. It is now
+  scoped to the decision-protocol section, and the phase test matches the numbered markers rather
+  than bare words ("verify" and "report" also occur in the capability map, so the loose match
+  survived deleting the phases).
 
 ## [0.31.0] - 2026-08-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- **The autonomous brief now carries the seven-phase loop and the decision protocol, not a
+  capability list** (#527, part of #526). `Format-AutoBrief` used to emit a bullet list of
+  agentic-board capabilities; the 7-phase method lived in `auto-loop.md`, a file the launched
+  session was never handed. The session had no phases, no sequence, and no instruction to
+  research before deciding — only "an in-scope problem: fix it in the loop and continue" as its
+  sole heuristic.
+
+  The brief now includes the full phase sequence (Ingest → Become the expert → Execute →
+  Verify + evidence → Self-heal → Loop until done → Report) and an explicit **decision protocol**:
+  when you hit an error, an unexpected state, or a fork in the path, *research before deciding —
+  do NOT act first*. Steps in order: Research (check prior-art, register via `/knowledge`),
+  Register (log findings — read-and-forget is not research), Decide (then choose the path).
+  The capability map is retained as a lookup table inside the same section, subordinate to the
+  phases rather than their replacement.
+
+  Verified by four new tests that assert on the rendered brief text, not on the source documents:
+  the seven phase names are present, "research before deciding" appears explicitly, the
+  Research-Register-Decide ordering holds in the text, and "read-and-forget" is called out.
+
 ## [0.31.0] - 2026-08-03
 ### Added
 - **A braked run can now authenticate as a machine account instead of as the owner** (#550, part of

--- a/evidence/527.md
+++ b/evidence/527.md
@@ -1,0 +1,54 @@
+# [abios-evidence] #527 — brief carries the method, not a capability list
+
+PR: #553 · branch `issue-527-brief-fold-the-phase-loop-and-the` · plan #526
+
+## What was tested
+
+`Format-AutoBrief` composes the only text an autonomous session ever receives. Every assertion below
+runs against the **rendered brief**, never against the reference documents.
+
+| # | Claim under test | Where |
+|---|---|---|
+| 1 | The seven numbered phases are in the brief | `Expert-Auto.Tests.ps1` — "includes all seven phases" |
+| 2 | "research before deciding" appears explicitly | "carries the decision protocol" |
+| 3 | Research → Register → Decide holds *inside the protocol section* | "names the decision protocol steps in order" |
+| 4 | "read-and-forget is not research" is stated | "says read-and-forget is not research" |
+| 5 | The no-improvise guard survives the rewrite | "keeps the do-NOT-improvise guard" |
+
+## Command and result
+
+```
+Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+Tests Passed: 21, Failed: 0, Skipped: 0
+```
+
+## A green suite proves nothing on its own — each guard was broken on purpose
+
+| Defect reintroduced | Test that went red | Result |
+|---|---|---|
+| Whole phase block deleted from the brief | the four #527 tests | 4 failed |
+| `do NOT improvise your own tooling` removed from the heading | "keeps the do-NOT-improvise guard" | 1 failed |
+| Protocol steps scrambled (Decide first, Research last) | "names the decision protocol steps in order" | 1 failed |
+| — restored — | — | 21 passed, 0 failed |
+
+## Review
+
+External review (Codex, gpt-5.5, xhigh) — two findings, both verified in the source before acting:
+
+1. **P2 — the rewrite dropped the no-improvise guard.** Confirmed: neither `improvise` nor
+   `total self-use` occurred anywhere in the new file, while both were in `origin/main`. Fixed and
+   asserted.
+2. **P3 — the ordering test did not protect the ordering it named.** Confirmed by reading the
+   assertion: first-occurrence over the whole brief, and "Research" occurs earlier in phase 2.
+   Scoped to the protocol section.
+
+Gemini was unavailable this round: its CLI rejects individual-tier accounts
+(`IneligibleTierError: UNSUPPORTED_CLIENT`). One reviewer, not two — recorded rather than glossed.
+
+## Not done by the autonomous run
+
+The run reached "PR ready" but recorded **no evidence at all** — no `[abios-evidence]` comment on
+#527, no `evidence/527.md`, and a PR body of exactly `Closes #527`, against a contract demanding all
+three. This file, the issue comment and the PR body were written afterwards, by hand. That gap is
+the subject of #532 ("prove the run used the tool instead of reporting that it did") and is filed
+separately rather than papered over here.

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -134,7 +134,9 @@ do NOT act first.**
 2. Register — log findings via ``/knowledge add`` / ``/knowledge harvest``. Read-and-forget is not research.
 3. Decide — then choose the fix or path.
 
-### Capability map (each need -> an agentic-board capability)
+### Capability map — total self-use of agentic-board (do NOT improvise your own tooling)
+
+Every need below already has a capability. Reach for it instead of inventing your own tooling.
 
 - Research / prior-art -> ``/knowledge add`` + ``/knowledge harvest``
 - Acquire / verify skills -> ``/skills bootstrap``, ``/skills audit``

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -106,21 +106,46 @@ $PlanBody
 ## Definition of Done — every gate must pass before you consider this complete
 $dodList
 
-## How you work — total self-use of agentic-board (do NOT improvise your own tooling)
-- Research / prior-art -> /knowledge add + /knowledge harvest
-- Acquire / verify skills -> /skills bootstrap, /skills audit
-- Discover latent work -> /scan
-- Record work / findings -> /board issue, /board plan, /board triage
-- Report progress / evidence -> /board update, [abios-evidence] comment
-- Survive budget / interruption -> /board handoff -Save
+## How you work — seven phases (do NOT skip any)
+
+Work sequentially through these seven phases. A capability list alone is not a method; the phases
+are the method.
+
+1. **Ingest** — read the epic/issue and its enriched plan (Role, Deliverables, Test plan / DoD).
+2. **Become the expert** — adopt the role objective. Research prior-art and docs, and register
+   findings via ``/knowledge add`` / ``/knowledge harvest`` (read-and-forget is not allowed).
+   Acquire missing tooling via ``/skills bootstrap`` / ``/skills audit``.
+3. **Execute (test-first)** — build guided by tests first, in the worktree.
+4. **Verify + evidence** — run the definition-of-done gates. Write a structured ``[abios-evidence]``
+   block to three places: the PR body, a durable issue comment, and ``evidence/<issue>.md``.
+   If green -> open the PR + run the review gate.
+5. **Self-heal + auto-drive the board**: in-scope problem -> fix it (after researching first);
+   out-of-scope finding -> file a sanitized 'discovered' issue on the board and keep going.
+6. **Loop until done or budget**: keep iterating until the DoD is green — then leave the PR ready
+   and STOP before merge — or the budget is spent -> ``/board handoff -Save``.
+7. **Report** — final evidence + updated board + a PR awaiting the human's merge approval.
+
+### Decision protocol — research before deciding
+
+When you hit an error, an unexpected state, or a fork in the path: **research before deciding —
+do NOT act first.**
+
+1. Research — check prior-art, existing patterns, similar resolved issues (``/knowledge``).
+2. Register — log findings via ``/knowledge add`` / ``/knowledge harvest``. Read-and-forget is not research.
+3. Decide — then choose the fix or path.
+
+### Capability map (each need -> an agentic-board capability)
+
+- Research / prior-art -> ``/knowledge add`` + ``/knowledge harvest``
+- Acquire / verify skills -> ``/skills bootstrap``, ``/skills audit``
+- Discover latent work -> ``/scan``
+- Record work / findings -> ``/board issue``, ``/board plan``, ``/board triage``
+- Report progress / evidence -> ``/board update``, ``[abios-evidence]`` comment
+- Survive budget / interruption -> ``/board handoff -Save``
 
 ## Test-first + evidence
 Build test-first. After each verify phase, record a structured [abios-evidence] block (what was
 tested, the command, the result) to the PR body, the issue comment, and evidence/<issue>.md.
-
-## Self-heal
-An in-scope problem: fix it in the loop and continue. An out-of-scope finding (side bug, debt):
-file a sanitized 'discovered' issue on the board and keep going — never block on it.
 
 $closingSection
 "@

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -66,6 +66,39 @@ Describe 'Agent type in the autonomous brief' {
     }
 }
 
+Describe 'Format-AutoBrief — phase loop and decision protocol (#527)' {
+    # #527: the brief was a capability LIST — the 7-phase loop and the research-before-deciding
+    # protocol lived in auto-loop.md, a file the launched session never received. The session
+    # must carry the METHOD (phases + decision protocol), not just a bullet list of capabilities.
+
+    It 'includes all seven phases so the session knows the method, not just the capability list' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)ingest'
+        $b | Should -Match '(?i)become the expert'
+        $b | Should -Match '(?i)execute'
+        $b | Should -Match '(?i)verify'
+        $b | Should -Match '(?i)self-heal'
+        $b | Should -Match '(?i)loop until'
+        $b | Should -Match '(?i)report'
+    }
+    It 'carries the decision protocol — research before deciding, not act first' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)research.*before deciding'
+    }
+    It 'names the decision protocol steps in order: research, register, decide' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $iR = $b.IndexOf('Research', [System.StringComparison]::OrdinalIgnoreCase)
+        $iReg = $b.IndexOf('Register', [System.StringComparison]::OrdinalIgnoreCase)
+        $iD = $b.IndexOf('Decide', [System.StringComparison]::OrdinalIgnoreCase)
+        $iR | Should -BeLessThan $iReg
+        $iReg | Should -BeLessThan $iD
+    }
+    It 'says read-and-forget is not research (the decision protocol standard)' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)read-and-forget'
+    }
+}
+
 Describe 'Format-AutoBrief — an ordered run is told the order is inert, not that it may close (#541)' {
     # #536 had the brief GRANT the close. Review then found the mechanism behind it had two holes
     # it could not defend, so the grant was withdrawn. The brief must not silently go back to a

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -72,26 +72,43 @@ Describe 'Format-AutoBrief — phase loop and decision protocol (#527)' {
     # must carry the METHOD (phases + decision protocol), not just a bullet list of capabilities.
 
     It 'includes all seven phases so the session knows the method, not just the capability list' {
+        # Asserted on the NUMBERED phase markers, not on bare words: 'verify' and 'report' also
+        # occur in the capability map, so a bare-word match would stay green with the phases gone.
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
-        $b | Should -Match '(?i)ingest'
-        $b | Should -Match '(?i)become the expert'
-        $b | Should -Match '(?i)execute'
-        $b | Should -Match '(?i)verify'
-        $b | Should -Match '(?i)self-heal'
-        $b | Should -Match '(?i)loop until'
-        $b | Should -Match '(?i)report'
+        $b | Should -Match '(?im)^1\. \*\*Ingest\*\*'
+        $b | Should -Match '(?im)^2\. \*\*Become the expert\*\*'
+        $b | Should -Match '(?im)^3\. \*\*Execute'
+        $b | Should -Match '(?im)^4\. \*\*Verify'
+        $b | Should -Match '(?im)^5\. \*\*Self-heal'
+        $b | Should -Match '(?im)^6\. \*\*Loop until'
+        $b | Should -Match '(?im)^7\. \*\*Report\*\*'
     }
     It 'carries the decision protocol — research before deciding, not act first' {
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
         $b | Should -Match '(?i)research.*before deciding'
     }
     It 'names the decision protocol steps in order: research, register, decide' {
+        # Scoped to the decision-protocol SECTION. Measuring first-occurrence over the whole brief
+        # would read 'Research' out of phase 2 and pass even with the protocol steps scrambled.
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
-        $iR = $b.IndexOf('Research', [System.StringComparison]::OrdinalIgnoreCase)
-        $iReg = $b.IndexOf('Register', [System.StringComparison]::OrdinalIgnoreCase)
-        $iD = $b.IndexOf('Decide', [System.StringComparison]::OrdinalIgnoreCase)
+        $start = $b.IndexOf('### Decision protocol', [System.StringComparison]::OrdinalIgnoreCase)
+        $start | Should -BeGreaterThan -1
+        $next = $b.IndexOf('### ', $start + 4, [System.StringComparison]::OrdinalIgnoreCase)
+        $section = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+
+        $iR = $section.IndexOf('1. Research', [System.StringComparison]::OrdinalIgnoreCase)
+        $iReg = $section.IndexOf('2. Register', [System.StringComparison]::OrdinalIgnoreCase)
+        $iD = $section.IndexOf('3. Decide', [System.StringComparison]::OrdinalIgnoreCase)
+        $iR | Should -BeGreaterThan -1
         $iR | Should -BeLessThan $iReg
         $iReg | Should -BeLessThan $iD
+    }
+    It 'keeps the do-NOT-improvise guard the old brief carried (regression, found in review)' {
+        # The rewrite dropped 'total self-use ... (do NOT improvise your own tooling)' from the ONLY
+        # text the session receives. A capability map lists options; it does not forbid inventing one.
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)total self-use of agentic-board'
+        $b | Should -Match '(?i)do NOT improvise your own tooling'
     }
     It 'says read-and-forget is not research (the decision protocol standard)' {
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'


### PR DESCRIPTION
Closes #527 — part of plan #526.

`Format-AutoBrief` composes the **only** text an autonomous session ever receives. It emitted a
bullet list of capabilities; the seven-phase method lived in `auto-loop.md`, a file the session was
never handed. The brief now carries the method: the phase sequence plus an explicit decision
protocol — *research before deciding, do NOT act first*.

## [abios-evidence]

Every assertion runs against the **rendered brief**, not the reference docs.

| # | Claim under test |
|---|---|
| 1 | The seven numbered phases are present |
| 2 | "research before deciding" appears explicitly |
| 3 | Research → Register → Decide holds *inside the protocol section* |
| 4 | "read-and-forget is not research" is stated |
| 5 | The no-improvise guard survived the rewrite |

```
Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
Tests Passed: 21, Failed: 0, Skipped: 0
```

**A green suite proves nothing on its own.** Each guard was broken on purpose:

| Defect reintroduced | Result |
|---|---|
| Whole phase block deleted from the brief | 4 failed |
| `do NOT improvise your own tooling` removed | 1 failed (the guard test) |
| Protocol steps scrambled (Decide first) | 1 failed (the ordering test) |
| — restored — | 21 passed, 0 failed |

Full record: [`evidence/527.md`](evidence/527.md).

## Review — two findings, both verified in source before acting

External review by Codex (gpt-5.5, xhigh) on the first commit:

1. **P2 — the rewrite dropped the no-improvise guard.** Confirmed: neither `improvise` nor
   `total self-use` occurred anywhere in the new file, while both were in `origin/main`. The
   plan's founding principle, deleted by the change meant to strengthen it. Restored and asserted.
2. **P3 — the ordering test did not protect the ordering it named.** First-occurrence over the
   whole brief, and "Research" occurs earlier in phase 2, so the protocol could be scrambled with
   the test green. Scoped to the protocol section.

Gemini was unavailable this round — its CLI rejects individual-tier accounts
(`IneligibleTierError: UNSUPPORTED_CLIENT`). One reviewer, not two; recorded rather than glossed.

## What the autonomous run did not do

The run reached "PR ready" and stopped at the brake, as designed — but recorded **no evidence at
all**: no `[abios-evidence]` comment, no `evidence/527.md`, and a PR body of exactly `Closes #527`,
against a contract demanding all three. The evidence above was written by hand afterwards. That gap
is #532's subject and is left filed rather than papered over.
