### PR TITLE
feat(docs): /docs deepwiki — route to the repo's DeepWiki instead of generating code docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
   pages`, `does NOT link to any Docs-Command-* page`) enforce the invariant.
 
 ### Added
+- **`/docs` is now a router, not a generator** (#417). `commands/docs.md` documents the split
+  between what is generated and what is routed: `/docs wiki` generates pages from repo content
+  (README + knowledge registry) and pushes them to the GitHub Wiki; `/docs deepwiki` resolves the
+  repo, checks visibility, and reports (or navigates to) the AI-authored wiki on DeepWiki without
+  generating anything. `commands/*.md` agent instruction files are explicitly excluded from
+  generation — publishing them verbatim produces AI system prompts dressed as documentation.
+  Three new Pester tests enforce the contract: `commands/docs.md` must not reference
+  `Docs-Command-*` pages (regression guard for #418), must document both subcommands, and must
+  declare the public-repos-only limit for DeepWiki at the point of use.
 - **DeepWiki MCP integration** (#416). Three connected pieces: (1) `mcp.json` toolkit catalog
   entry registers the DeepWiki MCP server (`cognitionai/deepwiki`, three tools:
   `read_wiki_structure` / `read_wiki_contents` / `ask_question`) so `/tools` can install it via

--- a/evidence/417.md
+++ b/evidence/417.md
@@ -2,7 +2,7 @@
 
 [abios-evidence]
 issue: 417
-pr: (see PR opened after this file)
+pr: 600
 verdict: COMPLETE
 
 ## What was tested

--- a/evidence/417.md
+++ b/evidence/417.md
@@ -1,0 +1,84 @@
+# Evidence — #417 feat(docs): /docs deepwiki — route to the repo's DeepWiki
+
+[abios-evidence]
+issue: 417
+pr: (see PR opened after this file)
+verdict: COMPLETE
+
+## What was tested
+
+### Test 1 — New tests RED before fix (test-first)
+
+**Command:**
+```
+pwsh -Command "Import-Module Pester; Invoke-Pester -Path 'plugins/agentic-board/tests/CommandSurface.Tests.ps1' -Output Detailed"
+```
+
+**Result (before fix):**
+```
+Tests Passed: 34, Failed: 1, Skipped: 0
+  [-] commands/docs.md does not reference Docs-Command-* pages (dropped in #418)
+      because commands/*.md are agent prompts not documentation; ... but it did match
+```
+
+The test was RED because `commands/docs.md` still contained `Docs-Command-<X>` (stale reference from before #418 dropped those pages).
+
+### Test 2 — Tests GREEN after fix
+
+**Command:**
+```
+pwsh -Command "Import-Module Pester; Invoke-Pester -Path 'plugins/agentic-board/tests/CommandSurface.Tests.ps1' -Output Detailed"
+```
+
+**Result (after fix):**
+```
+Tests Passed: 35, Failed: 0, Skipped: 0
+
+Describing Command surface - /docs routing contract (#417)
+  [+] commands/docs.md does not reference Docs-Command-* pages (dropped in #418)
+  [+] commands/docs.md documents both /docs wiki (generates) and /docs deepwiki (routes)
+  [+] commands/docs.md declares the public-repos-only limit for deepwiki
+```
+
+### Test 3 — All targeted tests pass (84 tests across 3 files)
+
+**Command:**
+```
+pwsh -Command "Invoke-Pester -Path tests/CommandSurface.Tests.ps1, tests/Publish-DocsWiki.Tests.ps1, tests/Get-DeepWikiStatus.Tests.ps1 -Output Normal"
+```
+
+**Result:**
+```
+Tests completed in 31.62s
+Tests Passed: 84, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
+```
+
+### Test 4 — Wiki freshness check passes (mirrors CI)
+
+**Command:**
+```
+pwsh Publish-DocsWiki.ps1 -Root . -PagesOnly -OutDir $out
+```
+
+**Result:**
+```
+Pages: 9 - _Footer, _Sidebar, Docs-Home, Home, Knowledge-Claude-Code, Knowledge-Diagrams,
+           Knowledge-Docs-Publishing, Knowledge-Multi-Agent-Orchestration, Knowledge-PowerBI
+All pages have GENERATED marker - OK
+```
+
+No `Docs-Command-*` pages in the output — correct.
+
+## Acceptance criteria verification
+
+| Criterion | Status |
+|-----------|--------|
+| `/docs deepwiki` handles all three states: indexed / not indexed / private | PASS — handled by `Get-DeepWikiStatus.ps1` (created in #416); tests in `Get-DeepWikiStatus.Tests.ps1` cover all three states |
+| `commands/docs.md` documents the split between what is generated and what is routed | PASS — "Generated vs routed" section added; stale `Docs-Command-<X>` reference removed; 3 new Pester tests enforce the contract |
+| No network call is required for the private-repo path | PASS — early-exit path in `Get-DeepWikiStatus.ps1` (line 86-101) exits before any HTTP probe when `isPrivate=true` |
+
+## Files changed
+
+- `plugins/agentic-board/commands/docs.md` — removed stale `Docs-Command-<X>` reference; added "Generated vs routed" section
+- `plugins/agentic-board/tests/CommandSurface.Tests.ps1` — 3 new regression tests
+- `CHANGELOG.md` — entry for #417

--- a/plugins/agentic-board/commands/docs.md
+++ b/plugins/agentic-board/commands/docs.md
@@ -10,13 +10,19 @@ Route the request to the docs publisher.
 - `deepwiki` → run `Get-DeepWikiStatus.ps1` to report DeepWiki indexing status for this repo.
 - no argument → show this menu.
 
-## What gets published
+## Generated vs routed
 
-`/docs wiki` generates and pushes every wiki page in one operation:
+`/docs` has two distinct jobs:
+
+- **`/docs wiki`** generates pages from repo content — the README and the knowledge registry — and pushes them to the GitHub Wiki. This content is legitimately ours to generate because it lives in the repo; the wiki is a publishing surface for it.
+- **`/docs deepwiki`** does not generate anything. It resolves the repo, checks its privacy, and reports (or navigates to) the AI-authored wiki on DeepWiki. DeepWiki writes explanation — how the code works, architecture diagrams, module overviews — content no generator can produce by copying the repo it just read.
+
+`commands/*.md` files are agent instruction files (system prompts), not documentation. Generating a wiki page from an instruction file produces a verbatim copy of the AI's system prompt, not a user manual. Those pages were dropped in #418; for code and architecture reference, route to `/docs deepwiki` instead.
+
+## What `/docs wiki` publishes
 
 **Product docs** (always):
 - `Docs-Home` — from `README.md` (HTML stripped)
-- `Docs-Command-<X>` — one page per `commands/*.md` file (frontmatter stripped)
 
 **Knowledge registry** (when `knowledge/registry.json` exists):
 - `Home` — index of domains and reference counts

--- a/plugins/agentic-board/tests/CommandSurface.Tests.ps1
+++ b/plugins/agentic-board/tests/CommandSurface.Tests.ps1
@@ -92,3 +92,26 @@ Describe 'Command surface — /tools referenced-tools catalog (#384)' {
         $board | Should -Match '(?m)^\s*/tools\b' -Because 'the whole tool must be discoverable from the /board entry point, alongside /scan /skills /knowledge'
     }
 }
+
+Describe 'Command surface — /docs routing contract (#417)' {
+    It 'commands/docs.md does not reference Docs-Command-* pages (dropped in #418)' {
+        $docsFile = Join-Path $script:CommandsDir 'docs.md'
+        Get-Content -LiteralPath $docsFile -Raw |
+            Should -Not -Match 'Docs-Command-' `
+            -Because 'commands/*.md are agent prompts not documentation; Docs-Command-* pages were dropped in #418 — the /docs prompt must not promise them'
+    }
+
+    It 'commands/docs.md documents both /docs wiki (generates) and /docs deepwiki (routes)' {
+        $docsFile = Join-Path $script:CommandsDir 'docs.md'
+        $raw = Get-Content -LiteralPath $docsFile -Raw
+        $raw | Should -Match '(?i)/docs wiki'     -Because '/docs wiki is the generation subcommand'
+        $raw | Should -Match '(?i)/docs deepwiki' -Because '/docs deepwiki is the routing subcommand'
+    }
+
+    It 'commands/docs.md declares the public-repos-only limit for deepwiki' {
+        $docsFile = Join-Path $script:CommandsDir 'docs.md'
+        Get-Content -LiteralPath $docsFile -Raw |
+            Should -Match '(?i)public.repos.only' `
+            -Because 'the docs prompt must warn about the DeepWiki public-repos-only limit at the point of use'
+    }
+}


### PR DESCRIPTION
Closes #417

## Summary

- Remove stale `Docs-Command-<X>` reference from `commands/docs.md` (dropped in #418, prompt was not updated)
- Add "Generated vs routed" section documenting the split: `/docs wiki` generates pages from repo content; `/docs deepwiki` routes to AI-authored DeepWiki without generating anything
- Three new Pester regression guards enforce the contract in `CommandSurface.Tests.ps1`

## Evidence

[abios-evidence] — Test results and acceptance criteria: [evidence/417.md](evidence/417.md)

All 3 acceptance criteria verified (see evidence file):
- `/docs deepwiki` handles indexed / not-indexed / private (via `Get-DeepWikiStatus.ps1` from #416)
- `commands/docs.md` documents the generated-vs-routed split ✓
- Private-repo path has no network call ✓

84 targeted tests pass (CommandSurface + Publish-DocsWiki + Get-DeepWikiStatus).