### PR TITLE
feat(plan): prior-art gate ÔÇö /board plan must record a build-vs-reference decision before creating the epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`/board plan` prior-art gate** (#415). `Board-Plan.ps1` now refuses to create an epic
+  unless the caller provides either `-PriorArt "<block>"` (queries run, candidates found with
+  stars/license/adoption, and the explicit build-vs-reference-vs-extend decision) or `-NoPriorArt`
+  (for genuinely novel work). In both cases the outcome lands in a `## Prior-art gate` section of
+  the epic body, making the decision auditable later. A silent skip — the failure mode that cost
+  five PRs on the wiki epic (#401) — is no longer possible: the script throws before creating
+  anything. Same enforcement shape as the `-Rationale` requirement in `/board triage`. Verified by
+  9 new Pester tests covering both paths (gate and skip).
+
 ## [0.33.0] - 2026-08-04
 
 **The performance & autonomy overhaul — the tool stops feeling slow and stalled.** A cold

--- a/evidence/415.md
+++ b/evidence/415.md
@@ -1,0 +1,74 @@
+# [abios-evidence] Issue #415 — feat(plan): prior-art gate
+
+## What was tested
+
+Two pure functions added to `Board-Plan.ps1` behind the dot-source guard, plus the gate call
+and body-construction wiring in the side-effecting section:
+
+1. `Format-PriorArtGateBlock` — renders `## Prior-art gate` heading with content or skip notice
+2. `Assert-PriorArtPresent` — throws when neither `-PriorArt` nor `-NoPriorArt` is supplied
+3. Body construction — the gate block always lands before the `## Tasks` section
+
+## Tests run
+
+### Board-Plan targeted suite (9 new tests + 5 original)
+
+**Command:**
+```
+pwsh -Command "Invoke-Pester plugins/agentic-board/tests/Board-Plan.Tests.ps1 -Output Detailed"
+```
+
+**Result:** Tests Passed: 14, Failed: 0
+
+New tests:
+- `Format-PriorArtGateBlock` — renders heading when PriorArt provided ✅
+- `Format-PriorArtGateBlock` — renders content under heading ✅
+- `Format-PriorArtGateBlock` — renders heading + skip notice when -NoPriorArt ✅
+- `Format-PriorArtGateBlock` — does NOT include caller PriorArt string when -NoPriorArt ✅
+- `Format-PriorArtGateBlock` — trims leading/trailing whitespace ✅
+- `Assert-PriorArtPresent` — throws when PriorArt empty and -NoPriorArt not set ✅
+- `Assert-PriorArtPresent` — throws when PriorArt is whitespace ✅
+- `Assert-PriorArtPresent` — does NOT throw when PriorArt has content ✅
+- `Assert-PriorArtPresent` — does NOT throw when -NoPriorArt set (even if PriorArt empty) ✅
+
+### Raw-gh ratchet lint
+
+**Command:**
+```
+pwsh -Command "Invoke-Pester plugins/agentic-board/tests/RawGh.Lint.Tests.ps1 -Output Detailed"
+```
+
+**Result:** Tests Passed: 2, Failed: 0
+
+### Full Pester suite
+
+**Command:**
+```
+pwsh -Command "
+  \$cfg = New-PesterConfiguration
+  \$cfg.Run.Path = 'plugins/agentic-board/tests'
+  \$cfg.Run.Throw = \$true
+  \$cfg.Output.Verbosity = 'Normal'
+  Invoke-Pester -Configuration \$cfg
+"
+```
+
+**Result:** Tests Passed: 1888, Failed: 0, Skipped: 0 (816.61s)
+
+### Docs freshness
+
+**Command:**
+```
+pwsh plugins/agentic-board/scripts/Update-Docs.ps1
+```
+
+**Result:** `README already up to date (commands, version) - nothing to write.`
+
+## Acceptance criteria vs. result
+
+| Criterion | Result |
+|---|---|
+| `Board-Plan.ps1` refuses to create an epic with no prior-art block (or an explicit skip) | ✅ `Assert-PriorArtPresent` throws before any `gh` call |
+| The block lands in the epic body, so the decision is auditable later | ✅ `Format-PriorArtGateBlock` output appended before `## Tasks` in all code paths |
+| `-NoPriorArt` records the skip in the body rather than omitting the section | ✅ Renders `## Prior-art gate` + `_Skipped with -NoPriorArt…_` |
+| Pester coverage for both paths | ✅ 9 new tests; all green in full suite (1888 passing) |

--- a/plugins/agentic-board/scripts/Board-Plan.ps1
+++ b/plugins/agentic-board/scripts/Board-Plan.ps1
@@ -45,6 +45,17 @@
     Enriched item: the Definition of Done / test plan (rendered as a bullet list).
     Any omitted enriched section renders a detectable TBD placeholder.
 
+.PARAMETER PriorArt
+    The prior-art record (queries run, candidates found with stars/license/
+    adoption, and the build / reference / extend decision). Rendered as a
+    "## Prior-art gate" section in the epic body. One of -PriorArt or
+    -NoPriorArt is REQUIRED - the script throws before creating anything
+    if neither is supplied.
+
+.PARAMETER NoPriorArt
+    Explicitly skip the prior-art search for genuinely novel work. The skip
+    is written into the epic body so the omission is visible, not invisible.
+
 .PARAMETER Repo
     owner/name. Default: derived from the current directory's origin remote.
 
@@ -59,7 +70,10 @@
     Windows USER env var holding the PAT. Defaults to GITHUB_TOKEN_PERSONAL.
 
 .EXAMPLE
-    .\Board-Plan.ps1 -Title "plan: PBIR migration" -Tasks "inventory reports", "convert themes", "validate rendering" -Description "Goal: ..."
+    .\Board-Plan.ps1 -Title "plan: PBIR migration" -Tasks "inventory reports", "convert themes", "validate rendering" -Description "Goal: ..." -PriorArt "Searched: gh search repos pbir migration ... Decision: build (no existing tool covers PBIR)."
+
+.EXAMPLE
+    .\Board-Plan.ps1 -Title "plan: novel internal tooling" -Tasks "task A", "task B" -Description "Goal: ..." -NoPriorArt
 #>
 [CmdletBinding()]
 param(

--- a/plugins/agentic-board/scripts/Board-Plan.ps1
+++ b/plugins/agentic-board/scripts/Board-Plan.ps1
@@ -70,6 +70,8 @@ param(
     [string]$RoleSeed = "",
     [string[]]$Deliverables = @(),
     [string[]]$TestPlan = @(),
+    [string]$PriorArt = "",
+    [switch]$NoPriorArt,
     [string]$Repo = "",
     [string]$Owner = "",
     [int]   $ProjectNum = 0,
@@ -107,11 +109,49 @@ function Format-EnrichedEpicBody {
     ) -join "`n"
 }
 
+# Format-PriorArtGateBlock renders the mandatory prior-art section that lands in every epic body.
+# With -NoPriorArt the section records the explicit skip so the omission is visible, not silent.
+function Format-PriorArtGateBlock {
+    [CmdletBinding()]
+    param(
+        [string]$PriorArt = "",
+        [switch]$NoPriorArt
+    )
+    if ($NoPriorArt) {
+        return @(
+            "## Prior-art gate",
+            "_Skipped with -NoPriorArt — record findings here before merging if possible._"
+        ) -join "`n"
+    }
+    @(
+        "## Prior-art gate",
+        $PriorArt.Trim()
+    ) -join "`n"
+}
+
+# Assert-PriorArtPresent enforces the gate: an epic cannot be created without either a
+# prior-art block or an explicit -NoPriorArt skip. A silent skip is invisible; a recorded
+# skip is auditable. Same shape as the -Rationale requirement in Board-Triage.
+function Assert-PriorArtPresent {
+    [CmdletBinding()]
+    param(
+        [string]$PriorArt = "",
+        [switch]$NoPriorArt
+    )
+    if (-not $NoPriorArt -and [string]::IsNullOrWhiteSpace($PriorArt)) {
+        throw ("Board-Plan: a prior-art search is required before creating an epic.`n" +
+               "Run 'gh search repos <topic>' and pass findings via -PriorArt, " +
+               "or use -NoPriorArt to record an explicit skip " +
+               "(the skip is written into the epic body so the omission is visible, not silent).")
+    }
+}
+
 # Dot-source guard: tests set $env:ABIOS_BOARDPLAN_DOTSOURCE to load the pure formatter only.
 if ($env:ABIOS_BOARDPLAN_DOTSOURCE) { return }
 
 if (-not $Title)                          { throw "Board-Plan: -Title is required." }
 if (-not $Tasks -or $Tasks.Count -eq 0)   { throw "Board-Plan: -Tasks is required (one or more task titles)." }
+Assert-PriorArtPresent -PriorArt $PriorArt -NoPriorArt:$NoPriorArt
 
 # The single resolver for owner/name from this clone's origin (#281). Do NOT inline the regex
 # again: the copy-pasted version ate any dot in the repo name (midominio.com -> midominio).
@@ -147,6 +187,9 @@ if ($enriched) {
 } elseif ($Description) {
     $body += "$Description`n`n"
 }
+# Prior-art gate block always lands in the epic body so the build-vs-reference decision is auditable.
+$body += (Format-PriorArtGateBlock -PriorArt $PriorArt -NoPriorArt:$NoPriorArt)
+$body += "`n`n"
 $body += "## Tasks (native sub-issues)`n$taskOverview`n`nCreated by /board plan - work them with /board work."
 
 # Same trap as the children (#281): a failing `gh` does not throw, so without these checks the

--- a/plugins/agentic-board/skills/projects-admin/references/verbs-plan.md
+++ b/plugins/agentic-board/skills/projects-admin/references/verbs-plan.md
@@ -20,13 +20,15 @@ Loaded on demand by /board (#573).
   the epic body so the omission is visible rather than invisible (same shape as `-Rationale` in
   `/board triage`). The script throws if neither is supplied.
   Then run `scripts/Board-Plan.ps1 -Title "plan: <feature>" -Tasks "A","B",... -Description "..." -PriorArt "<block>"`
-  — it ensures plan/plan-task labels, creates the epic (with the prior-art block in the body), reuses Board-Breakdown for NATIVE
+  (or `-NoPriorArt` in place of `-PriorArt "<block>"` for genuinely novel work) — it ensures
+  plan/plan-task labels, creates the epic (with the prior-art block in the body), reuses
+  Board-Breakdown for NATIVE sub-issues, resolves the repo board with Resolve-Board (never a
+  duplicate), and registers epic + children. Suggest `/board fill` for Priority/Size/Type and
+  `/board work` to start the first task. Issues are created ONLY in the current repo (origin) —
+  never elsewhere.
   Optionally enrich the epic with the four standard items the **`/board expert`** auto-mode
   reads: `-Research "<prior-art / docs found>"`, `-RoleSeed "<expert role objective>"`,
   `-Deliverables "d1","d2"`, `-TestPlan "DoD1","DoD2"` (here `-Description` becomes the Goal).
   Any omitted section renders a `_TBD - fill before /board expert auto_` placeholder, so a plan
   can be created now and completed before running the expert. All four are optional — with none,
   the epic body is rendered exactly as before.
-  sub-issues, resolves the repo board with Resolve-Board (never a duplicate), and registers
-  epic + children. Suggest `/board fill` for Priority/Size/Type and `/board work` to start the
-  first task. Issues are created ONLY in the current repo (origin) — never elsewhere.

--- a/plugins/agentic-board/skills/projects-admin/references/verbs-plan.md
+++ b/plugins/agentic-board/skills/projects-admin/references/verbs-plan.md
@@ -12,8 +12,15 @@ Loaded on demand by /board (#573).
      goal + substantial tasks, show the same proposal, and WAIT for approval. Link the doc in
      the description ONLY as a full `https://github.com/<owner>/<repo>/blob/<branch>/<path>`
      URL on a PUSHED ref — relative paths render broken in issues.
-  Then run `scripts/Board-Plan.ps1 -Title "plan: <feature>" -Tasks "A","B",... -Description "..."`
-  — it ensures plan/plan-task labels, creates the epic, reuses Board-Breakdown for NATIVE
+  **Before running the script, search for prior art** — this is a gate, not a suggestion:
+  run `gh search repos <topic> --sort=stars --limit=10` and `gh search code <pattern>` to find
+  existing tools or approaches. Record what you found (queries, candidates, stars/license/adoption,
+  decision: build / reference / extend) and pass it via `-PriorArt "<block>"`. If the work is
+  genuinely novel and no search makes sense, pass `-NoPriorArt` instead — the skip is written into
+  the epic body so the omission is visible rather than invisible (same shape as `-Rationale` in
+  `/board triage`). The script throws if neither is supplied.
+  Then run `scripts/Board-Plan.ps1 -Title "plan: <feature>" -Tasks "A","B",... -Description "..." -PriorArt "<block>"`
+  — it ensures plan/plan-task labels, creates the epic (with the prior-art block in the body), reuses Board-Breakdown for NATIVE
   Optionally enrich the epic with the four standard items the **`/board expert`** auto-mode
   reads: `-Research "<prior-art / docs found>"`, `-RoleSeed "<expert role objective>"`,
   `-Deliverables "d1","d2"`, `-TestPlan "DoD1","DoD2"` (here `-Description` becomes the Goal).

--- a/plugins/agentic-board/tests/Board-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Plan.Tests.ps1
@@ -16,6 +16,54 @@ BeforeAll {
     $script:Placeholder = '_TBD'
 }
 
+Describe 'Format-PriorArtGateBlock' {
+    It 'renders the ## Prior-art gate heading when PriorArt is provided' {
+        $b = Format-PriorArtGateBlock -PriorArt 'Searched: gh search repos wiki; Decision: build'
+        $b | Should -Match '## Prior-art gate'
+    }
+
+    It 'renders the PriorArt content under the heading' {
+        $b = Format-PriorArtGateBlock -PriorArt 'Decision: reference DeepWiki (zero setup)'
+        $b | Should -Match 'Decision: reference DeepWiki'
+        $b.IndexOf('## Prior-art gate') | Should -BeLessThan ($b.IndexOf('Decision: reference DeepWiki'))
+    }
+
+    It 'renders the heading and a skip notice when -NoPriorArt is set' {
+        $b = Format-PriorArtGateBlock -NoPriorArt
+        $b | Should -Match '## Prior-art gate'
+        $b | Should -Match 'Skipped with -NoPriorArt'
+    }
+
+    It 'does NOT include a caller-supplied PriorArt string when -NoPriorArt is set' {
+        $b = Format-PriorArtGateBlock -PriorArt 'should not appear' -NoPriorArt
+        $b | Should -Not -Match 'should not appear'
+    }
+
+    It 'trims leading/trailing whitespace from the PriorArt content' {
+        $b = Format-PriorArtGateBlock -PriorArt '  trimmed content  '
+        $b | Should -Match 'trimmed content'
+        $b | Should -Not -Match '  trimmed content  '
+    }
+}
+
+Describe 'Assert-PriorArtPresent' {
+    It 'throws when PriorArt is empty and -NoPriorArt is not set' {
+        { Assert-PriorArtPresent -PriorArt '' } | Should -Throw '*prior-art search is required*'
+    }
+
+    It 'throws when PriorArt is whitespace and -NoPriorArt is not set' {
+        { Assert-PriorArtPresent -PriorArt '   ' } | Should -Throw '*prior-art search is required*'
+    }
+
+    It 'does NOT throw when PriorArt has content' {
+        { Assert-PriorArtPresent -PriorArt 'Decision: build — no existing tool does X' } | Should -Not -Throw
+    }
+
+    It 'does NOT throw when -NoPriorArt is set even if PriorArt is empty' {
+        { Assert-PriorArtPresent -PriorArt '' -NoPriorArt } | Should -Not -Throw
+    }
+}
+
 Describe 'Format-EnrichedEpicBody' {
     It 'renders all five standard headings' {
         $b = Format-EnrichedEpicBody -Goal 'Build X' -Research 'Prior art: Ralph' `


### PR DESCRIPTION
Closes #415

[abios-evidence] #415 prior-art gate — COMPLETE

**Summary:** `Board-Plan.ps1` now refuses to create an epic without a prior-art record (or explicit skip). 9 new Pester tests; full suite 1888 passing.

**Evidence file:** [`evidence/415.md`](https://github.com/CSalcedoDataBI/agentic-board/blob/issue-415-feat-plan-prior-art-gate-board-plan/evidence/415.md)

**Changes:**
- `Board-Plan.ps1`: +`-PriorArt` / `-NoPriorArt` params; `Format-PriorArtGateBlock` + `Assert-PriorArtPresent` pure functions; gate enforced before first `gh` call; block appended to every epic body
- `Board-Plan.Tests.ps1`: 9 new Pester tests (5 for Format-PriorArtGateBlock, 4 for Assert-PriorArtPresent)
- `verbs-plan.md`: documents the gate step with examples
- `CHANGELOG.md`: [Unreleased] entry
- `evidence/415.md`: full evidence record