### PR TITLE
self-drive: build an epic + sub-issues when the work outgrows its issue, instead of only filing discoveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,25 @@
   created epics + native sub-issues for humans; it was unreachable from inside an autonomous run.
 
   `Format-AutoBrief` now includes a **Self-planning — escalating to an epic** section that:
-  - tells the run to use `Board-Plan.ps1` (`/board plan`) rather than filing loose issues,
+  - tells the run to use `/board plan` rather than filing loose issues,
   - caps the sub-issues of the created epic by the existing `boardSelfDrive.cap` (same limit as
     `discovered` issues, so self-planning stays bounded), and
   - requires linking the new epic back to the originating issue for traceability.
 
-  Verified by five tests that assert on the rendered brief text: `Board-Plan.ps1` is named,
-  escalation and sub-issues are instructed, `boardSelfDrive` cap applies, the originating issue
-  is linked, and the cap value from the contract is embedded. Each confirmed by reintroducing the
-  defect (removing the section) and watching all five tests go red together.
+  Verified by six tests that assert on the rendered brief text, each confirmed by reintroducing its
+  defect and watching the matching test go red.
+
+  **Caught by external review before merging — two defects, both known shapes.** The first cut told
+  the run to use `Board-Plan.ps1` and pinned that with a test asserting the script name. The brief
+  travels to runs working in *any* repository, where a plugin script name resolves to nothing — the
+  defect #480 and #494 are already open on, reintroduced and then locked in by its own test. It now
+  names `/board plan`, and the test asserts the command **and forbids** the script name.
+
+  The cap was read as `if ($Contract.boardSelfDrive.cap)`. In PowerShell `0` is falsy, so a contract
+  setting `cap = 0` — *create nothing* — was read as absent and the run was told it could create
+  ten. Presence is now tested, not truthiness, with a test constructing exactly the `cap = 0`
+  contract. The same fail-open shape this project keeps finding: the safe reading of a missing
+  value is not the permissive one.
 
 - **Phase 5 self-heal now explicitly invokes the decision protocol, replacing fix-it-and-continue**
   (#528, part of #526). After #527 added the decision protocol to the brief, Phase 5 still said

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@
   than bare words ("verify" and "report" also occur in the capability map, so the loose match
   survived deleting the phases).
 
+- **Autonomous brief now instructs the run to escalate to an epic + sub-issues when the work
+  outgrows its issue** (#531, part of #526). A run that discovered six tasks had one move: drop six
+  loose `discovered` issues on the board with no parent and no order. `Board-Plan.ps1` already
+  created epics + native sub-issues for humans; it was unreachable from inside an autonomous run.
+
+  `Format-AutoBrief` now includes a **Self-planning — escalating to an epic** section that:
+  - tells the run to use `Board-Plan.ps1` (`/board plan`) rather than filing loose issues,
+  - caps the sub-issues of the created epic by the existing `boardSelfDrive.cap` (same limit as
+    `discovered` issues, so self-planning stays bounded), and
+  - requires linking the new epic back to the originating issue for traceability.
+
+  Verified by five tests that assert on the rendered brief text: `Board-Plan.ps1` is named,
+  escalation and sub-issues are instructed, `boardSelfDrive` cap applies, the originating issue
+  is linked, and the cap value from the contract is embedded. Each confirmed by reintroducing the
+  defect (removing the section) and watching all five tests go red together.
+
 - **Phase 5 self-heal now explicitly invokes the decision protocol, replacing fix-it-and-continue**
   (#528, part of #526). After #527 added the decision protocol to the brief, Phase 5 still said
   "fix it (after researching first)" — a parenthetical that reads as act-first with a research note,

--- a/evidence/531.md
+++ b/evidence/531.md
@@ -1,0 +1,61 @@
+# [abios-evidence] #531 — self-planning: escalate to an epic instead of dropping loose issues
+
+PR: #558 · branch `issue-531-self-drive-build-an-epic-sub-issues` · plan #526
+
+## What was tested
+
+The **Self-planning** section of the brief rendered by `Format-AutoBrief` — the only text an
+autonomous run receives.
+
+| # | Claim under test |
+|---|---|
+| 1 | The escalation capability is named by its typed command, and the script name is absent |
+| 2 | Escalation to an epic + sub-issues is instructed |
+| 3 | The `boardSelfDrive` cap bounds the epic's sub-issues |
+| 4 | The run is told to link the epic to the originating issue |
+| 5 | The cap value is taken from the contract (a contract with `cap = 7` renders 7) |
+| 6 | A cap of `0` is honoured, not replaced by the default of 10 |
+
+## Command and result
+
+```
+Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+Tests Passed: 32, Failed: 0, Skipped: 0
+```
+
+## Each guard broken on purpose
+
+| Defect reintroduced | Test that went red |
+|---|---|
+| Whole Self-planning section removed | all 5 original tests |
+| `/board plan` replaced by the script name again | "names the escalation capability by its typed command" |
+| Cap read by truthiness instead of presence | "honours a cap of 0 instead of falling back to the default" |
+| — restored — | 32 passed, 0 failed |
+
+## Review
+
+External review by Codex (gpt-5.5, xhigh) — verdict *patch is incorrect*, two findings, both
+verified in the source before acting:
+
+1. **P1 (0.97) — the brief named an internal script.** The run may work in any repository, where
+   `Board-Plan.ps1` resolves to nothing; #480 and #494 are open on exactly this. Worse, a new test
+   asserted the script name, pinning the defect. Fixed: the brief names `/board plan`, and the test
+   now requires the command and forbids the script name.
+2. **P2 (0.90) — a cap of `0` was ignored.** `if ($Contract.boardSelfDrive.cap)` reads `0` as
+   absent in PowerShell, so a contract meaning *create nothing* told the run it could create ten.
+   Fixed to test presence (`$null -ne`), with a test constructing that contract.
+
+Gemini unavailable (`IneligibleTierError: UNSUPPORTED_CLIENT`) — one reviewer this round.
+
+## Not done by the autonomous run
+
+No `[abios-evidence]` comment, no `evidence/531.md`, PR body of exactly `Closes #531` — the third
+run in a row. This file was written by hand. #532 is the check that makes this state detectable
+instead of invisible; run against this very issue before it was written, it returned:
+
+```
+RUN VERIFY: INCOMPLETE — the run did not record its evidence. Missing:
+  - evidence/<issue>.md (file missing or marker absent)
+  - [abios-evidence] block in PR body
+  - [abios-evidence] comment on the issue
+```

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -62,6 +62,8 @@ function Format-AutoBrief {
     $irr = @()
     if ($Contract.autonomy -and $Contract.autonomy.irreversible) { $irr = @($Contract.autonomy.irreversible) }
     $irrList = ($irr -join ', ')
+    $selfDriveCap = 10
+    if ($Contract.boardSelfDrive -and $Contract.boardSelfDrive.cap) { $selfDriveCap = [int]$Contract.boardSelfDrive.cap }
     # A role may name an agent definition; its persona is already folded into $RoleObjective,
     # and naming it here lets the launched run adopt it as its agent type too.
     $agentLine = if ($Contract.roleAgent) {
@@ -146,6 +148,18 @@ Every need below already has a capability. Reach for it instead of inventing you
 - Record work / findings -> ``/board issue``, ``/board plan``, ``/board triage``
 - Report progress / evidence -> ``/board update``, ``[abios-evidence]`` comment
 - Survive budget / interruption -> ``/board handoff -Save``
+
+### Self-planning — escalating to an epic
+
+When you discover the work is larger than the issue you were given, escalate rather than dropping
+loose issues on the board with no parent. Use ``Board-Plan.ps1`` (``/board plan``) to create an
+epic + native sub-issues — the same structure ``/board plan`` builds for a human.
+
+Bounds: the ``boardSelfDrive`` cap ($selfDriveCap) that governs ``discovered`` issues also caps the
+sub-issues of any epic you create. Do not create more sub-issues than that limit.
+
+Traceability: link the new epic to the originating issue (include the issue number,
+e.g. ``Grew out of #<n>``, in the epic body) so the trail is followable.
 
 ## Test-first + evidence
 Build test-first. After each verify phase, record a structured [abios-evidence] block (what was
@@ -257,4 +271,6 @@ if ($ProjectNum -gt 0) {
     Write-Host ""
     Write-Host "Board: https://github.com/users/$owner/projects/$ProjectNum" -ForegroundColor Cyan
 }
+
+
 

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -62,8 +62,10 @@ function Format-AutoBrief {
     $irr = @()
     if ($Contract.autonomy -and $Contract.autonomy.irreversible) { $irr = @($Contract.autonomy.irreversible) }
     $irrList = ($irr -join ', ')
+    # Presence, not truthiness: a cap of 0 means "create nothing" and is a legitimate contract.
+    # `-and $...cap` would read 0 as absent and hand the run the default of 10 instead.
     $selfDriveCap = 10
-    if ($Contract.boardSelfDrive -and $Contract.boardSelfDrive.cap) { $selfDriveCap = [int]$Contract.boardSelfDrive.cap }
+    if ($Contract.boardSelfDrive -and $null -ne $Contract.boardSelfDrive.cap) { $selfDriveCap = [int]$Contract.boardSelfDrive.cap }
     # A role may name an agent definition; its persona is already folded into $RoleObjective,
     # and naming it here lets the launched run adopt it as its agent type too.
     $agentLine = if ($Contract.roleAgent) {
@@ -152,8 +154,8 @@ Every need below already has a capability. Reach for it instead of inventing you
 ### Self-planning — escalating to an epic
 
 When you discover the work is larger than the issue you were given, escalate rather than dropping
-loose issues on the board with no parent. Use ``Board-Plan.ps1`` (``/board plan``) to create an
-epic + native sub-issues — the same structure ``/board plan`` builds for a human.
+loose issues on the board with no parent. Use ``/board plan`` to create an epic + native
+sub-issues — the same structure it builds for a human.
 
 Bounds: the ``boardSelfDrive`` cap ($selfDriveCap) that governs ``discovered`` issues also caps the
 sub-issues of any epic you create. Do not create more sub-issues than that limit.
@@ -271,6 +273,5 @@ if ($ProjectNum -gt 0) {
     Write-Host ""
     Write-Host "Board: https://github.com/users/$owner/projects/$ProjectNum" -ForegroundColor Cyan
 }
-
 
 

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -155,6 +155,40 @@ Describe 'Format-AutoBrief — an ordered run is told the order is inert, not th
     }
 }
 
+Describe 'Format-AutoBrief — self-planning escalation (#531)' {
+    # #531: a run that discovers its task is really six tasks has one move: drop six loose discovered
+    # issues with no parent. The brief must instruct escalation to an epic + sub-issues via
+    # Board-Plan.ps1, bounded by the boardSelfDrive cap, and linked to the originating issue.
+
+    It 'names Board-Plan.ps1 as the escalation capability' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match 'Board-Plan\.ps1'
+    }
+    It 'instructs escalation to an epic + sub-issues when the work outgrows the issue' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)escalat'
+        $b | Should -Match '(?i)sub-issues'
+    }
+    It 'bounds the epic sub-issues by the boardSelfDrive cap' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)boardSelfDrive'
+        $b | Should -Match '(?i)\bcap\b'
+    }
+    It 'instructs the run to link the epic to the originating issue for traceability' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)originating issue'
+    }
+    It 'embeds the cap value from the contract into the self-planning section' {
+        $c = $script:Contract.Clone()
+        $c.boardSelfDrive = @{ createIssues = $true; label = 'discovered'; cap = 7 }
+        $b = Format-AutoBrief -Contract $c -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('Self-planning', [System.StringComparison]::OrdinalIgnoreCase)
+        $start | Should -BeGreaterThan -1
+        $section = $b.Substring($start)
+        $section | Should -Match '\b7\b'
+    }
+}
+
 Describe 'Format-AutoBrief — research-before-deciding in self-heal (#528)' {
     # #528: the self-heal phase said "fix it (after researching first)" — still act-first in framing.
     # The decision protocol must be the EXPLICIT response to an error or fork, not a parenthetical.

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -160,9 +160,13 @@ Describe 'Format-AutoBrief — self-planning escalation (#531)' {
     # issues with no parent. The brief must instruct escalation to an epic + sub-issues via
     # Board-Plan.ps1, bounded by the boardSelfDrive cap, and linked to the originating issue.
 
-    It 'names Board-Plan.ps1 as the escalation capability' {
+    It 'names the escalation capability by its typed command, not by an internal script' {
+        # The brief is the only text the run receives and the run may work in ANY repo, where a
+        # plugin script name resolves to nothing. #480 and #494 are open on exactly this; the first
+        # cut of this section named the script and pinned it with a test. Command surface only.
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
-        $b | Should -Match 'Board-Plan\.ps1'
+        $b | Should -Match '/board plan'
+        $b | Should -Not -Match '(?i)Board-Plan\.ps1'
     }
     It 'instructs escalation to an epic + sub-issues when the work outgrows the issue' {
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
@@ -186,6 +190,17 @@ Describe 'Format-AutoBrief — self-planning escalation (#531)' {
         $start | Should -BeGreaterThan -1
         $section = $b.Substring($start)
         $section | Should -Match '\b7\b'
+    }
+    It 'honours a cap of 0 instead of falling back to the default (regression, found in review)' {
+        # `if ($c.boardSelfDrive.cap)` reads 0 as absent, so a contract saying "create nothing"
+        # would tell the run it may create ten. Presence, not truthiness.
+        $c = $script:Contract.Clone()
+        $c.boardSelfDrive = @{ createIssues = $false; label = 'discovered'; cap = 0 }
+        $b = Format-AutoBrief -Contract $c -PlanBody 'x' -RoleObjective 'r'
+        $start = $b.IndexOf('Self-planning', [System.StringComparison]::OrdinalIgnoreCase)
+        $section = $b.Substring($start)
+        $section | Should -Match '\(0\)'
+        $section | Should -Not -Match '\(10\)'
     }
 }
 


### PR DESCRIPTION
# [abios-evidence] #531 — self-planning: escalate to an epic instead of dropping loose issues

PR: #558 · branch `issue-531-self-drive-build-an-epic-sub-issues` · plan #526

## What was tested

The **Self-planning** section of the brief rendered by `Format-AutoBrief` — the only text an
autonomous run receives.

| # | Claim under test |
|---|---|
| 1 | The escalation capability is named by its typed command, and the script name is absent |
| 2 | Escalation to an epic + sub-issues is instructed |
| 3 | The `boardSelfDrive` cap bounds the epic's sub-issues |
| 4 | The run is told to link the epic to the originating issue |
| 5 | The cap value is taken from the contract (a contract with `cap = 7` renders 7) |
| 6 | A cap of `0` is honoured, not replaced by the default of 10 |

## Command and result

```
Invoke-Pester -Path plugins/agentic-board/tests/Expert-Auto.Tests.ps1
Tests Passed: 32, Failed: 0, Skipped: 0
```

## Each guard broken on purpose

| Defect reintroduced | Test that went red |
|---|---|
| Whole Self-planning section removed | all 5 original tests |
| `/board plan` replaced by the script name again | "names the escalation capability by its typed command" |
| Cap read by truthiness instead of presence | "honours a cap of 0 instead of falling back to the default" |
| — restored — | 32 passed, 0 failed |

## Review

External review by Codex (gpt-5.5, xhigh) — verdict *patch is incorrect*, two findings, both
verified in the source before acting:

1. **P1 (0.97) — the brief named an internal script.** The run may work in any repository, where
   `Board-Plan.ps1` resolves to nothing; #480 and #494 are open on exactly this. Worse, a new test
   asserted the script name, pinning the defect. Fixed: the brief names `/board plan`, and the test
   now requires the command and forbids the script name.
2. **P2 (0.90) — a cap of `0` was ignored.** `if ($Contract.boardSelfDrive.cap)` reads `0` as
   absent in PowerShell, so a contract meaning *create nothing* told the run it could create ten.
   Fixed to test presence (`$null -ne`), with a test constructing that contract.

Gemini unavailable (`IneligibleTierError: UNSUPPORTED_CLIENT`) — one reviewer this round.

## Not done by the autonomous run

No `[abios-evidence]` comment, no `evidence/531.md`, PR body of exactly `Closes #531` — the third
run in a row. This file was written by hand. #532 is the check that makes this state detectable
instead of invisible; run against this very issue before it was written, it returned:

```
RUN VERIFY: INCOMPLETE — the run did not record its evidence. Missing:
  - evidence/<issue>.md (file missing or marker absent)
  - [abios-evidence] block in PR body
  - [abios-evidence] comment on the issue
```

---
Closes #531 — part of plan #526.
