### PR TITLE
Fleet sessions launched with -Parallel -Launch merge their own PRs unreviewed; only the expert path has a real brake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Fleet sessions launched with `-Parallel -Launch` now stop at a reviewed PR by default** (#598).
+  Previously, a session launched without an expert contract could merge its own PR with no review:
+  it was running with `--permission-mode bypassPermissions`, was briefed to call `Board-Merge.ps1`,
+  and nothing in the tool layer refused it. On 2026-08-03, two such sessions merged their own PRs
+  with `reviews: []` and no `[abios-review]` record; post-merge review found that one PR had not
+  built the central item of its issue's DoD. Fix: all `-Launch` and `-Fleet` sessions now arm the
+  brake by default — `Resolve-LaunchBrake` returns `$true` (stop at PR) unless `-AllowMerge` is
+  explicitly passed or the caller explicitly passes `-StopAtPR:$false` (an expert contract that
+  allows merging). This aligns the plain fleet path with the expert path, where the brake was
+  already mechanical. The `-Relaunch` path receives the same default. Three new Pester tests
+  cover: default brakes, `-AllowMerge` opt-out, explicit `-StopAtPR:$false` honored.
+
 ## [0.34.0] - 2026-08-04
 
 **The pending queue, cleared by the tool's own expert mode.** All seven triaged issues on the

--- a/evidence/598.md
+++ b/evidence/598.md
@@ -1,0 +1,59 @@
+# Evidence — Issue #598: Fleet sessions launched with -Parallel -Launch merge their own PRs unreviewed
+
+<!-- [abios-evidence] issue=598 -->
+
+## What was done
+
+Added `Resolve-LaunchBrake` pure function to `Board-Work.ps1` that returns the effective brake
+flag for launched sessions. All `-Launch`, `-Fleet`, and `-Relaunch` paths now default to
+`$true` (stop at PR) unless `-AllowMerge` is explicitly passed.
+
+Files changed:
+- `plugins/agentic-board/scripts/Board-Work.ps1` — added `-AllowMerge` parameter, `Resolve-LaunchBrake` function, updated all three dispatch paths
+- `plugins/agentic-board/tests/Board-Work.Tests.ps1` — 5 new Pester tests for `Resolve-LaunchBrake`
+- `CHANGELOG.md` — [Unreleased] entry
+
+## Gate: tests
+
+**Command:**
+```
+Invoke-Pester plugins/agentic-board/tests/Board-Work.Tests.ps1 -FullNameFilter '*Resolve-LaunchBrake*' -Output Detailed
+```
+
+**Result (new tests — red-to-green verified):**
+```
+Describing Resolve-LaunchBrake - all fleet sessions brake on merge by default (#598)
+  [+] brakes when no flags are given (the new safe default for plain -Parallel -Launch)
+  [+] -AllowMerge $true opts out of the brake explicitly
+  [+] honours an explicit -StopAtPR:$true even without -AllowMerge
+  [+] honours an explicit -StopAtPR:$false (an expert contract that allows merging)
+  [+] -AllowMerge wins over an explicit -StopAtPR:$true
+Tests Passed: 5, Failed: 0
+```
+
+**Red-before-green verified:** Tests were added BEFORE the implementation. First run yielded
+`CommandNotFoundException: The term 'Resolve-LaunchBrake' is not recognized` — 5 failures.
+After implementation: 5 passes.
+
+## Gate: full suite (regression check)
+
+**Command:**
+```
+Invoke-Pester plugins/agentic-board/tests/Board-Work.Tests.ps1 -Output Normal
+```
+
+**Result:** See PR comment for full output. No regressions introduced.
+
+## Gate: raw-gh lint
+
+No new bare `gh` calls added. `Board-Work.ps1` baseline remains 8.
+
+## Behavior change summary
+
+| Before | After |
+|--------|-------|
+| `-Parallel -Launch` without expert contract → merge step in briefing, no brake marker | `-Parallel -Launch` → brake ARMED by default (`stop at PR`), merge step suppressed |
+| `-Fleet` sessions could merge autonomously | `-Fleet` sessions stop at reviewed PR by default |
+| `-Relaunch` inherited `$StopAtPR` which defaulted `$false` | `-Relaunch` now also defaults to braked |
+| Expert path: braked via contract | Expert path: unchanged (still braked via contract) |
+| No opt-out path existed | `-AllowMerge` is the explicit opt-in for autonomous merging |

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -168,7 +168,12 @@ param(
     [switch]$TakeOver,
     # Irreversible brake (#440): brief the launched session to stop at a reviewed PR instead of
     # ordering the merge. Set by /expert auto when the contract marks `merge` as irreversible.
+    # When neither -StopAtPR nor -AllowMerge is specified, Resolve-LaunchBrake brakes by default (#598).
     [switch]$StopAtPR,
+    # Explicit opt-in to autonomous merging (#598). A launched session NEVER merges on its own
+    # unless the human passes this flag — the default is to stop at a reviewed PR. Pass
+    # -AllowMerge only when a fully autonomous close is intentional and the issue has been reviewed.
+    [switch]$AllowMerge,
     # Path to the full brief for the launched session (e.g. .agentic-board/expert-brief-<n>.md),
     # which it is told to read first and treat as overriding the generic steps.
     [string]$BriefFile     = "",
@@ -1013,6 +1018,25 @@ query($o:String!, $r:String!, $n:Int!) {
 # Parallel session launcher (mode 5 -Launch): one visible Claude session per
 # worktree, each briefed to work its own issue end-to-end.
 # ==============================================================================
+
+# Compute the effective brake for a launched session (#598).
+# All launched sessions stop at a reviewed PR by default — a session that merges its
+# own PR has no human review and the board has no safety check on the result (proven on
+# 2026-08-03: two sessions merged unreviewed, one shipped a DoD item it had not built).
+# -AllowMerge is the explicit opt-in for autonomous merging; -StopAtPR:$false from an
+# expert contract that allows merging is also honoured. -AllowMerge beats everything.
+# Pure (no side effects) -> unit-testable. Called from the -Launch and -Fleet paths.
+function Resolve-LaunchBrake {
+    param(
+        [bool]$AllowMerge,
+        # Was -StopAtPR explicitly bound by the caller? ($PSBoundParameters.ContainsKey('StopAtPR'))
+        [bool]$StopAtPRBound,
+        [bool]$StopAtPR
+    )
+    if ($AllowMerge) { return $false }
+    if ($StopAtPRBound) { return $StopAtPR }
+    return $true    # default: brake for every fleet/launch session (#598)
+}
 
 # The one-line first message a spawned Claude session receives. Pure -> testable.
 # -Cli is threaded (default 'claude') so Phase-2 adapters can specialize the leading
@@ -2226,7 +2250,9 @@ if ($Relaunch -gt 0) {
     $oauthPresent = [bool][System.Environment]::GetEnvironmentVariable('CLAUDE_CODE_OAUTH_TOKEN','User')
     $authVar      = Resolve-ClaudeAuthVar $PSBoundParameters.ContainsKey('ClaudeAuthVar') $ClaudeAuthVar $oauthPresent
     $marker       = New-FleetSessionMarker $Relaunch (New-FleetRunId)
-    $spawn = Start-WorktreeSession -IssueNum $Relaunch -Repo $sess.repo -Branch $sess.branch -WorkPath $sess.workPath -ClaudeAuthVar $authVar -Cli $cli -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
+    $relaunchBrake = Resolve-LaunchBrake -AllowMerge ([bool]$AllowMerge) `
+        -StopAtPRBound $PSBoundParameters.ContainsKey('StopAtPR') -StopAtPR ([bool]$StopAtPR)
+    $spawn = Start-WorktreeSession -IssueNum $Relaunch -Repo $sess.repo -Branch $sess.branch -WorkPath $sess.workPath -ClaudeAuthVar $authVar -Cli $cli -FleetSession $marker -StopAtPR:$relaunchBrake -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
     # Start-WorktreeSession returns $null on a failed/missing-worktree spawn. Registering
     # then would fall back to the coordinator PID and poison the registry - so only record a
     # session that actually launched.
@@ -2757,6 +2783,13 @@ if ($Parallel.Count -gt 0) {
         }
     }
 
+    # All -Launch/-Fleet sessions arm the brake by default (#598). -AllowMerge is the
+    # explicit opt-in for autonomous merging; an expert contract that allows merging
+    # is honoured via an explicit -StopAtPR:$false. See Resolve-LaunchBrake for the logic.
+    $launchBrake = Resolve-LaunchBrake -AllowMerge ([bool]$AllowMerge) `
+        -StopAtPRBound $PSBoundParameters.ContainsKey('StopAtPR') `
+        -StopAtPR ([bool]$StopAtPR)
+
     # -- Launch: one visible session per worktree. -Fleet probes CLIs and picks one
     # per issue (fallback claude); plain -Launch keeps the shipped claude-only path.
     # -Fleet TAKES OVER the launch (elseif), so the two never both spawn in one run.
@@ -2823,7 +2856,7 @@ if ($Parallel.Count -gt 0) {
                 $marker    = New-FleetSessionMarker $entry.issue $runId
                 $spawn = Start-WorktreeSession -IssueNum $entry.issue -Repo $entry.repo -Branch $entry.branch `
                                                -WorkPath $entry.workPath -ClaudeAuthVar $ClaudeAuthVar -Cli $actualCli -FleetSession $marker `
-                                               -StopAtPR:$StopAtPR -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
+                                               -StopAtPR:$launchBrake -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
                 $via = if ($spawn.usesWt) { "wt" } else { "pwsh" }
                 if ($spawn.process -and -not $spawn.usesWt) {
                     Write-SessionRegistryEntry -IssueNum $entry.issue -SessionPid $spawn.process.Id -Via $via -Cli $actualCli -FleetSession $marker
@@ -2837,7 +2870,8 @@ if ($Parallel.Count -gt 0) {
             # -MaxConcurrent (0 = capacity-only) caps how many run at once.
             $dispatched = @(Invoke-FleetDispatch -Queue $fleetPlan -NoQuotaClis $noQuota -LaunchSession $launchHook -MaxConcurrent $MaxConcurrent)
             Write-Host ""
-            Write-Host ("Fleet lanzada: {0} sesion(es) en oleadas por capacidad (fallback claude)." -f $dispatched.Count) -ForegroundColor Yellow
+            $fleetBrakeMsg = if ($launchBrake) { "freno ARMADO (sesiones paran en el PR listo)." } else { "ATENCION: freno desarmado con -AllowMerge." }
+            Write-Host ("Fleet lanzada: {0} sesion(es) en oleadas por capacidad (fallback claude). {1}" -f $dispatched.Count, $fleetBrakeMsg) -ForegroundColor Yellow
         }
     } elseif ($Launch) {
         Write-Host ""
@@ -2856,7 +2890,7 @@ if ($Parallel.Count -gt 0) {
                 # New-IssueWorktree / Get-IssueWorktreePath - the grouped-worktree layout).
                 $previewPath = Get-IssueWorktreePath $r.repo $r.issue (Split-Path (Get-Location) -Parent)
                 $marker = New-FleetSessionMarker $r.issue $runId
-                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile -Preview | Out-Null
+                Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $previewPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$launchBrake -BriefFile $BriefFile -Preview | Out-Null
             }
         } else {
             Write-Host "----- LANZANDO SESIONES CLAUDE -----" -ForegroundColor Cyan
@@ -2883,7 +2917,7 @@ if ($Parallel.Count -gt 0) {
             foreach ($r in $started) {
                 if ($r.workPath) {
                     $marker = New-FleetSessionMarker $r.issue $runId
-                    $spawn = Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $r.workPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$StopAtPR -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
+                    $spawn = Start-WorktreeSession -IssueNum $r.issue -Repo $r.repo -Branch $r.branch -WorkPath $r.workPath -ClaudeAuthVar $ClaudeAuthVar -FleetSession $marker -StopAtPR:$launchBrake -BriefFile $BriefFile -Irreversible $Irreversible -EndToEnd:$EndToEnd -SessionBudgetMinutes $BudgetMinutes
                     $launched++
                     # Track the spawned session's own PID (pwsh window is reliable; a wt
                     # launcher forks and exits, so keep the host PID there).
@@ -2896,7 +2930,8 @@ if ($Parallel.Count -gt 0) {
                 }
             }
             Write-Host ""
-            Write-Host ("Lanzadas: {0} sesion(es). Cada una trabaja su issue hasta el PR + review gate." -f $launched) -ForegroundColor Yellow
+            $brakeMsg = if ($launchBrake) { "el freno esta ARMADO: las sesiones paran en el PR listo (no mergean solas)." } else { "ATENCION: freno desarmado con -AllowMerge - las sesiones PUEDEN mergear autonomamente." }
+            Write-Host ("Lanzadas: {0} sesion(es). {1}" -f $launched, $brakeMsg) -ForegroundColor Yellow
         }
     }
 

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -568,6 +568,26 @@ Describe 'Resolve-ClaudeAuthVar' {
     }
 }
 
+Describe 'Resolve-LaunchBrake — all fleet sessions brake on merge by default (#598)' {
+    It 'brakes when no flags are given (the new safe default for plain -Parallel -Launch)' {
+        Resolve-LaunchBrake -AllowMerge $false -StopAtPRBound $false -StopAtPR $false | Should -BeTrue
+    }
+    It '-AllowMerge $true opts out of the brake explicitly' {
+        Resolve-LaunchBrake -AllowMerge $true -StopAtPRBound $false -StopAtPR $false | Should -BeFalse
+    }
+    It 'honours an explicit -StopAtPR:$true even without -AllowMerge' {
+        Resolve-LaunchBrake -AllowMerge $false -StopAtPRBound $true -StopAtPR $true | Should -BeTrue
+    }
+    It 'honours an explicit -StopAtPR:$false (an expert contract that allows merging)' {
+        # Expert-Auto.ps1 passes -StopAtPR:$false when the contract does not mark merge irreversible.
+        # That explicit opt-out must be respected; the default brake must not override it.
+        Resolve-LaunchBrake -AllowMerge $false -StopAtPRBound $true -StopAtPR $false | Should -BeFalse
+    }
+    It '-AllowMerge wins over an explicit -StopAtPR:$true' {
+        Resolve-LaunchBrake -AllowMerge $true -StopAtPRBound $true -StopAtPR $true | Should -BeFalse
+    }
+}
+
 Describe 'Build-WorktreeLaunch' {
     It 'builds a Windows Terminal tab command when wt is present' {
         Mock Get-Command -ParameterFilter { $Name -eq 'wt' } -MockWith { [pscustomobject]@{ Name = 'wt' } }


### PR DESCRIPTION
## Summary

Arm the irreversible brake for ALL fleet sessions, not just the expert path (#598).

**Root cause**: `-Parallel -Launch` sessions were briefed to call `Board-Merge.ps1` and no
brake marker was written to their worktree. On 2026-08-03, two such sessions merged their
own PRs with zero reviews; post-merge audit found that one had not built the central DoD item.

**Fix**: Added `Resolve-LaunchBrake` pure function to `Board-Work.ps1`. All dispatch paths
(`-Launch`, `-Fleet`, `-Relaunch`) now default to `StopAtPR=$true` unless the caller passes
`-AllowMerge` (explicit opt-in). An expert contract that explicitly allows merging is still
honoured via `-StopAtPR:$false`.

## Changes

- `Board-Work.ps1`: `-AllowMerge` switch parameter + `Resolve-LaunchBrake` pure function +
  updated all three dispatch paths (`-Launch`, `-Fleet`, `-Relaunch`) to default to braked
- `Board-Work.Tests.ps1`: 5 new Pester tests (red-before-green verified)
- `CHANGELOG.md`: [Unreleased] entry
- `evidence/598.md`: full structured evidence

## Evidence

<!-- [abios-evidence] issue=598 -->
Tests: 327 passed, 0 failed (Board-Work.Tests.ps1). Raw-gh lint: 2 passed, baseline unchanged.
Red-before-green: 5 tests failed before implementation, 5 passed after.
Full evidence: [evidence/598.md](evidence/598.md)

## Test plan

- [x] `Resolve-LaunchBrake` default: returns `$true` (brake on) when no flags given
- [x] `-AllowMerge` returns `$false` (no brake)
- [x] Explicit `-StopAtPR:$false` honoured (expert contract that allows merge)
- [x] `-AllowMerge` beats explicit `-StopAtPR:$true`
- [x] Full Board-Work.Tests.ps1 suite: 327 passed, 0 failed
- [x] RawGh.Lint.Tests.ps1: 2 passed, baseline unchanged

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
