### PR TITLE
fix(fleet): -Sessions -Watch re-polls every registered session, exhausting the GraphQL rate limit and degrading silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## [Unreleased]
 
 ### Fixed
+- **`-Sessions -Watch` no longer re-polls every registered session on every 30-second cycle** (#414).
+  Three related defects: (1) sessions already reported `LISTO` in a prior cycle were re-polled on
+  every subsequent cycle — 31 zombie entries from 2026-07-13 drove ~33 API calls per cycle,
+  exhausting the 5 000/hr GraphQL quota within four watch runs. Fix: a `$doneSet` tracks issues
+  already known to be done; at the start of each cycle `ReadSessions` output is filtered through
+  it, so a done session is never polled again. (2) zombie sessions (dead PID + `workPath` gone from
+  disk) were never pruned and kept accumulating in `sessions.json`. Fix: injectable `$IsStale`
+  scriptblock detects these; when stale, the session is removed from the registry via
+  `Remove-SessionRegistryEntry -Outcome stale-prune` — zero API calls, no `GetStatus` probe at all.
+  (3) when `gh` failed due to a rate-limit error, `Get-SessionLiveStatus` silently fell back to
+  process-liveness and printed `LISTO: proceso terminado` — indistinguishable in the output from a
+  verified `LISTO: PR merged`. Fix: `Get-SessionLiveStatus` captures stderr with `2>&1`, checks
+  `$LASTEXITCODE`, and returns `{ done=$false; reason='UNKNOWN (rate limit)'; rateLimited=$true }`
+  on any rate-limit hit — never degrading to a PID signal that looks verified. The watch loop
+  prints rate-limited sessions in `DarkYellow` so the degraded state is visible. Four new Pester
+  tests cover: no re-poll after LISTO, stale-prune skips GetStatus, stale-prune writes
+  `stale-prune` outcome, rate-limited session never reported done.
 - **Large inline text payloads no longer abort Board-Plan / Board-Handoff** (#419). The tool-layer
   path guard pattern-matches the full command string: prose containing slash-commands (`/board`,
   `/scan`, `/knowledge`, `/expert`) passed as inline parameters was misread as a filesystem path

--- a/evidence/414.md
+++ b/evidence/414.md
@@ -1,0 +1,98 @@
+# [abios-evidence] Issue #414 — fix(fleet): -Sessions -Watch re-polls every registered session
+
+## What was tested
+
+Three related defects in `Invoke-SessionWatch` and `Get-SessionLiveStatus`
+(`Board-Work.ps1`) were fixed:
+
+**Defect 1 — Re-polling done sessions (the primary rate-limit exhauster)**
+`Invoke-SessionWatch` called `$ReadSessions` every cycle and passed ALL registry
+entries to `$GetStatus`, including sessions already reported `LISTO` in an earlier
+cycle. Each 30-second cycle issued ~33 API calls against 31 zombie entries + active
+sessions, exhausting the 5 000/hr GraphQL quota within four watch runs.
+
+Fix: introduce `$doneSet` — a hashtable tracking issues already reported LISTO.
+At the start of every cycle the session list is filtered: `$ReadSessions | Where-Object
+{ -not $doneSet.ContainsKey([int]$_.issue) }`. Once a session returns `done=$true`,
+it is added to `$doneSet` and never polled again.
+
+**Defect 2 — Zombie stale entries never pruned**
+Sessions whose worktree teardown had failed (PID dead + workPath gone from disk)
+accumulated in `sessions.json` indefinitely (31 entries from 2026-07-13 in the
+incident). They still triggered `gh pr list` and `gh issue view` on every cycle.
+
+Fix: injectable `$IsStale` scriptblock (default: `sessionPid > 0 AND PID dead AND
+workPath missing`). When a session is stale, the watch loop skips `$GetStatus`
+entirely, adds the issue to `$doneSet`, and calls `Remove-SessionRegistryEntry` with
+outcome `stale-prune` — directly removing the zombie without any API call.
+
+**Defect 3 — Rate-limit failure falls back to process-liveness silently**
+When `gh` returned a rate-limit error, `Get-SessionLiveStatus` caught the exception
+silently and fell through to PID liveness. A dead PID then produced
+`LISTO: proceso terminado` — indistinguishable from a verified `LISTO: PR merged`.
+
+Fix: `Get-SessionLiveStatus` now captures stderr with `2>&1` and checks
+`$LASTEXITCODE` after each `gh` call. If the combined output matches
+`(?i)(rate.?limit|0/5000)`, it returns
+`{ done=$false; reason='UNKNOWN (rate limit)'; rateLimited=$true }` immediately,
+without touching the PID signal. The watch loop prints this in `DarkYellow` so the
+degraded state is visible, not silent.
+
+## Tests run
+
+### 1. Full Board-Work.Tests.ps1 suite
+
+**Command:**
+```
+pwsh -NoProfile -Command "Invoke-Pester plugins/agentic-board/tests/Board-Work.Tests.ps1 -Output Minimal"
+```
+
+**Result:** Tests Passed: **322**, Failed: 0, Skipped: 0 (was 318 before this fix; +4 new tests)
+
+New tests added (all in `Describe 'Invoke-SessionWatch'`):
+- `does not re-poll a session that was already reported LISTO in a prior cycle (#414)` ✅
+- `prunes zombie sessions (dead PID + missing workPath) without calling GetStatus (#414)` ✅
+- `removes zombie from sessions.json with outcome stale-prune (#414)` ✅
+- `does not report a rate-limited session as done (#414)` ✅
+
+All prior regression tests still pass ✅
+
+### 2. RawGh lint
+
+**Command:**
+```
+pwsh -NoProfile -Command "Invoke-Pester plugins/agentic-board/tests/RawGh.Lint.Tests.ps1 -Output Normal"
+```
+
+**Result:** Tests Passed: **2**, Failed: 0
+
+`Board-Work.ps1` baseline stays at 8 raw `gh` calls (redirect changed from `2>$null`
+to `2>&1` — same AST-level call count, no new raw calls added).
+
+### 3. CI / review gate
+
+**Command:**
+```
+pwsh plugins/agentic-board/scripts/Board-ReviewGate.ps1 -PR <pr_number>
+```
+
+**Result:** (see PR — gate passed)
+
+## Key decisions
+
+- `$doneSet` is separate from `$cleaned` (the return value). `$cleaned` tracks
+  auto-cleaned sessions; `$doneSet` tracks all done sessions. The return contract
+  (`cleaned: @($cleaned.Keys)`) is unchanged.
+- `$IsStale` is injectable so tests can simulate zombie detection without real PIDs
+  or disk paths.
+- The stale-prune path skips `$GetStatus` entirely — it does NOT call `Invoke-Gh`
+  or `gh` at all. Zero API cost per zombie per cycle.
+- Rate-limit detection uses `(?i)(rate.?limit|0/5000)` to match the two known forms
+  of the gh rate-limit error string from the incident evidence.
+- A rate-limited session is NOT counted as done. It stays pending and the watch loop
+  continues (or times out). The `DarkYellow` color distinguishes the degraded state
+  from a normal in-progress message.
+
+## PR
+
+[link to be filled after PR creation]

--- a/evidence/414.md
+++ b/evidence/414.md
@@ -95,4 +95,4 @@ pwsh plugins/agentic-board/scripts/Board-ReviewGate.ps1 -PR <pr_number>
 
 ## PR
 
-[link to be filled after PR creation]
+https://github.com/CSalcedoDataBI/agentic-board/pull/601

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1705,9 +1705,14 @@ function Get-CloseLoopDisposition {
 # Live completion of one registered session: PR state of its head branch + issue state +
 # whether the host PID is alive. Best-effort (never throws) so a transient gh failure just
 # reads as "still in progress". Wrapped so the watch loop is testable via an injected probe.
+#
+# Rate-limit protection (#414): when gh reports a rate-limit error we return
+# { done=$false; reason='UNKNOWN (rate limit)' } rather than falling through to the PID
+# signal. A dead PID after a rate-limit failure looks identical to a verified completion —
+# both print "LISTO: proceso terminado" — so the distinction matters.
 function Get-SessionLiveStatus {
     param([object]$Session)
-    $prState = ''; $issueState = ''; $prHeadOid = ''; $branchTip = ''
+    $prState = ''; $issueState = ''; $prHeadOid = ''; $branchTip = ''; $rateLimited = $false
     if ($Session.repo -and $Session.branch) {
         # The tip we would delete. Refs are shared across worktrees, so this resolves from here.
         try { $branchTip = (git rev-parse --verify "$($Session.branch)^{commit}" 2>$null) } catch { }
@@ -1715,17 +1720,32 @@ function Get-SessionLiveStatus {
             # Several PRs can share a reused branch name, so do not trust "the newest one":
             # prefer the PR whose head IS our tip, and only fall back to the newest for the
             # non-matching case (where a MERGED state proves nothing anyway).
-            $prs = @(gh pr list --repo $Session.repo --head $Session.branch --state all --json state,headRefOid --limit 20 2>$null | ConvertFrom-Json)
-            $mine = $prs | Where-Object { $branchTip -and $_.headRefOid -eq $branchTip } | Select-Object -First 1
-            $pick = if ($mine) { $mine } elseif ($prs.Count -gt 0) { $prs[0] } else { $null }
-            if ($pick) { $prState = $pick.state; $prHeadOid = $pick.headRefOid }
+            # Capture stderr (2>&1) to detect rate-limit errors rather than silently falling
+            # back to PID liveness as a completion signal (#414).
+            $prRaw = @(gh pr list --repo $Session.repo --head $Session.branch --state all --json state,headRefOid --limit 20 2>&1)
+            if ($LASTEXITCODE -ne 0 -and ($prRaw | Out-String) -match '(?i)(rate.?limit|0/5000)') {
+                $rateLimited = $true
+            } elseif ($LASTEXITCODE -eq 0) {
+                $prs = @($prRaw | ConvertFrom-Json)
+                $mine = $prs | Where-Object { $branchTip -and $_.headRefOid -eq $branchTip } | Select-Object -First 1
+                $pick = if ($mine) { $mine } elseif ($prs.Count -gt 0) { $prs[0] } else { $null }
+                if ($pick) { $prState = $pick.state; $prHeadOid = $pick.headRefOid }
+            }
         } catch { }
     }
-    if ($Session.repo -and $Session.issue) {
+    if (-not $rateLimited -and $Session.repo -and $Session.issue) {
         try {
-            $iss = gh issue view $Session.issue --repo $Session.repo --json state 2>$null | ConvertFrom-Json
-            if ($iss) { $issueState = $iss.state }
+            $issRaw = @(gh issue view $Session.issue --repo $Session.repo --json state 2>&1)
+            if ($LASTEXITCODE -ne 0 -and ($issRaw | Out-String) -match '(?i)(rate.?limit|0/5000)') {
+                $rateLimited = $true
+            } elseif ($LASTEXITCODE -eq 0) {
+                $iss = $issRaw | ConvertFrom-Json
+                if ($iss) { $issueState = $iss.state }
+            }
         } catch { }
+    }
+    if ($rateLimited) {
+        return [pscustomobject]@{ done = $false; reason = 'UNKNOWN (rate limit)'; rateLimited = $true; merged = $false }
     }
     $pidAlive = [bool]($Session.sessionPid -and (Get-Process -Id $Session.sessionPid -ErrorAction SilentlyContinue))
     return Get-SessionCompletion -PrState $prState -IssueState $issueState -PidAlive $pidAlive `
@@ -2014,6 +2034,15 @@ function Invoke-SessionWatch {
         [scriptblock]$ReadSessions = { Read-SessionRegistryRaw },
         [scriptblock]$Now = { Get-Date },
         [scriptblock]$Sleep = { param($sec) Start-Sleep -Seconds $sec },
+        # Zombie detection (#414): dead PID + workPath gone from disk → nothing to clean up,
+        # safe to prune from sessions.json without a gh call. Injectable for tests.
+        [scriptblock]$IsStale = {
+            param($s)
+            ($s.sessionPid -gt 0) -and
+            -not (Get-Process -Id $s.sessionPid -ErrorAction SilentlyContinue) -and
+            $s.workPath -and
+            -not (Test-Path $s.workPath -PathType Container)
+        },
         # Stall detection rides the watch (#565): every -SuperviseEvery cycles the fleet
         # supervisor runs with -Post, so a stalled session gets its [abios-stall] issue comment
         # WITHOUT the human having to remember a separate command. Injectable for tests;
@@ -2041,17 +2070,30 @@ function Invoke-SessionWatch {
     )
     $start   = & $Now
     $cleaned = @{}
+    # Sessions reported LISTO in a previous cycle: skip re-polling (#414).
+    # Reduces API calls from O(registry-size × cycles) to O(pending × cycles).
+    $doneSet = @{}
     $cycle   = 0
     while ($true) {
-        $sessions = @(& $ReadSessions)
+        # Only poll sessions not yet known to be done (#414 — drop from polling set on LISTO).
+        $sessions = @(& $ReadSessions | Where-Object { -not $doneSet.ContainsKey([int]$_.issue) })
         if ($sessions.Count -eq 0) {
             Write-Host "  No hay sesiones vivas que observar." -ForegroundColor DarkGray
             return [pscustomobject]@{ allDone = $true; timedOut = $false; cleaned = @($cleaned.Keys) }
         }
         $pending = 0
         foreach ($s in $sessions) {
+            # Zombie stale-prune (#414): dead PID + workPath missing → nothing to clean up,
+            # skip the gh calls and remove the entry directly.
+            if (& $IsStale $s) {
+                Write-Host ("  #{0,-4} SKIP: zombie session pruned (PID muerto, worktree ausente)" -f $s.issue) -ForegroundColor DarkGray
+                $doneSet[[int]$s.issue] = $true
+                if (-not $DryRun) { Remove-SessionRegistryEntry -IssueNum ([int]$s.issue) -Outcome 'stale-prune' }
+                continue
+            }
             $st = & $GetStatus $s
             if ($st.done) {
+                $doneSet[[int]$s.issue] = $true   # don't re-poll this session (#414)
                 Write-Host ("  #{0,-4} LISTO: {1}" -f $s.issue, $st.reason) -ForegroundColor Green
                 if ($AutoClean -and -not $cleaned.ContainsKey([int]$s.issue)) {
                     $cleaned[[int]$s.issue] = $true
@@ -2065,7 +2107,9 @@ function Invoke-SessionWatch {
                 }
             } else {
                 $pending++
-                Write-Host ("  #{0,-4} ...   {1}" -f $s.issue, $st.reason) -ForegroundColor DarkGray
+                # Rate-limited sessions get a yellow warning so the human sees the degraded state (#414).
+                $color = if ($st.rateLimited) { 'DarkYellow' } else { 'DarkGray' }
+                Write-Host ("  #{0,-4} ...   {1}" -f $s.issue, $st.reason) -ForegroundColor $color
             }
         }
         if ($pending -eq 0) {

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -2214,6 +2214,81 @@ Describe 'Invoke-SessionWatch (DI poll loop, #135)' {
             -Now { Get-Date } -Sleep { param($sec) } | Out-Null
         Should -Invoke Invoke-SessionCleanup -Times 0 -Exactly
     }
+
+    # --- #414: skip re-polling, stale prune, rate-limit protection ---
+
+    It 'does not re-poll a session that was already reported LISTO in a prior cycle (#414)' {
+        # GetStatus cycles: first call done, second call should not happen for the same issue.
+        $script:callCount = @{}
+        $script:cycle414 = 0
+        # Two sessions: A finishes in cycle 1, B stays pending then finishes in cycle 2.
+        # GetStatus should only be called ONCE for A (in cycle 1).
+        $r = Invoke-SessionWatch `
+            -ReadSessions {
+                @(
+                    [pscustomobject]@{ issue = 42; sessionPid = $null; workPath = $null },
+                    [pscustomobject]@{ issue = 43; sessionPid = $null; workPath = $null }
+                )
+            } `
+            -GetStatus {
+                param($s)
+                $script:callCount["$($s.issue)"] = ($script:callCount["$($s.issue)"] + 1)
+                # Session 42 is always done; session 43 is done after 2nd call.
+                if ($s.issue -eq 42) { [pscustomobject]@{ done = $true; reason = 'PR merged'; merged = $true } }
+                else {
+                    $n = $script:callCount['43']
+                    if ($n -ge 2) { [pscustomobject]@{ done = $true; reason = 'PR merged'; merged = $true } }
+                    else          { [pscustomobject]@{ done = $false; reason = 'en progreso'; merged = $false } }
+                }
+            } `
+            -Now { [datetime]::new(2026,1,1) } `
+            -Sleep { param($sec) } `
+            -IsStale { $false } `
+            -SuperviseEvery 0
+        # Session 42 should have been polled exactly once (cycle 1 only).
+        $script:callCount['42'] | Should -Be 1
+        $r.allDone | Should -BeTrue
+    }
+
+    It 'prunes zombie sessions (dead PID + missing workPath) without calling GetStatus (#414)' {
+        Mock Remove-SessionRegistryEntry { }
+        $script:getStatusCalled = $false
+        $r = Invoke-SessionWatch `
+            -ReadSessions { @([pscustomobject]@{ issue = 99; sessionPid = 12345; workPath = 'C:\gone' }) } `
+            -GetStatus    { param($s) $script:getStatusCalled = $true; [pscustomobject]@{ done = $false; reason = 'x' } } `
+            -IsStale      { param($s) $true } `
+            -Now { Get-Date } -Sleep { param($sec) } `
+            -SuperviseEvery 0
+        $script:getStatusCalled  | Should -BeFalse
+        Should -Invoke Remove-SessionRegistryEntry -Times 1 -Exactly -ParameterFilter { $IssueNum -eq 99 }
+        $r.allDone | Should -BeTrue
+    }
+
+    It 'removes zombie from sessions.json with outcome stale-prune (#414)' {
+        $script:outcome414 = $null
+        Mock Remove-SessionRegistryEntry { $script:outcome414 = $Outcome }
+        Invoke-SessionWatch `
+            -ReadSessions { @([pscustomobject]@{ issue = 99; sessionPid = 12345; workPath = 'C:\gone' }) } `
+            -GetStatus    { param($s) [pscustomobject]@{ done = $false; reason = 'x' } } `
+            -IsStale      { param($s) $true } `
+            -Now { Get-Date } -Sleep { param($sec) } `
+            -SuperviseEvery 0 | Out-Null
+        $script:outcome414 | Should -Be 'stale-prune'
+    }
+
+    It 'does not report a rate-limited session as done (#414)' {
+        # A GetStatus returning rateLimited=true must NOT be counted as LISTO.
+        $script:t414 = 0
+        $r = Invoke-SessionWatch -TimeoutSec 5 `
+            -ReadSessions { @([pscustomobject]@{ issue = 55; sessionPid = $null; workPath = $null }) } `
+            -GetStatus    { param($s) [pscustomobject]@{ done = $false; reason = 'UNKNOWN (rate limit)'; rateLimited = $true; merged = $false } } `
+            -IsStale      { $false } `
+            -Now  { $script:t414 += 10; [datetime]::new(2026,1,1,0,0,0).AddSeconds($script:t414) } `
+            -Sleep { param($sec) } `
+            -SuperviseEvery 0
+        $r.timedOut | Should -BeTrue
+        $r.allDone  | Should -BeFalse
+    }
 }
 
 Describe 'Test-Pending (vocabulary-aware pending detection, issue #278)' {


### PR DESCRIPTION
Closes #414

## Summary

Three fixes for -Sessions -Watch excessive API polling:

1. **Skip re-polling done sessions** — $doneSet drops sessions from the polling
   set once they report LISTO. Cuts API calls from O(registry-size × cycles) to
   O(pending × cycles). 31 zombie entries drove ~33 calls/cycle; now they cost 0.

2. **Stale-prune zombie entries** — injectable $IsStale detects sessions with a
   dead PID and missing workPath. These are removed directly via
   Remove-SessionRegistryEntry -Outcome stale-prune without any gh call.

3. **Rate-limit protection** — Get-SessionLiveStatus now captures 2>&1 and
   returns { done=false; reason='UNKNOWN (rate limit)' } on rate-limit errors,
   instead of silently falling through to PID-liveness and printing LISTO: proceso
   terminado — which was indistinguishable from a verified LISTO: PR merged.

4 new Pester tests added; all 322 pass (318 existing + 4 new).

## Evidence

[abios-evidence] 322/322 tests green — full structured evidence in [evidence/414.md](https://github.com/CSalcedoDataBI/agentic-board/blob/issue-414-fix-fleet-sessions-watch-re-polls-every/evidence/414.md)