### PR TITLE
fix(expert): a run can be fully green on its DoD while every factual claim in its deliverable is invented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## [Unreleased]
 
 ### Added
+- **Claims verification gate for expert deliverables — the evidence contract now covers external facts, not just tests** (#479).
+  An autonomous `/expert auto` run could produce fully green DoD evidence while every factual claim
+  in its deliverable was invented: five fabrications (package name, auth mechanism, CLI flag, two
+  API tools) reached `main` on `csalcedodatabi.com` because the evidence block recorded that tests
+  passed, not whether the claimed facts existed. `Expert-ClaimsGate.ps1` closes that gap: when a
+  deliverable asserts external facts, each claim is registered as *verified* (looked up; records how
+  and what was found), *unverified* (explicitly acknowledged as unchecked — visible, not hidden), or
+  *not-applicable* (the deliverable makes no external claims). `Test-ClaimsGate` fails the gate when
+  a verified claim does not resolve (`correct=$false`); `Format-ClaimsSection` renders three distinct
+  status labels (PASS / FAIL / UNVERIFIED) that never collapse. The expert brief now includes the
+  claims requirement: a document is a deliverable, and a deliverable needs a gate. The common case
+  (a code-only run, no external-claim deliverable) incurs no added friction — the gate is
+  not-applicable and costs nothing. 22 Pester tests cover all five issue tests including a
+  regression fixture from the five fabrications above: each one is caught.
+
 - **A closing summary every flow can end with — four blocks, always the same four** (#492, epic #491).
   Reported first-hand by the product owner, a BI professional and not a programmer: every command
   ends however its author felt like ending it, so there is no fixed place to look for the only four

--- a/evidence/479.md
+++ b/evidence/479.md
@@ -1,0 +1,37 @@
+<!-- [abios-evidence] -->
+## Evidence
+
+**Issue:** #479 fix(expert): a run can be fully green on its DoD while every factual claim in its deliverable is invented
+
+**Summary:** 22 passed / 0 failed
+
+| Test | Command | Result | Detail |
+| --- | --- | --- | --- |
+| T1: npm 404 is flagged | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | verified+correct=false → gateStatus=claims-failed, pass=false |
+| T1: CLI flag missing is flagged | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | --auth verified+wrong → flagged, pass=false |
+| T1: gateStatus=claims-failed | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | gateStatus correctly set |
+| T2: all verified+correct passes | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | 2 claims all correct → pass=true, flagged=0 |
+| T2: gateStatus=verified | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | gateStatus=verified when all pass |
+| T3: empty list is not-applicable | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | no claims → pass=true, gateStatus=not-applicable |
+| T3: no flagged claims on empty | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | flagged.Count=0 |
+| T3: null entry is still not-applicable | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | @($null) treated as empty |
+| T4: PASS and UNVERIFIED are distinct | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | distinct labels in rendered section |
+| T4: not-applicable rendered on empty | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | Format-ClaimsSection shows not-applicable |
+| T4: correct=true renders PASS | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | | PASS | in table |
+| T4: correct=false renders FAIL | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | | FAIL | in table |
+| T4: unverified renders UNVERIFIED | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | | UNVERIFIED | in table |
+| T4: never collapses all three | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | PASS+FAIL+UNVERIFIED all distinct |
+| T5: gate fails on five fabrications | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | all 5 as verified+wrong → pass=false |
+| T5: all 5 appear in flagged list | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | flagged.Count=5 |
+| T5: each fabrication flagged by name | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | all 5 claim names in flagged |
+| T5: all 5 render FAIL in section | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | 5 rows with | FAIL | |
+| T5: claim texts appear in section | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | @ahonn/mcp-server-gsc, list_sitemaps, get_sitemap visible |
+| unverified passes but has-unverified | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | unverified → pass=true, gateStatus=has-unverified |
+| gateStatus=has-unverified | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | correctly set |
+| verified+wrong beats unverified | Invoke-Pester Expert-ClaimsGate.Tests.ps1 | PASS | claims-failed takes precedence |
+| Expert-Auto brief unchanged (47 tests) | Invoke-Pester Expert-Auto.Tests.ps1 | PASS | 47/47 existing Expert-Auto tests pass |
+| RawGh lint | Invoke-Pester RawGh.Lint.Tests.ps1 | PASS | Expert-ClaimsGate.ps1 has no bare gh calls |
+
+## Claims
+
+**Status:** not-applicable — this run produced a PowerShell script and tests; no knowledge document with external claims was authored.

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -199,6 +199,21 @@ Build test-first. After each verify phase, record the structured [abios-evidence
 tested, the command, the result) ONCE in evidence/<issue>.md, and put the link stub (marker +
 summary + link) in the PR body and an issue comment - one source of truth, two pointers (#570).
 
+## Claims — external facts in deliverables need a gate (#479)
+A document is a deliverable, and a deliverable needs a gate. If this run produces a knowledge
+document, a reference guide, or any deliverable asserting external facts (a package exists, a CLI
+flag is supported, an API exposes specific tools), those claims must appear in the evidence block:
+
+  verified   — the run looked it up; record the command and what it found (correct=true/false)
+  unverified — explicitly acknowledged as unchecked; the gap is visible, not hidden
+  not-applicable — the deliverable makes no external claims; record this explicitly too
+
+Use ``Expert-ClaimsGate.ps1`` (``Format-ClaimsSection`` / ``Test-ClaimsGate``) to format and gate
+the claims. A verified claim that does not resolve (``correct=false``) fails the gate before the
+DoD goes green. Unverified claims are visible in the evidence block but do not block the DoD — the
+run explicitly acknowledged the gap. Runs producing no deliverables with external claims record
+``not-applicable`` and incur no added friction — the common case must not get slower or noisier.
+
 $closingSection
 "@
 }

--- a/plugins/agentic-board/scripts/Expert-ClaimsGate.ps1
+++ b/plugins/agentic-board/scripts/Expert-ClaimsGate.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+    Claims verification gate for /board expert deliverables (#479).
+
+.DESCRIPTION
+    Extends the evidence contract from "tests ran" to "claims were checked".
+
+    An autonomous run can produce fully green DoD evidence while every factual claim
+    in its deliverable is invented — the evidence block records test results, not claim
+    correctness. This gate closes that gap: when a deliverable asserts external facts
+    (a package exists, a CLI flag is supported, an API exposes specific tools), those
+    claims must appear in the evidence block as verified, unverified, or not-applicable.
+
+    A claim is one of three states:
+      verified   — the run looked it up; howChecked records the method, correct records the result
+      unverified — explicitly acknowledged as unchecked; the gap is visible, not hidden
+      not-applicable — the deliverable makes no external claims (empty claims list)
+
+    Gate logic (Test-ClaimsGate):
+      empty list             → not-applicable → pass (no friction for code-only runs)
+      all verified + correct → verified → pass
+      any verified + wrong   → claims-failed → FAIL (the DoD cannot go green silently)
+      any unverified         → has-unverified → pass (gap is visible in the evidence block)
+
+    Verified+wrong takes precedence over unverified when both are present.
+
+    Pure functions (Test-ClaimsGate, Format-ClaimsSection) behind
+    $env:ABIOS_EXPERTCLAIMSGATE_DOTSOURCE for unit tests without a network round-trip.
+
+.EXAMPLE
+    . .\Expert-ClaimsGate.ps1
+    $claims = @(
+        @{ claim='mcp-server-gsc'; kind='npm-package'; status='verified'; howChecked='npm view mcp-server-gsc'; correct=$true }
+    )
+    Test-ClaimsGate -Claims $claims
+    Format-ClaimsSection -Claims $claims
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+# ── Pure core ───────────────────────────────────────────────────────────────────
+
+<#
+    Evaluate the claims gate for a set of claim verification records.
+
+    Each record is a hashtable or PSObject with:
+      claim      (string)  — the claim text, e.g. '@ahonn/mcp-server-gsc'
+      kind       (string)  — npm-package | cli-flag | api-tool | auth-mechanism | other
+      status     (string)  — 'verified' | 'unverified'
+      howChecked (string)  — how it was looked up (e.g. 'npm view pkg')
+      correct    ($true/$false/$null) — $true=exists/correct, $false=wrong/404, $null=not checked
+
+    Returns @{ pass; gateStatus; flagged; summary }
+
+    gateStatus values:
+      not-applicable  — claims list is empty; the gate does not apply
+      verified        — all claims verified and all correct
+      has-unverified  — at least one claim is explicitly unverified (visible gap)
+      claims-failed   — at least one verified claim is incorrect (pass=$false)
+
+    Verified+wrong takes precedence over unverified when both are present.
+#>
+function Test-ClaimsGate {
+    param([object[]]$Claims = @())
+    $rows = @($Claims | Where-Object { $_ -ne $null })
+
+    if ($rows.Count -eq 0) {
+        return @{
+            pass       = $true
+            gateStatus = 'not-applicable'
+            flagged    = @()
+            summary    = 'No external claims — gate not applicable.'
+        }
+    }
+
+    $flagged = @($rows | Where-Object {
+        "$($_.status)" -eq 'verified' -and $_.correct -eq $false
+    } | ForEach-Object { "$($_.claim)" })
+
+    if ($flagged.Count -gt 0) {
+        return @{
+            pass       = $false
+            gateStatus = 'claims-failed'
+            flagged    = $flagged
+            summary    = "$($flagged.Count) claim(s) verified as incorrect: $($flagged -join '; ')"
+        }
+    }
+
+    $hasUnverified = [bool]@($rows | Where-Object { "$($_.status)" -eq 'unverified' })
+
+    if ($hasUnverified) {
+        $uvCount = @($rows | Where-Object { "$($_.status)" -eq 'unverified' }).Count
+        return @{
+            pass       = $true
+            gateStatus = 'has-unverified'
+            flagged    = @()
+            summary    = "$uvCount unverified claim(s) — gap is visible in the evidence block."
+        }
+    }
+
+    return @{
+        pass       = $true
+        gateStatus = 'verified'
+        flagged    = @()
+        summary    = "All $($rows.Count) claim(s) verified and correct."
+    }
+}
+
+<#
+    Render a claims section for inclusion in an evidence block.
+
+    Three distinct status labels, never collapsed:
+      PASS        — status=verified, correct=$true
+      FAIL        — status=verified, correct=$false
+      UNVERIFIED  — status=unverified (explicitly acknowledged as unchecked)
+
+    When the claims list is empty, renders a not-applicable notice — the
+    common case (a code-only run) is represented explicitly, not silently absent.
+#>
+function Format-ClaimsSection {
+    param([object[]]$Claims = @())
+    $rows = @($Claims | Where-Object { $_ -ne $null })
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Claims')
+    $lines.Add('')
+
+    if ($rows.Count -eq 0) {
+        $lines.Add('**Status:** not-applicable — this run made no external claims in its deliverable.')
+        return ($lines -join "`n")
+    }
+
+    $lines.Add('| Claim | Kind | Status | How Checked |')
+    $lines.Add('| --- | --- | --- | --- |')
+    foreach ($r in $rows) {
+        $claim      = "$($r.claim)"      -replace '\|', '\|'
+        $kind       = "$($r.kind)"       -replace '\|', '\|'
+        $howChecked = "$($r.howChecked)" -replace '\|', '\|'
+        $label = if ("$($r.status)" -eq 'verified') {
+            if ($r.correct -eq $true)  { 'PASS' }
+            elseif ($r.correct -eq $false) { 'FAIL' }
+            else { 'verified (result unknown)' }
+        } else {
+            'UNVERIFIED'
+        }
+        $lines.Add("| $claim | $kind | $label | $howChecked |")
+    }
+    ($lines -join "`n")
+}
+
+# Dot-source guard: tests set $env:ABIOS_EXPERTCLAIMSGATE_DOTSOURCE to load the pure core only.
+if ($env:ABIOS_EXPERTCLAIMSGATE_DOTSOURCE) { return }
+
+# This module is consumed by Expert-Auto.ps1 and the evidence recording step.
+# Invoked directly with no arguments it is a no-op — the pure core is the reusable surface.

--- a/plugins/agentic-board/tests/Expert-ClaimsGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-ClaimsGate.Tests.ps1
@@ -1,0 +1,195 @@
+#Requires -Modules Pester
+<#  Tests for Expert-ClaimsGate.ps1 — the claims verification gate for deliverables (#479).
+
+    Five tests from the issue:
+    1. A deliverable asserting a package name that does not resolve is flagged
+    2. A deliverable whose claims all resolve passes without added friction
+    3. A run making no external claims is unaffected (not-applicable)
+    4. The evidence block distinguishes verified / unverified / not-applicable
+    5. Regression fixture from the five fabrications in the incident: each one is caught
+
+    Pure core behind ABIOS_EXPERTCLAIMSGATE_DOTSOURCE. No network calls needed.
+    Design: each guard is verified by its exact success and failure conditions. #>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Expert-ClaimsGate.ps1' | Resolve-Path
+    $env:ABIOS_EXPERTCLAIMSGATE_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_EXPERTCLAIMSGATE_DOTSOURCE = ''
+}
+
+Describe 'Test-ClaimsGate — verified claim that does not resolve is flagged (#479 test 1)' {
+    It 'flags an npm package that 404s (status=verified, correct=false)' {
+        $claims = @(@{ claim = '@ahonn/mcp-server-gsc'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view @ahonn/mcp-server-gsc'; correct = $false })
+        $r = Test-ClaimsGate -Claims $claims
+        $r.pass | Should -BeFalse
+        $r.flagged | Should -Contain '@ahonn/mcp-server-gsc'
+    }
+
+    It 'flags a CLI flag verified as non-existent in the tool README (status=verified, correct=false)' {
+        $claims = @(@{ claim = '--auth'; kind = 'cli-flag'; status = 'verified'; howChecked = 'read README'; correct = $false })
+        $r = Test-ClaimsGate -Claims $claims
+        $r.pass | Should -BeFalse
+        $r.flagged | Should -Contain '--auth'
+    }
+
+    It 'gateStatus is claims-failed when a verified claim is wrong' {
+        $claims = @(@{ claim = 'bad-pkg'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $false })
+        (Test-ClaimsGate -Claims $claims).gateStatus | Should -Be 'claims-failed'
+    }
+}
+
+Describe 'Test-ClaimsGate — all claims resolve passes without added friction (#479 test 2)' {
+    It 'passes when all verified claims are correct' {
+        $claims = @(
+            @{ claim = 'mcp-server-gsc'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view mcp-server-gsc'; correct = $true },
+            @{ claim = 'search_analytics'; kind = 'api-tool'; status = 'verified'; howChecked = 'read README'; correct = $true }
+        )
+        $r = Test-ClaimsGate -Claims $claims
+        $r.pass | Should -BeTrue
+        @($r.flagged).Count | Should -Be 0
+    }
+
+    It 'gateStatus is verified when all claims pass' {
+        $claims = @(@{ claim = 'mcp-server-gsc'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $true })
+        (Test-ClaimsGate -Claims $claims).gateStatus | Should -Be 'verified'
+    }
+}
+
+Describe 'Test-ClaimsGate — no external claims is not-applicable, no friction (#479 test 3)' {
+    It 'returns not-applicable and pass for an empty claims list' {
+        $r = Test-ClaimsGate -Claims @()
+        $r.pass | Should -BeTrue
+        $r.gateStatus | Should -Be 'not-applicable'
+    }
+
+    It 'produces zero flagged claims when there are no claims' {
+        @((Test-ClaimsGate -Claims @()).flagged).Count | Should -Be 0
+    }
+
+    It 'a null entry in an otherwise empty list is still not-applicable' {
+        $r = Test-ClaimsGate -Claims @($null)
+        $r.pass | Should -BeTrue
+        $r.gateStatus | Should -Be 'not-applicable'
+    }
+}
+
+Describe 'Format-ClaimsSection — distinguishes verified / unverified / not-applicable (#479 test 4)' {
+    It 'renders verified and unverified as distinct labels' {
+        # A verified+correct claim renders PASS; an unverified claim renders UNVERIFIED.
+        # These are three distinct status values that never collapse.
+        $claims = @(
+            @{ claim = 'mcp-server-gsc'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $true },
+            @{ claim = '@ahonn/mcp-server-gsc'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null }
+        )
+        $s = Format-ClaimsSection -Claims $claims
+        $s | Should -Match '\| PASS \|'
+        $s | Should -Match '\| UNVERIFIED \|'
+    }
+
+    It 'renders not-applicable when claims list is empty' {
+        Format-ClaimsSection -Claims @() | Should -Match '(?i)not.applicable'
+    }
+
+    It 'a correct verified claim is rendered PASS' {
+        $claims = @(@{ claim = 'good-pkg'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $true })
+        Format-ClaimsSection -Claims $claims | Should -Match '\| PASS \|'
+    }
+
+    It 'a wrong verified claim is rendered FAIL' {
+        $claims = @(@{ claim = 'bad-pkg'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $false })
+        Format-ClaimsSection -Claims $claims | Should -Match '\| FAIL \|'
+    }
+
+    It 'an unverified claim is rendered UNVERIFIED' {
+        $claims = @(@{ claim = 'maybe-pkg'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null })
+        Format-ClaimsSection -Claims $claims | Should -Match '\| UNVERIFIED \|'
+    }
+
+    It 'never collapses all three into the same label when mixed' {
+        $claims = @(
+            @{ claim = 'good'; kind = 'npm-package'; status = 'verified'; howChecked = 'x'; correct = $true },
+            @{ claim = 'bad'; kind = 'npm-package'; status = 'verified'; howChecked = 'x'; correct = $false },
+            @{ claim = 'maybe'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null }
+        )
+        $s = Format-ClaimsSection -Claims $claims
+        $s | Should -Match '\| PASS \|'
+        $s | Should -Match '\| FAIL \|'
+        $s | Should -Match '\| UNVERIFIED \|'
+    }
+}
+
+Describe 'Regression fixture — five fabrications from the incident are each caught (#479 test 5)' {
+    BeforeAll {
+        # The five fabricated claims from PR #262 on csalcedodatabi.com — each was stated
+        # as a verified fact; in reality each was wrong. Registered here as verified+correct=false,
+        # which is the state they would have been in had the run actually looked them up.
+        $script:FiveFabrications = @(
+            @{ claim = '@ahonn/mcp-server-gsc'; kind = 'npm-package'; status = 'verified'
+               howChecked = '(would have been: npm view @ahonn/mcp-server-gsc)'; correct = $false },
+            @{ claim = 'OAuth 2.0 via ~/.mcp/gsc-credentials.json'; kind = 'auth-mechanism'; status = 'verified'
+               howChecked = '(would have been: read README auth section)'; correct = $false },
+            @{ claim = '--auth flag on npx invocation'; kind = 'cli-flag'; status = 'verified'
+               howChecked = '(would have been: npx mcp-server-gsc --help)'; correct = $false },
+            @{ claim = 'list_sitemaps tool'; kind = 'api-tool'; status = 'verified'
+               howChecked = '(would have been: read README tool list)'; correct = $false },
+            @{ claim = 'get_sitemap tool'; kind = 'api-tool'; status = 'verified'
+               howChecked = '(would have been: read README tool list)'; correct = $false }
+        )
+    }
+
+    It 'the gate fails when the five fabrications are registered as verified+wrong' {
+        $r = Test-ClaimsGate -Claims $script:FiveFabrications
+        $r.pass | Should -BeFalse
+    }
+
+    It 'all five fabrications appear in the flagged list' {
+        $r = Test-ClaimsGate -Claims $script:FiveFabrications
+        @($r.flagged).Count | Should -Be 5
+    }
+
+    It 'each fabrication is flagged by its claim text' {
+        $r = Test-ClaimsGate -Claims $script:FiveFabrications
+        $r.flagged | Should -Contain '@ahonn/mcp-server-gsc'
+        $r.flagged | Should -Contain 'OAuth 2.0 via ~/.mcp/gsc-credentials.json'
+        $r.flagged | Should -Contain '--auth flag on npx invocation'
+        $r.flagged | Should -Contain 'list_sitemaps tool'
+        $r.flagged | Should -Contain 'get_sitemap tool'
+    }
+
+    It 'the rendered claims section shows all five as FAIL' {
+        $s = Format-ClaimsSection -Claims $script:FiveFabrications
+        ($s -split "`n" | Where-Object { $_ -match '\| FAIL \|' }).Count | Should -Be 5
+    }
+
+    It 'each fabrication claim text appears in the rendered section' {
+        $s = Format-ClaimsSection -Claims $script:FiveFabrications
+        # @ and / are not regex metacharacters in .NET; literal match is safe
+        $s | Should -Match '@ahonn/mcp-server-gsc'
+        $s | Should -Match 'list_sitemaps'
+        $s | Should -Match 'get_sitemap'
+    }
+}
+
+Describe 'Test-ClaimsGate — unverified claims are visible but not blocking' {
+    It 'a run with only unverified claims still passes (gap is visible, not blocking)' {
+        $claims = @(@{ claim = 'maybe-pkg'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null })
+        $r = Test-ClaimsGate -Claims $claims
+        $r.pass | Should -BeTrue
+    }
+
+    It 'gateStatus is has-unverified when some claims are not checked' {
+        $claims = @(@{ claim = 'maybe'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null })
+        (Test-ClaimsGate -Claims $claims).gateStatus | Should -Be 'has-unverified'
+    }
+
+    It 'verified+wrong takes precedence over unverified (both present → gate fails)' {
+        $claims = @(
+            @{ claim = 'bad-pkg'; kind = 'npm-package'; status = 'verified'; howChecked = 'npm view'; correct = $false },
+            @{ claim = 'maybe'; kind = 'npm-package'; status = 'unverified'; howChecked = ''; correct = $null }
+        )
+        $r = Test-ClaimsGate -Claims $claims
+        $r.pass | Should -BeFalse
+        $r.gateStatus | Should -Be 'claims-failed'
+    }
+}


### PR DESCRIPTION
Closes #479

## Summary

- **New:** `Expert-ClaimsGate.ps1` — claims verification gate extending the evidence contract from "tests ran" to "claims were checked"
- **New:** `Expert-ClaimsGate.Tests.ps1` — 22 Pester tests covering all 5 issue tests, including regression fixture from the five fabrications
- **Updated:** `Expert-Auto.ps1` — expert brief now includes the claims gate requirement: a document is a deliverable, and a deliverable needs a gate
- **Updated:** `CHANGELOG.md` — entry in [Unreleased]

<!-- [abios-evidence] -->
## Evidence

**Summary:** 24 passed / 0 failed

Full evidence (single source of truth): [evidence/479.md](https://github.com/CSalcedoDataBI/agentic-board/blob/main/evidence/479.md)