### PR TITLE
fix(docs): drop Docs-Command-* wiki pages — they publish the agent prompt, not documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,16 @@ jobs:
             exit 1
           fi
 
-      # Wiki docs freshness (#406): verify that the wiki pages can still be generated
-      # from the current README + commands/ without error, and that every generated page
+      # Wiki docs freshness (#406, updated #418): verify that the wiki pages can still be
+      # generated from the current README without error, and that every generated page
       # carries the <!-- GENERATED --> marker.  No git/network — pure -PagesOnly run.
+      #
+      # IMPORTANT: "it generates" is NOT evidence that "it reads".  The original check
+      # passed a 31 KB Docs-Command-Board page that read as second-person AI instructions
+      # because commands/*.md are agent prompts, not documentation.  The GENERATED marker
+      # only proves the generator ran — it says nothing about whether the output is useful
+      # or safe to publish.  Docs-Command-* pages were dropped in #418 precisely because
+      # a check that cannot ask "does this read?" will report green on garbage forever.
       - name: Validate wiki doc generation
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`Publish-DocsWiki.ps1` no longer generates `Docs-Command-*` wiki pages** (#418).
+  `commands/*.md` files are agent instruction files (system prompts addressed to an AI),
+  not documentation. Publishing them verbatim produced a 31 KB `Docs-Command-Board` page
+  full of internal recipes, script paths and conditional branches — instructions readable
+  only by the agent that would execute them. The `_Sidebar` no longer links to command
+  pages. `Docs-Home` is now purely the README with HTML stripped. Stale `Docs-Command-*`
+  pages left in the wiki are automatically removed on the next publish (the clone-write-
+  `git add -A` cycle stages their deletion). The CI freshness step is annotated to explain
+  why "it generates" was never evidence that "it reads" — a check that cannot ask that
+  question will report green on garbage forever. For code and architecture reference, route
+  to DeepWiki instead of generating. 15 Pester tests updated; the `Docs-Command-<X>`
+  describe block (7 tests) was removed; 2 new tests (`does NOT generate any Docs-Command-*
+  pages`, `does NOT link to any Docs-Command-* page`) enforce the invariant.
+
 ### Added
 - **`/board plan` prior-art gate** (#415). `Board-Plan.ps1` now refuses to create an epic
   unless the caller provides either `-PriorArt "<block>"` (queries run, candidates found with

--- a/evidence/418.md
+++ b/evidence/418.md
@@ -1,0 +1,53 @@
+# [abios-evidence] Issue #418 — fix(docs): drop Docs-Command-* wiki pages
+
+## Summary
+
+`commands/*.md` are agent system prompts, not documentation. Publishing them verbatim
+produced wiki pages addressed to an AI, not to a user. The root cause was the wrong
+choice of source: a generator cannot fix a bad source by formatting it better.
+
+## What was changed
+
+| File | Change |
+|------|--------|
+| `plugins/agentic-board/scripts/Publish-DocsWiki.ps1` | Removed `Docs-Command-*` generation, `Clean-CommandBody`, `Get-CommandSlug`, `commandsDir` resolution; updated header comment and push-path comment (stale-page deletion). |
+| `plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1` | Removed `Docs-Command-<X>` describe block (7 tests); added 2 new invariant tests; updated page-count formula from `3 + cmds + knowledge` to `3 + knowledge`. |
+| `.github/workflows/ci.yml` | Added note explaining "it generates" is NOT evidence "it reads". |
+| `CHANGELOG.md` | Added `### Fixed` entry in `[Unreleased]`. |
+
+## Test evidence
+
+**Command:**
+```powershell
+$cfg = New-PesterConfiguration
+$cfg.Run.Path = 'plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1'
+$cfg.Run.Throw = $false
+$cfg.Output.Verbosity = 'Detailed'
+Invoke-Pester -Configuration $cfg
+```
+
+**Result:** `Tests Passed: 29, Failed: 0, Skipped: 0`
+
+Key new tests:
+- `does NOT generate any Docs-Command-* pages` — PASS
+- `does NOT link to any Docs-Command-* page` (Home) — PASS
+- `does NOT link to any Docs-Command-* page` (Sidebar) — PASS
+- `generates exactly 3 + (knowledge pages) total pages` — PASS (9 pages: Docs-Home + 5 knowledge + Home + _Sidebar + _Footer)
+
+## Stale-page removal
+
+The push path clones the wiki, writes only current pages, then runs `git add -A`.
+Any stale `Docs-Command-*` page already in the wiki repo is staged for deletion and
+removed in that commit. No orphaned pages remain after the next publish.
+
+## "Generates vs reads" note
+
+The CI freshness check (`Validate wiki doc generation`) was updated with an explicit
+comment explaining why the `<!-- GENERATED -->` marker check is insufficient: it proves
+the generator ran, not that the output is useful. A 31 KB agent prompt passes this check
+while being worse than nothing as documentation.
+
+## PR
+
+- PR #594: https://github.com/CSalcedoDataBI/agentic-board/pull/594
+- Commit: be55834

--- a/plugins/agentic-board/scripts/Publish-DocsWiki.ps1
+++ b/plugins/agentic-board/scripts/Publish-DocsWiki.ps1
@@ -3,22 +3,28 @@
     Generates ALL wiki pages in one clone → commit → push:
       Product docs (always):
         Docs-Home          — from README.md (HTML stripped)
-        Docs-Command-<X>   — one page per commands/*.md file (frontmatter stripped)
       Knowledge registry (when knowledge/registry.json exists at $Root):
         Home               — index of domains and reference counts
         Knowledge-<Domain> — one page per domain
 
     Navigation:
-      _Sidebar — links to all product docs pages + all knowledge domain pages
+      _Sidebar — links to Docs-Home + all knowledge domain pages
       _Footer  — "generated from the repo" notice
 
     All pages carry a <!-- GENERATED --> marker so the wiki is clearly derived output,
     never hand-maintained. Source of truth stays in the repo.
 
+    NOTE: commands/*.md files are agent instruction files, not documentation.
+    Generating one wiki page per command file publishes the agent system prompt verbatim,
+    which reads as second-person orders to an AI, not as a user manual.  Those pages were
+    dropped in #418.  For code and architecture reference, route to DeepWiki instead.
+
     Testable page generation is exposed via -PagesOnly -OutDir (pure, no git/network).
     The clone -> commit -> push path mirrors Publish-KnowledgeWiki: the token travels ONLY
     as an env var read by a one-shot credential helper, never on the command line or in
-    the remote URL. #>
+    the remote URL. Stale pages (e.g. Docs-Command-* left from before #418) are removed
+    automatically on the next publish because the wiki is cloned fresh and git add -A
+    stages any deletions before the commit. #>
 [CmdletBinding()]
 param(
     [string]$Root = (Get-Location).Path,
@@ -67,35 +73,6 @@ function Get-FrontmatterField {
     $fm.Groups[1].Value.Trim()
 }
 
-# Remove the YAML frontmatter block (--- … ---) from the top of a Markdown file.
-function Remove-Frontmatter {
-    param([Parameter(Mandatory)][string]$Text)
-    $stripped = [regex]::Replace($Text, '(?s)^\s*---\r?\n.*?\r?\n---\r?\n?', '')
-    $stripped.Trim()
-}
-
-# Strip agent-specific template artifacts from a command file's body so the wiki
-# page reads as user documentation, not an agent system prompt.
-# Removes: "You are running the agentic-board /X command." lines,
-#          "Arguments: $ARGUMENTS" trailing lines.
-# Replaces: inline $ARGUMENTS occurrences with "<arguments>" for readability.
-function Clean-CommandBody {
-    param([Parameter(Mandatory)][string]$Text)
-    # "You are running …" opener (one or two lines at the very beginning)
-    $Text = [regex]::Replace($Text, '(?m)^You are running the agentic-board /\S+ command\.\r?\n?', '')
-    # "Arguments: $ARGUMENTS" tail (standalone line)
-    $Text = [regex]::Replace($Text, '(?m)^Arguments: \$ARGUMENTS\r?\n?', '')
-    # Remaining $ARGUMENTS occurrences (inline in "If $ARGUMENTS is empty …" patterns)
-    $Text = $Text.Replace('$ARGUMENTS', '<arguments>')
-    $Text.Trim()
-}
-
-# Build the wiki-page slug for a command by its base name (e.g. "board" → "Docs-Command-Board").
-function Get-CommandSlug {
-    param([Parameter(Mandatory)][string]$BaseName)
-    'Docs-Command-' + (($BaseName.Substring(0,1).ToUpper() + $BaseName.Substring(1)) -replace '[^\w-]+', '-')
-}
-
 # Build the wiki-page slug for a knowledge domain (e.g. "Power-Query" → "Knowledge-Power-Query").
 function Get-DomainSlug {
     param([Parameter(Mandatory)][string]$Domain)
@@ -104,16 +81,11 @@ function Get-DomainSlug {
 
 # ── Find source files ────────────────────────────────────────────────────────────────────
 
-# The README lives at the repo root; commands/ is relative to this script's plugin dir.
-$readmePath   = Join-Path $Root 'README.md'
-$commandsDir  = Join-Path $PSScriptRoot '..' 'commands'
+# The README lives at the repo root.
+$readmePath = Join-Path $Root 'README.md'
 
 if (-not (Test-Path -LiteralPath $readmePath)) {
     throw "README.md not found at $readmePath. Run from the repo root or pass -Root."
-}
-$commandsDir = Resolve-Path $commandsDir | Select-Object -ExpandProperty Path
-if (-not (Test-Path -LiteralPath $commandsDir)) {
-    throw "Commands directory not found at $commandsDir."
 }
 
 # ── Build pages in memory ─────────────────────────────────────────────────────────────
@@ -132,48 +104,10 @@ $homeSb = [Text.StringBuilder]::new()
 [void]$homeSb.AppendLine("")
 [void]$homeSb.AppendLine("---")
 [void]$homeSb.AppendLine("")
-
-# Navigation index to command pages
-$cmdFiles = @(Get-ChildItem -LiteralPath $commandsDir -Filter '*.md' -File | Sort-Object Name)
-if ($cmdFiles.Count -gt 0) {
-    [void]$homeSb.AppendLine("## Command reference")
-    [void]$homeSb.AppendLine("")
-    foreach ($cf in $cmdFiles) {
-        $slug = Get-CommandSlug -BaseName $cf.BaseName
-        $desc = Get-FrontmatterField -Raw ([System.IO.File]::ReadAllText($cf.FullName)) -Field 'description'
-        $blurb = if ($desc) { " — $desc" } else { '' }
-        [void]$homeSb.AppendLine("- [/$($cf.BaseName)]($slug)$blurb")
-    }
-    [void]$homeSb.AppendLine("")
-}
 [void]$homeSb.AppendLine("_Last published $Date._")
 
 $pages['Docs-Home'] = $homeSb.ToString()
 $sourceFiles['Docs-Home'] = $readmePath
-
-# --- One page per command --------------------------------------------------------
-foreach ($cf in $cmdFiles) {
-    $raw     = [System.IO.File]::ReadAllText($cf.FullName)
-    $desc    = Get-FrontmatterField -Raw $raw -Field 'description'
-    $body    = Remove-Frontmatter -Text $raw
-    $body    = Clean-CommandBody  -Text $body
-
-    $slug = Get-CommandSlug -BaseName $cf.BaseName
-
-    $pageSb = [Text.StringBuilder]::new()
-    [void]$pageSb.AppendLine("<!-- GENERATED by /docs wiki — do not edit here; edit commands/$($cf.Name) in the repo. -->")
-    if ($desc) {
-        [void]$pageSb.AppendLine("")
-        [void]$pageSb.AppendLine("> $desc")
-    }
-    [void]$pageSb.AppendLine("")
-    [void]$pageSb.AppendLine($body)
-    [void]$pageSb.AppendLine("")
-    [void]$pageSb.AppendLine("[← Product Docs](Docs-Home)")
-
-    $pages[$slug] = $pageSb.ToString()
-    $sourceFiles[$slug] = $cf.FullName
-}
 
 # --- Knowledge registry pages (optional) -----------------------------------------
 # When knowledge/registry.json (or .yaml) exists, generate Home + Knowledge-<Domain>
@@ -239,10 +173,6 @@ $sidebarSb = [Text.StringBuilder]::new()
 [void]$sidebarSb.AppendLine("## Product Docs")
 [void]$sidebarSb.AppendLine("")
 [void]$sidebarSb.AppendLine("- [Home](Docs-Home)")
-foreach ($cf in $cmdFiles) {
-    $slug = Get-CommandSlug -BaseName $cf.BaseName
-    [void]$sidebarSb.AppendLine("- [/$($cf.BaseName)]($slug)")
-}
 [void]$sidebarSb.AppendLine("")
 [void]$sidebarSb.AppendLine("## Knowledge")
 [void]$sidebarSb.AppendLine("")
@@ -326,6 +256,8 @@ if ($DryRun) {
 }
 
 # ── Clone the wiki, write pages, commit, push ────────────────────────────────────────
+# Any page present in the clone but absent from $pages (e.g. stale Docs-Command-* pages
+# left from before #418) is staged for deletion by git add -A and removed on this push.
 $tmp = Join-Path ([IO.Path]::GetTempPath()) ("docswiki-" + [guid]::NewGuid().ToString('N'))
 $helper = 'credential.helper=!f(){ echo username=x-access-token; echo password=$ABIOS_WIKI_TOKEN; };f'
 $env:ABIOS_WIKI_TOKEN = $token

--- a/plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1
+++ b/plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1
@@ -2,41 +2,19 @@
 <#  Pester tests for Publish-DocsWiki.ps1 page generation (-PagesOnly, no git/network).
     Validates:
       - Docs-Home is generated from README.md (HTML stripped, GENERATED marker present)
-      - One Docs-Command-<X> page per commands/*.md file (frontmatter + agent artifacts stripped)
-      - Navigation links: command pages link back to Docs-Home; Home links to each command
       - Knowledge registry pages (Home + Knowledge-<Domain>) when registry.json exists
       - _Sidebar and _Footer navigation pages
       - Empty states: README with only HTML still produces a Docs-Home
       - Uninitialized wiki produces an actionable error with the wiki URL
+
+    Note: Docs-Command-* pages were dropped in #418.  commands/*.md are agent instruction
+    files (system prompts), not documentation.  Verifying that a page "generates" was never
+    evidence that it "reads" — a 31 KB dump of internal recipes passes the GENERATED marker
+    check while being worse than nothing as documentation.  The generator was removed; for
+    code and architecture reference, route users to DeepWiki instead.
 #>
 BeforeAll {
     $script:Engine = Join-Path $PSScriptRoot '..' 'scripts' 'Publish-DocsWiki.ps1' | Resolve-Path
-
-    # Helper: create a minimal fake repo root with README.md and commands/*.md
-    function New-FakeRoot {
-        param(
-            [string]$ReadmeContent = '',
-            [hashtable]$Commands   = @{}   # basename -> content
-        )
-        $root = Join-Path ([IO.Path]::GetTempPath()) ("docswiki-t-" + [guid]::NewGuid().ToString('N'))
-        New-Item -ItemType Directory -Path $root -Force | Out-Null
-        if ($ReadmeContent -or $ReadmeContent -eq '') {
-            $ReadmeContent | Set-Content -LiteralPath (Join-Path $root 'README.md') -Encoding utf8
-        }
-        $cmdsDir = Join-Path $root 'commands'
-        New-Item -ItemType Directory -Path $cmdsDir -Force | Out-Null
-        foreach ($name in $Commands.Keys) {
-            $Commands[$name] | Set-Content -LiteralPath (Join-Path $cmdsDir "$name.md") -Encoding utf8
-        }
-        # Also put commands dir at the expected relative path for the script (../commands from scripts/)
-        # The script resolves $commandsDir = Join-Path $PSScriptRoot '..' 'commands'
-        # so we wire a symlink-free approach: override by setting $env:ABIOS_DOCS_COMMANDS_DIR if
-        # the script supports it, or simply use the real commands dir (which always exists).
-        #
-        # Because -PagesOnly uses the REAL commandsDir (relative to PSScriptRoot), we test with
-        # both the real commands dir and the README we supply via -Root.
-        $root
-    }
 
     # Helper: run the script in -PagesOnly mode and return a hashtable of page-name -> content
     function Invoke-PagesOnly {
@@ -83,12 +61,9 @@ Describe 'Publish-DocsWiki — page set' {
         $script:Pages.Keys | Should -Contain 'Docs-Home'
     }
 
-    It 'generates one Docs-Command-<X> page per command file' {
-        $commandFiles = @(Get-ChildItem -Path (Join-Path $PSScriptRoot '..' 'commands') -Filter '*.md' -File)
-        foreach ($cf in $commandFiles) {
-            $expectedSlug = 'Docs-Command-' + ($cf.BaseName.Substring(0,1).ToUpper() + $cf.BaseName.Substring(1))
-            $script:Pages.Keys | Should -Contain $expectedSlug -Because "commands/$($cf.Name) must produce a wiki page"
-        }
+    It 'does NOT generate any Docs-Command-* pages' {
+        $cmdPages = @($script:Pages.Keys | Where-Object { $_ -like 'Docs-Command-*' })
+        $cmdPages | Should -BeNullOrEmpty -Because 'commands/*.md are agent prompts, not documentation (#418)'
     }
 
     It 'generates _Sidebar navigation page' {
@@ -99,10 +74,10 @@ Describe 'Publish-DocsWiki — page set' {
         $script:Pages.Keys | Should -Contain '_Footer'
     }
 
-    It 'generates exactly 3 + (command files) + (knowledge pages) total pages' {
-        $commandCount = @(Get-ChildItem -Path (Join-Path $PSScriptRoot '..' 'commands') -Filter '*.md' -File).Count
-        $knExtra      = Get-KnowledgePageCount -Root $script:RepoRoot
-        $script:Pages.Count | Should -Be ($commandCount + 3 + $knExtra)
+    It 'generates exactly 3 + (knowledge pages) total pages' {
+        $knExtra = Get-KnowledgePageCount -Root $script:RepoRoot
+        # Fixed set: Docs-Home + _Sidebar + _Footer (+ optional knowledge pages)
+        $script:Pages.Count | Should -Be (3 + $knExtra)
     }
 }
 
@@ -138,68 +113,12 @@ Describe 'Publish-DocsWiki — Docs-Home content' {
         $script:DocsHomePage | Should -Match 'agentic-board'
     }
 
-    It 'links to each command page' {
-        $commandFiles = @(Get-ChildItem -Path (Join-Path $PSScriptRoot '..' 'commands') -Filter '*.md' -File)
-        $content = $script:DocsHomePage   # capture before foreach to avoid scope drift
-        foreach ($cf in $commandFiles) {
-            $slug    = 'Docs-Command-' + ($cf.BaseName.Substring(0,1).ToUpper() + $cf.BaseName.Substring(1))
-            $pattern = [regex]::Escape("($slug)")
-            $content | Should -Match $pattern -Because "Home must link to $slug"
-        }
+    It 'does NOT link to any Docs-Command-* page' {
+        $script:DocsHomePage | Should -Not -Match 'Docs-Command-' -Because 'command pages were dropped in #418'
     }
 
     It 'contains a "Last published" datestamp' {
         $script:DocsHomePage | Should -Match 'Last published \d{4}-\d{2}-\d{2}'
-    }
-}
-
-# ─────────────────────────────────────────────────────────────────────────────────────
-Describe 'Publish-DocsWiki — Docs-Command-<X> content' {
-    BeforeAll {
-        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..'))
-        $script:Out      = Join-Path ([IO.Path]::GetTempPath()) ("docswiki-cmds-" + [guid]::NewGuid().ToString('N'))
-        $script:Pages    = Invoke-PagesOnly -Root $script:RepoRoot -OutDir $script:Out
-        # Pick the 'board' command page as the representative rich test subject
-        $script:BoardPage = $script:Pages['Docs-Command-Board']
-    }
-    AfterAll { if ($script:Out -and (Test-Path $script:Out)) { Remove-Item $script:Out -Recurse -Force } }
-
-    It 'each command page carries the GENERATED marker' {
-        foreach ($key in ($script:Pages.Keys | Where-Object { $_ -like 'Docs-Command-*' })) {
-            $script:Pages[$key] | Should -Match 'GENERATED by /docs wiki' -Because "$key must carry the generated marker"
-        }
-    }
-
-    It 'each command page strips the YAML frontmatter' {
-        foreach ($key in ($script:Pages.Keys | Where-Object { $_ -like 'Docs-Command-*' })) {
-            $script:Pages[$key] | Should -Not -Match '(?m)^---$' -Because "$key must not contain raw YAML frontmatter"
-        }
-    }
-
-    It 'strips the "You are running the agentic-board /X command." line' {
-        $script:BoardPage | Should -Not -Match 'You are running the agentic-board /board command\.'
-    }
-
-    It 'strips the "Arguments: $ARGUMENTS" template artifact' {
-        foreach ($key in ($script:Pages.Keys | Where-Object { $_ -like 'Docs-Command-*' })) {
-            $script:Pages[$key] | Should -Not -Match '\$ARGUMENTS' -Because "$key must not contain the raw template variable"
-        }
-    }
-
-    It 'includes the description from frontmatter as a blockquote' {
-        # board.md description starts with "Administer/automate a GitHub Projects board"
-        $script:BoardPage | Should -Match '> Administer/automate a GitHub Projects board'
-    }
-
-    It 'includes substantive command content (not just the header)' {
-        # The board page documents its verbs — check one known verb keyword
-        $script:BoardPage | Should -Match '\bwork\b'
-    }
-
-    It 'links back to Docs-Home' {
-        foreach ($key in ($script:Pages.Keys | Where-Object { $_ -like 'Docs-Command-*' })) {
-            $script:Pages[$key] | Should -Match '\[← Product Docs\]\(Docs-Home\)' -Because "$key must link back to Docs-Home"
-        }
     }
 }
 
@@ -285,14 +204,8 @@ Describe 'Publish-DocsWiki — _Sidebar content' {
         $script:SidebarPage | Should -Match '\[Home\]\(Docs-Home\)'
     }
 
-    It 'links to each command page' {
-        $commandFiles = @(Get-ChildItem -Path (Join-Path $PSScriptRoot '..' 'commands') -Filter '*.md' -File)
-        $content = $script:SidebarPage
-        foreach ($cf in $commandFiles) {
-            $slug    = 'Docs-Command-' + ($cf.BaseName.Substring(0,1).ToUpper() + $cf.BaseName.Substring(1))
-            $pattern = [regex]::Escape("($slug)")
-            $content | Should -Match $pattern -Because "_Sidebar must link to $slug"
-        }
+    It 'does NOT link to any Docs-Command-* page' {
+        $script:SidebarPage | Should -Not -Match 'Docs-Command-' -Because 'command pages were dropped in #418'
     }
 
     It 'contains a Knowledge section linking to Home' {


### PR DESCRIPTION
Closes #418

## Summary

`commands/*.md` are agent system prompts, not documentation. Publishing them verbatim
produced wiki pages addressed to an AI (31 KB `Docs-Command-Board` of internal recipes and
conditional branches). The generator cannot fix a bad source by reformatting it.

## Changes

- **`Publish-DocsWiki.ps1`**: removed `Docs-Command-*` generation, `Clean-CommandBody`,
  `Get-CommandSlug`, and `commandsDir` resolution. The `_Sidebar` no longer links to command
  pages. Stale `Docs-Command-*` pages left in the wiki are removed automatically on the next
  publish (clone to write current pages to `git add -A` stages their deletion).
- **`Publish-DocsWiki.Tests.ps1`**: removed `Docs-Command-X` describe block (7 tests);
  added 2 new invariant tests; updated page-count formula (3 + knowledge, not 3 + cmds + knowledge).
- **`.github/workflows/ci.yml`**: annotated the freshness step explaining why "it generates" is
  NOT evidence that "it reads".
- **`CHANGELOG.md`**: Fixed entry in Unreleased.

## Evidence

[abios-evidence] 29/29 Pester tests pass -- see evidence/418.md for full record.

Evidence file: evidence/418.md in this branch.