### PR TITLE
Board-Triage is single-repo: cross-repo items invisible, and colliding issue numbers write to the wrong issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Board-Triage now works correctly on multi-repo boards — cross-repo items visible, number collisions refused** (#506).
+  Two silent defects on boards that hold issues from several repositories: (1) `-Pending` sorted and
+  displayed items by bare `#number` with no repo context, making cross-repo items indistinguishable
+  and colliding numbers invisible; (2) a bare `-Issue <n>` matched against the first item with that
+  number — which was always the linked repo's — so triage writes landed on the wrong issue with a
+  success message naming a completely different title. Three new pure functions fix this: `Resolve-IssueRef`
+  parses `-Issue` as a bare number OR a qualified `owner/repo#n`; `Find-TriageItems` matches by
+  repo+number when qualified, or returns ALL same-number candidates when bare; `Format-ItemRef`
+  renders the canonical `owner/repo#number` reference. The `-Pending` display now groups items by
+  repo and shows the full reference for every item. When a bare `-Issue <n>` would write to more
+  than one board item, the script refuses and lists the candidates — silent writes to the wrong issue
+  are structurally impossible. A new `-Repo` parameter lets callers qualify a bare number without
+  rewriting existing scripts that already pass plain integers. 11 new Pester tests cover
+  `Resolve-IssueRef` (bare, qualified, -Repo, conflict detection), `Find-TriageItems` (single-repo,
+  multi-repo, collision, not-found), and `Format-ItemRef` (with and without repo).
+
 ### Added
 - **A closing summary every flow can end with — four blocks, always the same four** (#492, epic #491).
   Reported first-hand by the product owner, a BI professional and not a programmer: every command

--- a/evidence/506.md
+++ b/evidence/506.md
@@ -1,0 +1,66 @@
+# Evidence — #506 Board-Triage cross-repo fix
+
+[abios-evidence]
+
+## What was tested
+
+Three new pure helper functions added to `Board-Triage.ps1` to fix two silent defects on
+multi-repo boards:
+
+1. `Resolve-IssueRef` — parses `-Issue` as bare number, `owner/repo#n`, or bare + `-Repo`
+2. `Find-TriageItems` — matches items by repo+number (qualified) or number only (bare, may collide)
+3. `Format-ItemRef` — renders canonical `owner/repo#number` for display
+
+Plus Mode 1 (`-Pending`) now displays full repo references and sorts by repo+number, and
+Mode 2/3 refuses ambiguous bare numbers instead of silently writing the wrong item.
+
+## Test evidence
+
+### Board-Triage unit tests — 25/25 PASS
+
+Command:
+```
+Invoke-Pester plugins/agentic-board/tests/Board-Triage.Tests.ps1 -PassThru
+```
+
+Result:
+```
+Tests Passed: 25, Failed: 0, Skipped: 0
+```
+
+New tests added (11):
+- `Resolve-IssueRef`: bare number, qualified form, -Repo qualifier, same-repo accepted, conflict throws, invalid throws
+- `Find-TriageItems`: qualified match, other repo match, bare single, bare collision, not found
+- `Format-ItemRef`: with repo, without repo
+
+### RawGh lint — 2/2 PASS (no new bare gh calls)
+
+Command:
+```
+Invoke-Pester plugins/agentic-board/tests/RawGh.Lint.Tests.ps1 -PassThru
+```
+
+Result:
+```
+Tests Passed: 2, Failed: 0, Skipped: 0
+```
+
+### Script parse (84 scripts) — 84/84 PASS
+
+Command:
+```
+Invoke-Pester plugins/agentic-board/tests/Scripts.Parse.Tests.ps1 -PassThru
+```
+
+Result:
+```
+Tests Passed: 84, Failed: 0, Skipped: 0
+```
+
+## Key decisions
+
+- Changed `-Issue` from `[int]` to `[string]` — backward compatible (bare `"42"` works the same as old `42`)
+- Added `-Repo` parameter for single-repo callers that cannot rewrite to `owner/repo#n` form
+- Ambiguity is structural: `Find-TriageItems` returns ALL candidates; caller refuses if count > 1
+- `Format-ItemRef` always shows repo when `content.repository` is set; falls back to `#number` for DraftIssues
+- Existing `Format-PriorityProposal` signature unchanged; caller passes `$issueRef.Number` (int)

--- a/plugins/agentic-board/scripts/Board-Triage.ps1
+++ b/plugins/agentic-board/scripts/Board-Triage.ps1
@@ -20,17 +20,26 @@
       ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Pending
 
       # 2. Write the evidence fields the agent inferred for ONE issue:
+      #    Single-repo board: bare number is unambiguous
       ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 42 -Type Bug -Area scripts -Estimate 3
+      #    Multi-repo board: qualify with owner/repo#n or -Repo to avoid number collision (#506)
+      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 'owner/repo#42' -Type Bug -Area scripts -Estimate 3
+      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 42 -Repo owner/repo -Type Bug -Area scripts -Estimate 3
 
       # 3. Priority — proposal only (prints, writes nothing) unless -ConfirmPriority:
-      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 42 -Priority P1 -Rationale 'blocks the release'
-      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 42 -Priority P1 -Rationale '...' -ConfirmPriority
+      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 'owner/repo#42' -Priority P1 -Rationale 'blocks the release'
+      ./Board-Triage.ps1 -Number 13 -Owner CSalcedoDataBI -Issue 'owner/repo#42' -Priority P1 -Rationale '...' -ConfirmPriority
 #>
 [CmdletBinding()]
 param(
   [int]   $Number     = 13,
   [string]$Owner      = 'CSalcedoDataBI',
-  [int]   $Issue      = 0,
+  # Accept bare number ("42") or qualified "owner/repo#42"; use -Repo to disambiguate bare numbers
+  # on multi-repo boards (#506). Empty string = -Pending / batch-view mode.
+  [string]$Issue      = '',
+  # Explicit repo qualifier. Combined with a bare -Issue number it produces a qualified ref that
+  # targets exactly one item even when the same number exists in several repos (#506).
+  [string]$Repo       = '',
   [switch]$Pending,
   [string]$Type,
   [string]$Area,
@@ -100,6 +109,62 @@ function Get-TriageBoardPlan {
     return [pscustomobject]@{ ResolveFromOrigin = $false; Owner = $DefaultOwner; Number = 0; Reason = 'no-origin' }
 }
 
+# Parse an issue reference (bare number OR "owner/repo#n") and an optional -Repo qualifier.
+# Returns { Repo; Number; Qualified } or throws on invalid/conflicting input.
+# Qualified = $true  -> exact match by repo+number (safe on multi-repo boards).
+# Qualified = $false -> bare number; caller must detect and refuse ambiguous collisions.
+# Pure (#506).
+function Resolve-IssueRef {
+    param([string]$IssueArg, [string]$ExplicitRepo)
+
+    # Qualified form: "owner/repo#number"
+    if ($IssueArg -match '^([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)#(\d+)$') {
+        $repo   = $Matches[1]
+        $number = [int]$Matches[2]
+        if ($ExplicitRepo -and $ExplicitRepo -ne $repo) {
+            throw "-Issue qualifies '$repo' but -Repo says '$ExplicitRepo': use one, not both."
+        }
+        return [pscustomobject]@{ Repo = $repo; Number = $number; Qualified = $true }
+    }
+
+    # Bare number form
+    if ($IssueArg -match '^\d+$') {
+        $number = [int]$IssueArg
+        $r      = "$ExplicitRepo".Trim()
+        return [pscustomobject]@{ Repo = $r; Number = $number; Qualified = ($r -ne '') }
+    }
+
+    throw "-Issue '$IssueArg' is not a valid issue reference. Use a bare number (42) or 'owner/repo#42'."
+}
+
+# Find board items matching an issue ref. Returns ALL candidates.
+# Qualified ref -> filter by repo+number (unambiguous).
+# Bare ref      -> filter by number only; may return >1 if repos collide — caller must refuse.
+# Pure (#506).
+function Find-TriageItems {
+    param(
+        [Parameter(Mandatory)][object]  $Ref,
+        [Parameter(Mandatory)][object[]]$Items
+    )
+    if ($Ref.Qualified) {
+        return @($Items | Where-Object {
+            [int]$_.content.number -eq $Ref.Number -and
+            "$($_.content.repository)" -eq $Ref.Repo
+        })
+    }
+    return @($Items | Where-Object { [int]$_.content.number -eq $Ref.Number })
+}
+
+# Format an item's canonical reference including its repo for display.
+# Without a repo (e.g. DraftIssues) falls back to bare #number. Pure (#506).
+function Format-ItemRef {
+    param([Parameter(Mandatory)][object]$Item)
+    $repo = "$($Item.content.repository)".Trim()
+    $num  = [int]$Item.content.number
+    if ($repo) { return "$repo#$num" }
+    return "#$num"
+}
+
 # Dot-source guard: tests set $env:ABIOS_TRIAGE_DOTSOURCE to load the pure helpers only.
 if ($env:ABIOS_TRIAGE_DOTSOURCE) { return }
 
@@ -162,7 +227,7 @@ function Get-ItemTriageValues($item) {
 }
 
 # ── Mode 1: batch view of the pending items and their triage gaps ─────────────
-if ($Issue -le 0) {
+if (-not $Issue.Trim()) {
     $pendingStatuses = @('Backlog', 'In Progress', 'Todo', 'To Do')   # legacy names included
     $pend = @($items | Where-Object { $pendingStatuses -contains "$($_.status)" -and $_.content.number })
     Write-Host "=== Triage: pendientes del board #$Number de $Owner ===" -ForegroundColor Cyan
@@ -177,27 +242,53 @@ if ($Issue -le 0) {
     if ($itemTrunc) { Write-Host "  $itemTrunc" -ForegroundColor Yellow }
     Write-Host ("  {0}{1} item(s) pendiente(s). Faltantes marcados con []." -f $pend.Count, $(if ($itemTrunc) { '+' } else { '' })) -ForegroundColor DarkGray
     Write-Host ""
-    foreach ($it in ($pend | Sort-Object { [int]$_.content.number })) {
+    # Sort by repo then number so multi-repo boards group items by origin repository (#506).
+    foreach ($it in ($pend | Sort-Object { "$($_.content.repository)-{0:D10}" -f [int]$_.content.number })) {
         $v    = Get-ItemTriageValues $it
         $gaps = Get-TriageGaps $v
         $cell = { param($n) if ("$($v[$n])".Trim()) { "$n=$($v[$n])" } else { "[$n]" } }
         $prio = if ("$($v['Priority'])".Trim()) { "Priority=$($v['Priority'])" } else { "[Priority?]" }
-        Write-Host ("  #{0,-4} {1}" -f $it.content.number, $it.content.title)
+        # Always include repo so cross-repo items are visible and number collisions obvious (#506).
+        $ref  = Format-ItemRef $it
+        Write-Host ("  {0,-30} {1}" -f $ref, $it.content.title)
         Write-Host ("        {0}  {1}  {2}  {3}" -f (& $cell 'Type'), (& $cell 'Area'), (& $cell 'Estimate'), $prio) -ForegroundColor $(if ($gaps.Count) { 'DarkYellow' } else { 'DarkGreen' })
     }
     Write-Host ""
     Write-Host "  Evidence (Type/Area/Estimate): el agente los infiere del contenido y los escribe:" -ForegroundColor DarkGray
-    Write-Host "    Board-Triage.ps1 -Number $Number -Owner $Owner -Issue <n> -Type <t> -Area <a> -Estimate <n>" -ForegroundColor DarkGray
+    Write-Host "    Board-Triage.ps1 -Number $Number -Owner $Owner -Issue 'owner/repo#<n>' -Type <t> -Area <a> -Estimate <n>" -ForegroundColor DarkGray
+    Write-Host "    Board-Triage.ps1 -Number $Number -Owner $Owner -Issue <n> -Repo owner/repo -Type <t> ...  (alternativa)" -ForegroundColor DarkGray
+    Write-Host "    (En boards de un solo repo, -Issue <n> bare funciona si no hay colision de numero)" -ForegroundColor DarkGray
     Write-Host "  Priority: el agente PROPONE (con razon) y el usuario confirma — nunca en silencio:" -ForegroundColor DarkGray
-    Write-Host "    Board-Triage.ps1 -Number $Number -Owner $Owner -Issue <n> -Priority P2 -Rationale '...'  [-ConfirmPriority]" -ForegroundColor DarkGray
+    Write-Host "    Board-Triage.ps1 -Number $Number -Owner $Owner -Issue 'owner/repo#<n>' -Priority P2 -Rationale '...'  [-ConfirmPriority]" -ForegroundColor DarkGray
     Write-Host "Board: $boardUrl" -ForegroundColor Cyan
     exit 0
 }
 
 # ── Mode 2/3: one issue — write evidence fields, propose/confirm Priority ──────
-$item = $items | Where-Object { [int]$_.content.number -eq $Issue } | Select-Object -First 1
-if (-not $item) { throw "El issue #$Issue no esta en el board #$Number (agregalo con /board add, o /board fill)." }
-Write-Host ("=== Triage #{0}: {1} ===" -f $Issue, $item.content.title) -ForegroundColor Cyan
+
+# Resolve the -Issue string (bare or qualified) and find the matching board item(s) (#506).
+$issueRef    = Resolve-IssueRef -IssueArg $Issue -ExplicitRepo $Repo
+$itemMatches = Find-TriageItems -Ref $issueRef -Items $items
+
+if (-not $itemMatches) {
+    $refStr = if ($issueRef.Repo) { "$($issueRef.Repo)#$($issueRef.Number)" } else { "#$($issueRef.Number)" }
+    throw "El issue $refStr no esta en el board #$Number (agregalo con /board add, o /board fill)."
+}
+
+if ($itemMatches.Count -gt 1) {
+    # Number collision across repos — refuse and list the ambiguous candidates so the operator
+    # can qualify the target with 'owner/repo#n' or -Repo (#506 symptom 2).
+    $candidateList = ($itemMatches | ForEach-Object {
+        "    $(Format-ItemRef $_): $($_.content.title)"
+    }) -join "`n"
+    throw (
+        "Numero ambiguo: #{0} existe en {1} repos del board. Califica el target con 'owner/repo#{0}' o -Repo:`n{2}" -f
+        $issueRef.Number, $itemMatches.Count, $candidateList
+    )
+}
+
+$item = $itemMatches[0]
+Write-Host ("=== Triage {0}: {1} ===" -f (Format-ItemRef $item), $item.content.title) -ForegroundColor Cyan
 
 # Set one field on this item, picking the write flag from the field's type. Fails loud.
 function Set-ItemField([string]$name, [string]$value) {
@@ -214,7 +305,7 @@ function Set-ItemField([string]$name, [string]$value) {
     } else {
         $editArgs += @('--text', $value)
     }
-    $null = Invoke-Gh -GhArgs $editArgs -What "escribir $name en #$Issue" -Retries 3
+    $null = Invoke-Gh -GhArgs $editArgs -What "escribir $name en $(Format-ItemRef $item)" -Retries 3
     Write-Host ("  OK  {0} -> {1}" -f $name, $value) -ForegroundColor Green
     return $true
 }
@@ -230,7 +321,7 @@ if ($Estimate) { $wroteEvidence = (Set-ItemField 'Estimate' $Estimate) -or $wrot
 if ($Priority) {
     Write-Host ""
     Write-Host "  Propuesta de Priority (juicio de negocio - requiere confirmacion):" -ForegroundColor Yellow
-    Write-Host (Format-PriorityProposal -IssueNum $Issue -Priority $Priority -Rationale $Rationale)
+    Write-Host (Format-PriorityProposal -IssueNum $issueRef.Number -Priority $Priority -Rationale $Rationale)
     if ($ConfirmPriority) {
         $ok = Set-ItemField 'Priority' $Priority
         if ($ok -and -not $DryRun) { Write-Host "  OK  Priority confirmada y escrita." -ForegroundColor Green }

--- a/plugins/agentic-board/tests/Board-Triage.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Triage.Tests.ps1
@@ -75,3 +75,82 @@ Describe 'Get-TriageBoardPlan — never default to the tool board from a foreign
         $p.Reason            | Should -Be 'no-origin'
     }
 }
+
+Describe 'Resolve-IssueRef — parse -Issue argument into repo+number (#506)' {
+    It 'bare number returns unqualified ref with empty repo' {
+        $r = Resolve-IssueRef -IssueArg '42' -ExplicitRepo ''
+        $r.Number    | Should -Be 42
+        $r.Repo      | Should -Be ''
+        $r.Qualified | Should -BeFalse
+    }
+    It 'qualified form owner/repo#n returns exact repo+number' {
+        $r = Resolve-IssueRef -IssueArg 'owner/repoA#42' -ExplicitRepo ''
+        $r.Number    | Should -Be 42
+        $r.Repo      | Should -Be 'owner/repoA'
+        $r.Qualified | Should -BeTrue
+    }
+    It 'bare number with -ExplicitRepo returns qualified ref' {
+        $r = Resolve-IssueRef -IssueArg '42' -ExplicitRepo 'owner/repoA'
+        $r.Number    | Should -Be 42
+        $r.Repo      | Should -Be 'owner/repoA'
+        $r.Qualified | Should -BeTrue
+    }
+    It 'qualified form matching -ExplicitRepo is accepted (same repo)' {
+        $r = Resolve-IssueRef -IssueArg 'owner/repoA#42' -ExplicitRepo 'owner/repoA'
+        $r.Repo | Should -Be 'owner/repoA'
+    }
+    It 'qualified form conflicting with -ExplicitRepo throws' {
+        { Resolve-IssueRef -IssueArg 'owner/repoA#42' -ExplicitRepo 'owner/repoB' } | Should -Throw
+    }
+    It 'invalid input throws' {
+        { Resolve-IssueRef -IssueArg 'not-valid' -ExplicitRepo '' } | Should -Throw
+    }
+}
+
+Describe 'Find-TriageItems — locate board items by issue ref (#506)' {
+    BeforeAll {
+        $script:ItemA5  = [pscustomobject]@{ id = 'PVTI_aa'; content = [pscustomobject]@{ number = 5; repository = 'owner/repoA'; title = 'Bug in A' }; status = 'Backlog' }
+        $script:ItemB5  = [pscustomobject]@{ id = 'PVTI_bb'; content = [pscustomobject]@{ number = 5; repository = 'owner/repoB'; title = 'Bug in B' }; status = 'Backlog' }
+        $script:ItemA10 = [pscustomobject]@{ id = 'PVTI_cc'; content = [pscustomobject]@{ number = 10; repository = 'owner/repoA'; title = 'Feature in A' }; status = 'In Progress' }
+        $script:Items   = @($script:ItemA5, $script:ItemB5, $script:ItemA10)
+    }
+    It 'qualified ref returns only the matching repo item' {
+        $ref  = [pscustomobject]@{ Repo = 'owner/repoA'; Number = 5; Qualified = $true }
+        $hits = Find-TriageItems -Ref $ref -Items $script:Items
+        $hits.Count        | Should -Be 1
+        $hits[0].id        | Should -Be 'PVTI_aa'
+    }
+    It 'qualified ref for the other repo returns that repo item only' {
+        $ref  = [pscustomobject]@{ Repo = 'owner/repoB'; Number = 5; Qualified = $true }
+        $hits = Find-TriageItems -Ref $ref -Items $script:Items
+        $hits.Count        | Should -Be 1
+        $hits[0].id        | Should -Be 'PVTI_bb'
+    }
+    It 'bare ref matching one item returns that single item' {
+        $ref  = [pscustomobject]@{ Repo = ''; Number = 10; Qualified = $false }
+        $hits = Find-TriageItems -Ref $ref -Items $script:Items
+        $hits.Count        | Should -Be 1
+        $hits[0].id        | Should -Be 'PVTI_cc'
+    }
+    It 'bare ref with number collision returns both candidates (caller must refuse)' {
+        $ref  = [pscustomobject]@{ Repo = ''; Number = 5; Qualified = $false }
+        $hits = Find-TriageItems -Ref $ref -Items $script:Items
+        $hits.Count | Should -Be 2
+    }
+    It 'returns empty array when no item matches' {
+        $ref  = [pscustomobject]@{ Repo = 'owner/repoA'; Number = 99; Qualified = $true }
+        $hits = Find-TriageItems -Ref $ref -Items $script:Items
+        $hits.Count | Should -Be 0
+    }
+}
+
+Describe 'Format-ItemRef — display canonical owner/repo#number (#506)' {
+    It 'includes repo when content.repository is present' {
+        $item = [pscustomobject]@{ content = [pscustomobject]@{ repository = 'owner/repoA'; number = 42 } }
+        Format-ItemRef -Item $item | Should -Be 'owner/repoA#42'
+    }
+    It 'falls back to bare #number when content.repository is empty' {
+        $item = [pscustomobject]@{ content = [pscustomobject]@{ repository = ''; number = 7 } }
+        Format-ItemRef -Item $item | Should -Be '#7'
+    }
+}


### PR DESCRIPTION
Closes #506

## Summary

Board-Triage now works correctly on multi-repo boards. Fixed two silent defects:

1. **`-Pending` cross-repo items invisible** — display now shows `owner/repo#number` for every item and sorts by repo so colliding numbers are obvious.
2. **Bare `-Issue <n>` writes the wrong item** — when a bare number matches more than one board item, the script refuses and lists the candidates. Silent misdirected writes are structurally impossible.

Three new pure helpers: `Resolve-IssueRef`, `Find-TriageItems`, `Format-ItemRef`. New `-Repo` parameter for callers that cannot switch to the qualified `owner/repo#n` form.

## Evidence

[abios-evidence] 25 Pester tests pass (11 new), RawGh lint clean, all CI green. Full record: [evidence/506.md](https://github.com/CSalcedoDataBI/agentic-board/blob/issue-506-board-triage-is-single-repo-cross-repo/evidence/506.md)