### PR TITLE
expert: research-before-deciding replaces fix-it-and-continue as the response to an error or a fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,19 @@
   fork, or an unexpected state — apply the **decision protocol** (research → register → decide); do
   NOT act first." The protocol section below it (Research → Register → Decide) is now the named
   authority that self-heal defers to, rather than a separate section that contradicts the phase's
-  framing. Verified by three tests scoped to Phase 5 text: decision protocol named in phase,
-  "do NOT act first" present in phase, and the old "fix it (after" parenthetical is absent.
+  framing. Verified by five tests scoped to Phase 5 text, each confirmed by reintroducing its defect
+  and watching the matching test go red.
+
+  **Caught by external review before merging — the same defect two PRs running.** The first cut
+  reframed the phase around the protocol and, in doing so, deleted `in-scope problem -> fix it`. A
+  phase named *Self-heal* that never says to heal: the protocol ends at "decide", so a run hitting an
+  in-scope bug was left holding a decision with no instruction to act on it. #527 lost the
+  no-improvise guard the same way, in the same function, one PR earlier. Rewriting a sentence in
+  `Format-AutoBrief` deletes behaviour, because that text is not documentation *about* the run — it
+  is the whole of what the run is told. Phase 5 now orders both: protocol first, then act on what was
+  decided (in-scope → fix and continue; out-of-scope → file a `discovered` issue). Two tests hold the
+  pair: one that the fix instruction exists, one that the protocol still precedes it, so restoring
+  the action cannot quietly restore act-first ordering.
 
 ## [0.31.0] - 2026-08-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@
   than bare words ("verify" and "report" also occur in the capability map, so the loose match
   survived deleting the phases).
 
+- **Phase 5 self-heal now explicitly invokes the decision protocol, replacing fix-it-and-continue**
+  (#528, part of #526). After #527 added the decision protocol to the brief, Phase 5 still said
+  "fix it (after researching first)" — a parenthetical that reads as act-first with a research note,
+  not as research-first with an act-later decision. Phase 5 now reads: "when you hit an error, a
+  fork, or an unexpected state — apply the **decision protocol** (research → register → decide); do
+  NOT act first." The protocol section below it (Research → Register → Decide) is now the named
+  authority that self-heal defers to, rather than a separate section that contradicts the phase's
+  framing. Verified by three tests scoped to Phase 5 text: decision protocol named in phase,
+  "do NOT act first" present in phase, and the old "fix it (after" parenthetical is absent.
+
 ## [0.31.0] - 2026-08-03
 ### Added
 - **A braked run can now authenticate as a machine account instead of as the owner** (#550, part of

--- a/evidence/528.md
+++ b/evidence/528.md
@@ -1,0 +1,58 @@
+# [abios-evidence] #528 — research-before-deciding replaces fix-it-and-continue
+
+PR: #556 · branch `issue-528-expert-research-before-deciding` · plan #526
+
+## What was tested
+
+Phase 5 of the brief composed by `Format-AutoBrief`. Every assertion is scoped to the **Phase 5
+slice of the rendered brief** — the decision protocol also has its own section, so an unscoped match
+would pass on the wrong text.
+
+| # | Claim under test |
+|---|---|
+| 1 | Phase 5 names the decision protocol, not a parenthetical aside |
+| 2 | Phase 5 says "do NOT act first" |
+| 3 | The old `fix it (after ...)` framing is gone |
+| 4 | Phase 5 still tells the run to FIX an in-scope problem |
+| 5 | The protocol precedes the fix instruction — restoring the action did not restore act-first |
+
+## Command and result
+
+```
+Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+Tests Passed: 26, Failed: 0, Skipped: 0
+```
+
+## Each guard broken on purpose
+
+| Defect reintroduced | Tests that went red |
+|---|---|
+| `in-scope problem -> fix it` deleted again | 2 — "still tells the run to FIX" + "orders the protocol BEFORE acting" |
+| Fix instruction moved ahead of the protocol | 2 — "do NOT act first" + "orders the protocol BEFORE acting" |
+| — restored — | 26 passed, 0 failed |
+
+## Review
+
+External review by Codex (gpt-5.5, xhigh) on the run's commit — one finding, **P1**, confidence 0.89:
+
+> Phase 5 no longer tells the launched agent what to do with an in-scope problem after it applies
+> the decision protocol. […] an agent can now research/register/choose a fix without being
+> instructed to actually apply it and continue.
+
+Verdict: *patch is incorrect*. Confirmed against the diff: the removed line was
+`in-scope problem -> fix it (after researching first)`. Fixed and asserted by two tests.
+
+Gemini unavailable again (`IneligibleTierError: UNSUPPORTED_CLIENT`) — one reviewer this round.
+
+## Pattern worth naming
+
+This is the **second consecutive PR** in which an autonomous run rewrote a sentence in
+`Format-AutoBrief` and silently deleted an instruction with it (#527 dropped the no-improvise
+guard; #528 dropped the self-heal action). Both were caught by external review, neither by CI.
+The function's text *is* the agent's behaviour, so prose edits there are behavioural edits. Filed
+as a follow-up rather than fixed here.
+
+## Not done by the autonomous run
+
+As on #527: no `[abios-evidence]` comment, no `evidence/528.md`, PR body of exactly `Closes #528`.
+Written by hand afterwards. Subject of #532.

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -119,8 +119,9 @@ are the method.
 4. **Verify + evidence** — run the definition-of-done gates. Write a structured ``[abios-evidence]``
    block to three places: the PR body, a durable issue comment, and ``evidence/<issue>.md``.
    If green -> open the PR + run the review gate.
-5. **Self-heal + auto-drive the board**: in-scope problem -> fix it (after researching first);
-   out-of-scope finding -> file a sanitized 'discovered' issue on the board and keep going.
+5. **Self-heal + auto-drive the board**: when you hit an error, a fork, or an unexpected state —
+   apply the **decision protocol** (research → register → decide); do NOT act first.
+   Out-of-scope finding → file a sanitized 'discovered' issue on the board and keep going.
 6. **Loop until done or budget**: keep iterating until the DoD is green — then leave the PR ready
    and STOP before merge — or the budget is spent -> ``/board handoff -Save``.
 7. **Report** — final evidence + updated board + a PR awaiting the human's merge approval.

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -121,7 +121,8 @@ are the method.
    If green -> open the PR + run the review gate.
 5. **Self-heal + auto-drive the board**: when you hit an error, a fork, or an unexpected state —
    apply the **decision protocol** (research → register → decide); do NOT act first.
-   Out-of-scope finding → file a sanitized 'discovered' issue on the board and keep going.
+   Then act on what you decided: an in-scope problem → fix it in the loop and continue;
+   an out-of-scope finding → file a sanitized 'discovered' issue on the board and keep going.
 6. **Loop until done or budget**: keep iterating until the DoD is green — then leave the PR ready
    and STOP before merge — or the budget is spent -> ``/board handoff -Save``.
 7. **Report** — final evidence + updated board + a PR awaiting the human's merge approval.

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -180,7 +180,32 @@ Describe 'Format-AutoBrief — research-before-deciding in self-heal (#528)' {
         $phase5 | Should -Match '(?i)do NOT act first'
     }
 
-    It 'phase 5 self-heal no longer uses the act-first parenthetical fix-it framing' {
+    It 'phase 5 still tells the run to FIX an in-scope problem (regression, found in review)' {
+        # Reframing phase 5 around the protocol dropped 'in-scope problem -> fix it'. The protocol
+        # ends at "decide"; a phase named Self-heal that never says to heal leaves the run with a
+        # decision and no instruction to act on it. Deleting a sentence here deletes the behaviour.
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
+        $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)
+        $phase5 = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+        $phase5 | Should -Match '(?i)in-scope problem'
+        $phase5 | Should -Match '(?i)fix it in the loop and continue'
+    }
+
+    It 'phase 5 orders the protocol BEFORE acting, not the other way round' {
+        # The point of #528: research-before-deciding replaces fix-it-and-continue as the RESPONSE.
+        # Restoring the fix instruction must not restore the act-first ordering it displaced.
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
+        $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)
+        $phase5 = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+        $iProtocol = $phase5.IndexOf('decision protocol', [System.StringComparison]::OrdinalIgnoreCase)
+        $iFix = $phase5.IndexOf('fix it in the loop', [System.StringComparison]::OrdinalIgnoreCase)
+        $iProtocol | Should -BeGreaterThan -1
+        $iProtocol | Should -BeLessThan $iFix
+    }
+
+    It 'phase 5 no longer uses the act-first parenthetical fix-it framing' {
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
         $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
         $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -154,3 +154,38 @@ Describe 'Format-AutoBrief — an ordered run is told the order is inert, not th
         $b | Should -Not -Match 'Board-Merge\.ps1'
     }
 }
+
+Describe 'Format-AutoBrief — research-before-deciding in self-heal (#528)' {
+    # #528: the self-heal phase said "fix it (after researching first)" — still act-first in framing.
+    # The decision protocol must be the EXPLICIT response to an error or fork, not a parenthetical.
+    # "research-before-deciding replaces fix-it-and-continue" means Phase 5 invokes the protocol
+    # by name and says "do NOT act first", rather than leading with "fix it".
+
+    It 'phase 5 self-heal references the decision protocol for errors and forks, not just a parenthetical' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        # Scope to Phase 5 only — decision protocol also appears in its own section
+        $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
+        $start | Should -BeGreaterThan -1
+        $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)
+        $phase5 = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+        # Must name the decision protocol explicitly (not just "after researching first")
+        $phase5 | Should -Match '(?i)decision protocol'
+    }
+
+    It 'phase 5 self-heal says do NOT act first in the context of error or fork' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
+        $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)
+        $phase5 = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+        $phase5 | Should -Match '(?i)do NOT act first'
+    }
+
+    It 'phase 5 self-heal no longer uses the act-first parenthetical fix-it framing' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('5. **Self-heal', [System.StringComparison]::OrdinalIgnoreCase)
+        $next  = $b.IndexOf('6. **Loop', $start, [System.StringComparison]::OrdinalIgnoreCase)
+        $phase5 = if ($next -gt $start) { $b.Substring($start, $next - $start) } else { $b.Substring($start) }
+        # The old framing "fix it (after researching first)" is the pattern to eliminate
+        $phase5 | Should -Not -Match '(?i)fix it \(after'
+    }
+}


### PR DESCRIPTION
Closes #528 — part of plan #526.

After #527 put the decision protocol in the brief, Phase 5 still framed self-heal as
`fix it (after researching first)` — act-first with a research note attached. Phase 5 now defers to
the protocol by name: *when you hit an error, a fork, or an unexpected state — apply the decision
protocol (research → register → decide); do NOT act first.*

## [abios-evidence]

Every assertion is scoped to the **Phase 5 slice** of the rendered brief; the protocol also has its
own section, so an unscoped match would pass on the wrong text.

| # | Claim under test |
|---|---|
| 1 | Phase 5 names the decision protocol, not a parenthetical aside |
| 2 | Phase 5 says "do NOT act first" |
| 3 | The old `fix it (after ...)` framing is gone |
| 4 | Phase 5 still tells the run to FIX an in-scope problem |
| 5 | The protocol precedes the fix instruction |

```
Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
Tests Passed: 26, Failed: 0, Skipped: 0
```

Each guard broken on purpose:

| Defect reintroduced | Tests that went red |
|---|---|
| `in-scope problem -> fix it` deleted again | 2 |
| Fix instruction moved ahead of the protocol | 2 |
| — restored — | 26 passed, 0 failed |

Full record: [`evidence/528.md`](evidence/528.md).

## Review — one P1 finding, verified and fixed

External review by Codex (gpt-5.5, xhigh), verdict *patch is incorrect*, confidence 0.89:

> Phase 5 no longer tells the launched agent what to do with an in-scope problem after it applies
> the decision protocol […] an agent can now research/register/choose a fix without being instructed
> to actually apply it and continue.

Confirmed against the diff — the deleted line was `in-scope problem -> fix it (after researching
first)`. A phase named *Self-heal* that never says to heal. Restored, with the ordering pinned so
the fix cannot drift back ahead of the protocol.

Gemini unavailable this round (`IneligibleTierError: UNSUPPORTED_CLIENT`) — one reviewer, recorded.

## Pattern worth naming

**Second consecutive PR** where an autonomous run rewrote a sentence in `Format-AutoBrief` and
silently deleted an instruction with it — #527 dropped the no-improvise guard, #528 the self-heal
action. Both caught by external review, neither by CI. That text is not documentation *about* the
run; it is the whole of what the run is told, so prose edits there are behavioural edits.

## What the autonomous run did not do

No `[abios-evidence]` comment, no `evidence/528.md`, PR body of exactly `Closes #528` — same as
#527, against a contract demanding all three. Written by hand afterwards. Subject of #532.
