### PR TITLE
Bound the CI watch and run CI + review waits concurrently in the review gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **The review gate's CI wait now has a ceiling, and the CI and review waits run concurrently**
+  (#562, part of epic #561). `gh pr checks --watch` was the only unbounded wait in the codebase:
+  a queued or never-scheduled workflow hung the entire session indefinitely, with no signal. The
+  gate now polls a structured checks snapshot in the same loop as the review wait — worst case is
+  max(CI, review) instead of their sum — and the CI side expires at `-CiTimeoutMinutes`
+  (default 25) into an explicit **"checks still pending" BLOCK**, never a silent hang and never
+  a pass. An unreadable checks snapshot also blocks (fail closed) instead of being trusted from
+  display text. Verified by 12 new Pester tests; mutation-checked by reintroducing both defects
+  (cancel-counts-as-pass, sequential-OR exit) and watching 4 tests go red.
+
 ## [0.32.0] - 2026-08-03
 
 **Expert mode carries its method.** Until now the launched session received a *capability list* —

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -645,7 +645,10 @@ while ($true) {
 # while CI was still running would otherwise be invisible to a verdict computed from stale state.
 $prState = Get-ReviewState
 
-# CI verdict, from the last snapshot.
+# CI verdict, from the last snapshot. The deadline bounds the WAIT, not the validity of a late
+# result: if checks settle green while the loop is still open for the review side, that pass is
+# real and counts. The invariant that matters is fail-closed and it holds on every path - a pass
+# requires a PARSED, SETTLED, all-green snapshot; pending-at-exit and unreadable both block.
 $checksOk     = $true
 $ciTimedOut   = $false
 $failedChecks = @($verdictCi.Failed)

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -22,11 +22,15 @@
          Both degrade safely: no model, no BPA rules file, or no Tabular Editor
          is a WARN + skip, never a block - a merge is only ever stopped by an
          actual finding. A non-BI repo never triggers either.
-      3. Waits for CI checks on the PR (gh pr checks --watch). "No checks
+      3. Waits for CI checks AND the requested review in ONE bounded loop
+         (#562). Both waits are independent, so they run concurrently: total
+         wait is max(CI, review), not their sum. The CI side is capped at
+         -CiTimeoutMinutes — the previous `gh pr checks --watch` had no
+         timeout, so a queued/stuck workflow hung the session indefinitely;
+         now it expires into an explicit "CI still pending" BLOCK. "No checks
          configured" counts as pass, with a note.
-      4. Waits (up to -TimeoutMinutes) for the requested review to arrive,
-         then reports: review decision, every review with author/state/body,
-         and unresolved review-thread count.
+      4. Reports: review decision, every review with author/state/body, and
+         unresolved review-thread count.
       5. Verdict via exit code:
            0 -> gate PASSED (checks ok, no CHANGES_REQUESTED, no unresolved
                 threads, no TMDL-breaking / BPA-error findings, AND somebody
@@ -56,6 +60,12 @@
 
 .PARAMETER TimeoutMinutes
     Max minutes to wait for the requested review. Default 6.
+
+.PARAMETER CiTimeoutMinutes
+    Max minutes to wait for CI checks to settle. Default 25 (the repo's CI
+    jobs cap at 20). Expiry is an explicit block ("CI still pending"), never
+    a silent hang — this bound exists because the unbounded watch was the
+    only wait in the codebase with no ceiling (#562).
 
 .PARAMETER MaxLines
     Small-PR guard: warn when additions+deletions exceed this. Default 600.
@@ -104,6 +114,8 @@ param(
     [int]   $PR = 0,
     [switch]$InstallRuleset,
     [int]   $TimeoutMinutes = 6,
+    # Ceiling for the CI wait (#562). The old `--watch` could hang forever on a queued workflow.
+    [int]   $CiTimeoutMinutes = 25,
     [int]   $MaxLines = 600,
     [int]   $MaxFiles = 20,
     # Days to remember "this account has no Copilot" before the gate tries it again (#367).
@@ -255,6 +267,63 @@ function Test-OnlyReviewerChecksFailed {
     if ($names.Count -eq 0) { return $false }                 # nothing named -> nothing to excuse
     foreach ($n in $names) { if (-not (Test-IsReviewerCheck $n)) { return $false } }
     return $true
+}
+
+<#
+    Classify one structured snapshot of `gh pr checks --json name,bucket` (#562).
+
+    Buckets per gh: pass / fail / pending / skipping / cancel. 'cancel' counts as failed (a
+    cancelled check did not pass) and 'skipping' as settled-ok — both mirror the previous
+    verdict logic, just computed from one snapshot instead of trusting --watch's exit code.
+
+    Fails closed: an unparsed snapshot ($Parsed=$false) reports Settled=$false and Ok=$false,
+    so the caller keeps polling and, at the deadline, blocks with a readable reason instead of
+    inventing a pass from data it never saw. An empty parsed list is the "no checks configured"
+    case — settled and ok, with NoChecks so the caller can print the note. Pure.
+#>
+function Get-ChecksVerdict {
+    param(
+        $Checks = @(),
+        [bool]$Parsed = $false
+    )
+    if (-not $Parsed) {
+        return @{ Parsed = $false; Settled = $false; Ok = $false; NoChecks = $false; Failed = @(); Pending = @() }
+    }
+    $list = @(@($Checks) | Where-Object { $_ })
+    if ($list.Count -eq 0) {
+        return @{ Parsed = $true; Settled = $true; Ok = $true; NoChecks = $true; Failed = @(); Pending = @() }
+    }
+    $failed  = @($list | Where-Object { "$($_.bucket)" -in @('fail','cancel') } | ForEach-Object { "$($_.name)" })
+    $pending = @($list | Where-Object { "$($_.bucket)" -eq 'pending' }          | ForEach-Object { "$($_.name)" })
+    return @{
+        Parsed   = $true
+        Settled  = ($pending.Count -eq 0)
+        Ok       = ($pending.Count -eq 0 -and $failed.Count -eq 0)
+        NoChecks = $false
+        Failed   = $failed
+        Pending  = $pending
+    }
+}
+
+<#
+    Should the combined CI+review wait loop exit? (#562)
+
+    The two waits are independent, so the loop runs them CONCURRENTLY and exits only when both
+    sides are done: the CI side when checks settle or its deadline passes, the review side when
+    no review is being waited on, or one arrived, or its deadline passes. This is what turns
+    the old sequential worst case (CI wait + full review wait) into max(CI, review). Pure.
+#>
+function Test-GateWaitDone {
+    param(
+        [bool]$ChecksSettled,
+        [bool]$WaitingReview,
+        [Parameter(Mandatory)][datetime]$Now,
+        [Parameter(Mandatory)][datetime]$CiDeadline,
+        [Parameter(Mandatory)][datetime]$ReviewDeadline
+    )
+    $ciDone     = $ChecksSettled -or ($Now -ge $CiDeadline)
+    $reviewDone = (-not $WaitingReview) -or ($Now -ge $ReviewDeadline)
+    return ($ciDone -and $reviewDone)
 }
 
 # Dot-source guard: tests set $env:ABIOS_REVIEWGATE_DOTSOURCE to load the pure helper only.
@@ -496,46 +565,11 @@ if ($tmdlChanged) {
     }
 }
 
-# ── 2. CI checks ───────────────────────────────────────────────────────────────
-Write-Host ""
-Write-Host "  Esperando checks de CI..." -ForegroundColor Cyan
-$checksOk = $true
-$checksOut = gh pr checks $PR --repo $Repo --watch 2>&1
-$checksExit = $LASTEXITCODE
-$checksText = ($checksOut | Out-String).Trim()
-if ($checksText) { Write-Host $checksText }
-# Which checks failed, by name - read from STRUCTURED output, never scraped from the human-readable
-# table. Scraping was a merge decision made from display text: a failure printed in any shape the
-# regex missed would drop out of the list, leaving a reviewer failure as the only one seen and
-# waving a genuinely broken build through. If this read fails, $checksParsed stays false and the
-# downgrade below is simply never offered.
-$failedChecks = @()
-$checksParsed = $false
-$checksJson = gh pr checks $PR --repo $Repo --json name,bucket 2>$null
-if ($checksJson) {
-    try {
-        $parsedChecks = $checksJson | ConvertFrom-Json
-        # 'cancel' counts as failed: a cancelled check did not pass, and treating it as absent
-        # would be the same silent-hole mistake one level down.
-        $failedChecks = @(@($parsedChecks) | Where-Object { "$($_.bucket)" -in @('fail','cancel') } |
-                          ForEach-Object { "$($_.name)" })
-        $checksParsed = $true
-    } catch {
-        Write-Host "  WARN no pude leer los checks en formato estructurado - no se aplicara ninguna excepcion por revisor." -ForegroundColor DarkYellow
-    }
-}
-if ($checksExit -ne 0) {
-    if ($checksText -match '(?i)no checks') {
-        Write-Host "  (sin checks configurados - cuenta como pass, considera /board automate)" -ForegroundColor DarkGray
-    } else {
-        $checksOk = $false
-        Write-Host "  FAIL hay checks fallando" -ForegroundColor Red
-    }
-} else {
-    Write-Host "  OK  checks en verde" -ForegroundColor Green
-}
-
-# ── 3. Wait for the review, then collect decision + threads ───────────────────
+# ── 2+3. CI checks AND review, waited together (bounded + concurrent, #562) ───
+# The old shape was two waits in sequence: `gh pr checks --watch` (no timeout — the only unbounded
+# wait in the codebase; a queued workflow hung the session forever) and THEN a review poll. They
+# are independent, so one loop now polls both: worst case is max(CI, review), not their sum, and
+# the CI side expires at -CiTimeoutMinutes into an explicit "still pending" block.
 function Get-ReviewState {
     # THE gate verdict read. -Graphql throws on exit OR errors[] so a failed read can never come
     # back as 0 reviews / 0 unresolved / null decision -> a false GATE PASSED that authorizes a
@@ -556,19 +590,70 @@ query($o:String!, $r:String!, $n:Int!) {
     return $q.data.repository.pullRequest
 }
 
+Write-Host ""
+if ($copilotRequested) {
+    Write-Host "  Esperando checks de CI (max $CiTimeoutMinutes min) y el review (max $TimeoutMinutes min) EN PARALELO..." -ForegroundColor Cyan
+} else {
+    Write-Host "  Esperando checks de CI (max $CiTimeoutMinutes min)..." -ForegroundColor Cyan
+}
+
+$ciDeadline     = (Get-Date).AddMinutes([Math]::Max(1, $CiTimeoutMinutes))
+$reviewDeadline = (Get-Date).AddMinutes([Math]::Max(1, $TimeoutMinutes))
+$verdictCi      = Get-ChecksVerdict -Checks @() -Parsed $false
+$reviewArrived  = $false
 # NOTE: variable must NOT be named $pr - PowerShell vars are case-insensitive and it would
 # collide with the [int]$PR parameter (type conversion crash).
-$prState = Get-ReviewState
-if ($copilotRequested) {
-    Write-Host ""
-    Write-Host "  Esperando el review (max $TimeoutMinutes min)..." -ForegroundColor Cyan
-    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
-    while ((Get-Date) -lt $deadline) {
-        $reviews = @($prState.reviews.nodes)
-        if ($reviews.Count -gt 0 -and ($reviews | Where-Object { $_.author.login -match '(?i)copilot' })) { break }
-        Start-Sleep -Seconds 20
-        $prState = Get-ReviewState
+$prState        = $null
+
+while ($true) {
+    # CI snapshot — STRUCTURED read only (the display-text table was a merge decision made from
+    # human-readable output; see the #510 history above). A failed read keeps polling and, at the
+    # deadline, blocks — it can never invent a pass.
+    $checksJson = gh pr checks $PR --repo $Repo --json name,bucket 2>$null
+    $parsedList = @(); $parsedOk = $false
+    if ($checksJson) {
+        try { $parsedList = @($checksJson | ConvertFrom-Json); $parsedOk = $true } catch { }
+    } else {
+        # Empty stdout is either "no checks configured" (benign) or a transient read failure.
+        # Probe the human-readable form to tell them apart: only the explicit "no checks" text
+        # counts as benign; anything else stays unparsed and fails closed at the deadline.
+        $probe = (gh pr checks $PR --repo $Repo 2>&1 | Out-String)
+        if ($probe -match '(?i)no checks') { $parsedList = @(); $parsedOk = $true }
     }
+    $verdictCi = Get-ChecksVerdict -Checks $parsedList -Parsed $parsedOk
+
+    # Review snapshot — while one is awaited, and at least once so the verdict section always has
+    # PR state (decision, threads, head SHA) even when no review was requested.
+    if (-not $prState -or ($copilotRequested -and -not $reviewArrived)) {
+        $prState = Get-ReviewState
+        $reviewArrived = [bool](@($prState.reviews.nodes) | Where-Object { $_.author.login -match '(?i)copilot' })
+    }
+
+    if (Test-GateWaitDone -ChecksSettled ([bool]$verdictCi.Settled) `
+                          -WaitingReview ($copilotRequested -and -not $reviewArrived) `
+                          -Now (Get-Date) -CiDeadline $ciDeadline -ReviewDeadline $reviewDeadline) { break }
+    Start-Sleep -Seconds 15
+}
+
+# CI verdict, from the last snapshot.
+$checksOk     = $true
+$ciTimedOut   = $false
+$failedChecks = @($verdictCi.Failed)
+$checksParsed = [bool]$verdictCi.Parsed
+if ($verdictCi.NoChecks) {
+    Write-Host "  (sin checks configurados - cuenta como pass, considera /board automate)" -ForegroundColor DarkGray
+} elseif (-not $verdictCi.Parsed) {
+    $checksOk = $false
+    Write-Host "  FAIL no pude leer los checks del PR dentro del limite - se bloquea por precaucion, no como pass." -ForegroundColor Red
+} elseif (-not $verdictCi.Settled) {
+    $checksOk = $false; $ciTimedOut = $true
+    Write-Host ("  FAIL checks aun PENDIENTES tras {0} min: {1}" -f $CiTimeoutMinutes, (@($verdictCi.Pending) -join ', ')) -ForegroundColor Red
+    Write-Host "       (limite del gate #562 - antes esto esperaba sin techo y colgaba la sesion)" -ForegroundColor DarkGray
+} elseif (-not $verdictCi.Ok) {
+    $checksOk = $false
+    Write-Host ("  FAIL hay checks fallando: {0}" -f ($failedChecks -join ', ')) -ForegroundColor Red
+} else {
+    Write-Host "  OK  checks en verde" -ForegroundColor Green
 }
 
 $reviews    = @($prState.reviews.nodes)
@@ -630,7 +715,10 @@ if (-not $checksOk -and $evidence.reviewed -and (Test-OnlyReviewerChecksFailed -
 }
 
 $blockers = @()
-if (-not $checksOk)                        { $blockers += "checks de CI fallando" }
+if (-not $checksOk) {
+    $blockers += $(if ($ciTimedOut) { "checks de CI aun pendientes tras $CiTimeoutMinutes min (limite del gate, #562)" }
+                   else             { "checks de CI fallando" })
+}
 if ($decision -eq "CHANGES_REQUESTED")     { $blockers += "review pide cambios (CHANGES_REQUESTED)" }
 if ($unresolved -gt 0)                     { $blockers += "$unresolved hilo(s) de review sin resolver" }
 if ($tmdlBlocked)                          { $blockers += "cambios TMDL BREAKING en el modelo (M3.3)" }

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -260,9 +260,14 @@ function Test-IsReviewerCheck {
 function Test-OnlyReviewerChecksFailed {
     param(
         [string[]]$FailedChecks = @(),
-        [bool]$Parsed = $false
+        [bool]$Parsed = $false,
+        # The snapshot must be SETTLED for the allowance to mean anything (#562, external review):
+        # with checks still pending at the CI deadline, "the only FAILURE is the reviewer" says
+        # nothing about the pending ones - excusing the reviewer there would excuse the timeout.
+        [bool]$Settled = $true
     )
-    if (-not $Parsed) { return $false }                       # cannot enumerate -> never downgrade
+    if (-not $Parsed)  { return $false }                      # cannot enumerate -> never downgrade
+    if (-not $Settled) { return $false }                      # pending checks -> nothing is excused
     $names = @(@($FailedChecks) | Where-Object { "$_".Trim() })
     if ($names.Count -eq 0) { return $false }                 # nothing named -> nothing to excuse
     foreach ($n in $names) { if (-not (Test-IsReviewerCheck $n)) { return $false } }
@@ -635,6 +640,11 @@ while ($true) {
     Start-Sleep -Seconds 15
 }
 
+# Re-read PR state AFTER the wait so the verdict below judges the PRESENT, not a snapshot from
+# early in the CI wait (#562, external review): a review that requested changes or a thread opened
+# while CI was still running would otherwise be invisible to a verdict computed from stale state.
+$prState = Get-ReviewState
+
 # CI verdict, from the last snapshot.
 $checksOk     = $true
 $ciTimedOut   = $false
@@ -707,7 +717,7 @@ Write-Host ""
 # file, so its verification correctly reports "nobody reviewed" and would then block that PR
 # forever, no matter how carefully a human or an external reviewer read it.
 # Narrow on purpose: only when EVERY failing check is a reviewer job AND real evidence exists.
-if (-not $checksOk -and $evidence.reviewed -and (Test-OnlyReviewerChecksFailed -FailedChecks $failedChecks -Parsed $checksParsed)) {
+if (-not $checksOk -and $evidence.reviewed -and (Test-OnlyReviewerChecksFailed -FailedChecks $failedChecks -Parsed $checksParsed -Settled ([bool]$verdictCi.Settled))) {
     $checksOk = $true
     Write-Host ("  NOTA: el unico check en rojo es el revisor automatico ({0}), y ya hay una revision real" -f ($failedChecks -join ', ')) -ForegroundColor DarkYellow
     Write-Host ("        registrada para este commit ({0}). Su pregunta -'alguien reviso esto?'- ya esta" -f ($evidence.reviewers -join ', ')) -ForegroundColor DarkGray

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -198,3 +198,105 @@ Describe 'Test-OnlyReviewerChecksFailed - the reviewer-red allowance (#510, revi
         It 'does not recognise "Docs freshness"' { Test-IsReviewerCheck 'Docs freshness' | Should -BeFalse }
     }
 }
+
+Describe 'Get-ChecksVerdict - one snapshot, fail-closed (#562)' {
+    # Replaces trusting `gh pr checks --watch` (unbounded, exit-code driven). The verdict is
+    # computed from one structured snapshot; whatever cannot be read can only ever block.
+    BeforeAll {
+        function script:Chk([string]$name, [string]$bucket) {
+            [pscustomobject]@{ name = $name; bucket = $bucket }
+        }
+    }
+
+    Context 'fails closed' {
+        It 'an unparsed snapshot is neither settled nor ok' {
+            $v = Get-ChecksVerdict -Checks @() -Parsed $false
+            $v.Settled | Should -BeFalse
+            $v.Ok      | Should -BeFalse
+            $v.Parsed  | Should -BeFalse
+        }
+        It 'an unparsed snapshot never reports NoChecks (cannot know that)' {
+            (Get-ChecksVerdict -Checks @() -Parsed $false).NoChecks | Should -BeFalse
+        }
+    }
+
+    Context 'no checks configured' {
+        It 'an empty PARSED list is the benign case: settled, ok, flagged NoChecks' {
+            $v = Get-ChecksVerdict -Checks @() -Parsed $true
+            $v.Settled  | Should -BeTrue
+            $v.Ok       | Should -BeTrue
+            $v.NoChecks | Should -BeTrue
+        }
+    }
+
+    Context 'buckets' {
+        It 'all pass -> settled and ok' {
+            $v = Get-ChecksVerdict -Checks @((script:Chk 'Pester' 'pass'), (script:Chk 'lint' 'pass')) -Parsed $true
+            $v.Settled | Should -BeTrue ; $v.Ok | Should -BeTrue
+            @($v.Failed).Count | Should -Be 0
+        }
+        It 'a pending check means NOT settled, and is named' {
+            $v = Get-ChecksVerdict -Checks @((script:Chk 'Pester' 'pass'), (script:Chk 'build' 'pending')) -Parsed $true
+            $v.Settled | Should -BeFalse
+            $v.Pending | Should -Contain 'build'
+        }
+        It 'a fail is settled but not ok, and is named' {
+            $v = Get-ChecksVerdict -Checks @((script:Chk 'Pester' 'fail')) -Parsed $true
+            $v.Settled | Should -BeTrue ; $v.Ok | Should -BeFalse
+            $v.Failed  | Should -Contain 'Pester'
+        }
+        It 'cancel counts as failed - a cancelled check did not pass' {
+            (Get-ChecksVerdict -Checks @((script:Chk 'build' 'cancel')) -Parsed $true).Failed | Should -Contain 'build'
+        }
+        It 'skipping counts as settled-ok (mirrors the previous verdict)' {
+            $v = Get-ChecksVerdict -Checks @((script:Chk 'docs' 'skipping')) -Parsed $true
+            $v.Settled | Should -BeTrue ; $v.Ok | Should -BeTrue
+        }
+    }
+}
+
+Describe 'Test-GateWaitDone - CI and review waited concurrently (#562)' {
+    # The property under test: total wait is max(CI, review), never their sum, and BOTH sides
+    # have a deadline - the unbounded CI watch is gone.
+    BeforeAll {
+        $script:T0     = [datetime]'2026-08-03T10:00:00'
+        $script:Later  = $script:T0.AddMinutes(60)
+    }
+
+    It 'keeps waiting while checks are pending and CI deadline has not passed' {
+        Test-GateWaitDone -ChecksSettled $false -WaitingReview $false `
+            -Now $script:T0 -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeFalse
+    }
+    It 'keeps waiting for the review even when CI already settled (concurrent, not sequential)' {
+        Test-GateWaitDone -ChecksSettled $true -WaitingReview $true `
+            -Now $script:T0 -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeFalse
+    }
+    It 'exits when both sides are done' {
+        Test-GateWaitDone -ChecksSettled $true -WaitingReview $false `
+            -Now $script:T0 -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeTrue
+    }
+    It 'the CI deadline bounds the wait - pending checks stop blocking the exit once it passes' {
+        Test-GateWaitDone -ChecksSettled $false -WaitingReview $false `
+            -Now $script:Later -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeTrue
+    }
+    It 'the review deadline bounds the wait - a silent reviewer stops blocking the exit once it passes' {
+        Test-GateWaitDone -ChecksSettled $true -WaitingReview $true `
+            -Now $script:Later -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeTrue
+    }
+    It 'waits for the LATER of the two sides, not their sum (max, not plus)' {
+        # 10 min in: CI (25m) still pending, review deadline (6m) already passed.
+        # The only thing keeping the loop alive is CI - the review side is done.
+        $now = $script:T0.AddMinutes(10)
+        Test-GateWaitDone -ChecksSettled $false -WaitingReview $true `
+            -Now $now -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeFalse   # still waiting, but ONLY on CI
+        Test-GateWaitDone -ChecksSettled $true -WaitingReview $true `
+            -Now $now -CiDeadline $script:T0.AddMinutes(25) -ReviewDeadline $script:T0.AddMinutes(6) |
+            Should -BeTrue    # CI settles -> nothing else to wait for
+    }
+}

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -160,6 +160,11 @@ Describe 'Test-OnlyReviewerChecksFailed - the reviewer-red allowance (#510, revi
         It 'never downgrades when a list of blanks is all there is' {
             Test-OnlyReviewerChecksFailed -FailedChecks @('', '   ') -Parsed $true | Should -BeFalse
         }
+        It 'never downgrades while checks are still PENDING - excusing the reviewer there would excuse the CI timeout (#562)' {
+            # External-review finding: reviewer red + another check pending at the CI deadline.
+            # "The only FAILURE is the reviewer" says nothing about the pending ones.
+            Test-OnlyReviewerChecksFailed -FailedChecks @('claude-review') -Parsed $true -Settled $false | Should -BeFalse
+        }
     }
 
     Context 'a real build failure always blocks' {


### PR DESCRIPTION
Closes #562