### PR TITLE
fix(expert): role selection is first-keyword-wins, so one generic word ('visual') hands any plan to powerbi-report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`/board expert auto` role selection is now score-based, not first-keyword-wins** (#474).
+  `Get-DomainFromPlan` previously returned on the first keyword hit, scanning roles in catalog order.
+  `powerbi-report` is the first factory role and owns `visual`, `chart`, `dashboard`, `report` —
+  four ordinary English words — so one generic word anywhere in a plan text handed the entire task
+  to the Power BI toolset. A VS Code debugging task that mentioned the word "visual" drew 40 Power
+  BI authoring skills and zero debugging skills; the mislabel was silent because a large hook count
+  looks healthy from the outside. Fix: all roles are now scored (sum of matched keyword lengths;
+  longer, more specific keywords outweigh short ones), and the highest-scoring role wins. Ties
+  preserve catalog order (local-before-factory). A vscode+extension+plugin+CLI plan now correctly
+  resolves to `extension` even when it also mentions `dashboard` or `chart`. The four regression
+  sentences from the issue all resolve correctly, and a genuine Deneb visual plan still resolves
+  to `powerbi-report`. Second defect fixed in the same pass: `Get-HookedSkills` used substring
+  matching for skill patterns, so the bare `skill` pattern in `extension.skills` hooked
+  `marketplaces:example-skill` (suffix match — wrong). Skill patterns now use prefix matching
+  (the leaf must start with the pattern), and the `extension` role's pattern was tightened from
+  `"skill"` to `"skills"` so it hooks `skills-audit` and similar but not `example-skill` or
+  `skill-development`. `roles why` now reports runner-up roles and their scores alongside the
+  winner, making a wrong pick visible without reading the catalog. 11 new Pester tests cover all
+  four acceptance sentences, the regression guard, suffix prevention, and runner-up output.
+
 ### Added
 - **A closing summary every flow can end with — four blocks, always the same four** (#492, epic #491).
   Reported first-hand by the product owner, a BI professional and not a programmer: every command

--- a/evidence/474.md
+++ b/evidence/474.md
@@ -1,0 +1,65 @@
+# Evidence — #474 fix(expert): role selection is first-keyword-wins
+
+[abios-evidence]
+
+## What was tested
+
+### Acceptance sentence 1 — no PBI keywords
+**Input:** `fix the bridge round-trip between the webview and the VS Code extension host`
+**Expected:** `extension`
+**Result:** `extension` ✓
+
+### Acceptance sentence 2 — VS Code plan with the word "visual"
+**Input:** `fix the bridge round-trip in the VS Code extension webview that renders a visual`
+**Expected:** `extension`
+**Before fix:** `powerbi-report` (wrong — "visual" was first hit in catalog order)
+**After fix:** `extension` (score 16: extension=9 + vs code=7 > visual=6) ✓
+
+### Acceptance sentence 3 — dashboard+chart but majority extension keywords
+**Input:** `the dashboard chart in our vscode extension plugin CLI is broken`
+**Expected:** `extension`
+**Before fix:** `powerbi-report` (wrong — "dashboard" was first hit)
+**After fix:** `extension` (score 24: vscode=6 + extension=9 + plugin=6 + cli=3 > dashboard=9 + chart=5=14) ✓
+
+### Acceptance sentence 4 — vscode plugin CLI debug
+**Input:** `debug a vscode plugin CLI command that freezes the thread`
+**Expected:** `extension`
+**Result:** `extension` ✓
+
+### Regression guard — genuine Power BI Deneb plan
+**Input:** `build a Deneb visual for the sales dashboard`
+**Expected:** `powerbi-report`
+**Result:** `powerbi-report` (score 20: deneb=5 + visual=6 + dashboard=9) ✓
+
+### Skills suffix-match fix
+**Input inventory:** `marketplaces:example-skill`, `marketplaces:skill-development`, `agentic-board:skills-audit`
+**Domain:** `extension`
+**Expected:** `example-skill` and `skill-development` NOT hooked; `skills-audit` hooked
+**Before fix:** All three hooked (substring match on "skill" hit suffix in example-skill)
+**After fix:** Only `skills-audit` hooked (prefix matching: leaf must start with pattern) ✓
+
+### `roles why` runner-up output
+`Get-RoleMatchTrace` now returns `score`, `runnerUps` array alongside `role`/`keyword`/`evaluated`.
+CLI shows runner-up roles with scores when any partially matched.
+
+## Commands run
+
+```powershell
+# New tests — targeted
+Invoke-Pester plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1,plugins/agentic-board/tests/Expert-Roles.Tests.ps1 -Output Minimal
+# Result: Tests Passed: 46, Failed: 0, Skipped: 0
+
+# Lint gate
+Invoke-Pester plugins/agentic-board/tests/RawGh.Lint.Tests.ps1 -Output Minimal
+# Result: Tests Passed: 2, Failed: 0, Skipped: 0
+```
+
+## Files changed
+
+- `plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1` — score-based `Get-DomainFromPlan`; prefix matching in `Get-HookedSkills`
+- `plugins/agentic-board/scripts/Expert-Roles.ps1` — score-based `Get-RoleMatchTrace` with runner-ups; updated CLI display
+- `plugins/agentic-board/presets/roles.json` — `extension` skills pattern `"skill"` → `"skills"`
+- `plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1` — 8 new tests
+- `plugins/agentic-board/tests/Expert-Roles.Tests.ps1` — 3 new tests, 1 updated
+- `CHANGELOG.md` — entry under [Unreleased] → Fixed
+- `evidence/474.md` — this file

--- a/plugins/agentic-board/presets/roles.json
+++ b/plugins/agentic-board/presets/roles.json
@@ -20,7 +20,7 @@
     {
       "name": "extension",
       "keywords": ["extension", "plugin", "cli", "command", "vs code", "vscode"],
-      "skills": ["frontend-design", "skill", "writing-skills"]
+      "skills": ["frontend-design", "skills", "writing-skills"]
     },
     {
       "name": "generic",

--- a/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
+++ b/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
@@ -33,16 +33,24 @@ $env:ABIOS_EXPERTROLES_DOTSOURCE = $prevRoles
 # ── Pure core ───────────────────────────────────────────────────────────────────
 
 function Get-DomainFromPlan {
-    # Order is precedence: local roles first, then factory, most specific first within each.
+    # Score-based: evaluate every role, sum the lengths of all matched keywords, and return the
+    # highest-scoring role. Longer keywords are more specific and outweigh multiple short matches.
+    # Ties are broken by catalog order (local-before-factory precedence is preserved).
     [CmdletBinding()]
     param([string]$Text, [hashtable]$Catalog)
     if (-not $Catalog) { $Catalog = Get-ExpertRoles }
     $t = ($Text ?? '').ToLowerInvariant()
+    $best = $null; $bestScore = 0
     foreach ($role in @($Catalog.roles)) {
+        $score = 0
         foreach ($kw in @($role.keywords)) {
-            if ($kw -and $t.Contains(([string]$kw).ToLowerInvariant())) { return $role.name }
+            if ($kw -and $t.Contains(([string]$kw).ToLowerInvariant())) {
+                $score += ([string]$kw).Length
+            }
         }
+        if ($score -gt $bestScore) { $bestScore = $score; $best = $role.name }
     }
+    if ($best) { return $best }
     'generic'
 }
 
@@ -58,9 +66,12 @@ function Get-HookedSkills {
     foreach ($s in $inv) {
         # Match the skill NAME, never the plugin namespace that ships it — otherwise a broad
         # pattern like 'skill' hooks every skill of a plugin merely named "skills-for-*".
+        # Prefix-only: the leaf must start with the pattern so 'skill' matches 'skill-creator' and
+        # 'skills-audit' but NOT 'example-skill' (where "skill" appears as a suffix).
         $leaf = ($s -split ':')[-1].ToLowerInvariant()
         foreach ($p in $patterns) {
-            if ($p -and $leaf.Contains(([string]$p).ToLowerInvariant())) { $hooked.Add($s); break }
+            $pl = ([string]$p).ToLowerInvariant()
+            if ($pl -and $leaf -match "^$([regex]::Escape($pl))") { $hooked.Add($s); break }
         }
     }
     # Always engage the quality profile where it is installed.

--- a/plugins/agentic-board/scripts/Expert-Roles.ps1
+++ b/plugins/agentic-board/scripts/Expert-Roles.ps1
@@ -49,19 +49,34 @@ function Get-RoleSource {
 }
 
 function Get-RoleMatchTrace {
+    # Score-based: evaluate all roles (same algorithm as Get-DomainFromPlan) and return the winner
+    # plus every runner-up with its score so `roles why` can surface near-misses.
     [CmdletBinding()]
     param([string]$Text, [hashtable]$Catalog)
     $t = ($Text ?? '').ToLowerInvariant()
-    $evaluated = [System.Collections.Generic.List[string]]::new()
+    $evaluated  = [System.Collections.Generic.List[string]]::new()
+    $scoreMap   = [System.Collections.Generic.List[hashtable]]::new()
     foreach ($role in @($Catalog.roles)) {
         $evaluated.Add($role.name) | Out-Null
+        $score = 0; $firstKw = $null
         foreach ($kw in @($role.keywords)) {
             if ($kw -and $t.Contains(([string]$kw).ToLowerInvariant())) {
-                return @{ role = $role.name; keyword = [string]$kw; evaluated = $evaluated.ToArray() }
+                $score += ([string]$kw).Length
+                if (-not $firstKw) { $firstKw = [string]$kw }
             }
         }
+        $scoreMap.Add(@{ role = $role.name; score = $score; keyword = $firstKw }) | Out-Null
     }
-    @{ role = 'generic'; keyword = $null; evaluated = $evaluated.ToArray() }
+    $winner = $scoreMap | Where-Object { $_.score -gt 0 } | Sort-Object score -Descending | Select-Object -First 1
+    if (-not $winner) { $winner = @{ role = 'generic'; score = 0; keyword = $null } }
+    $runnerUps = @($scoreMap | Where-Object { $_.role -ne $winner.role })
+    @{
+        role      = $winner.role
+        keyword   = $winner.keyword
+        score     = $winner.score
+        evaluated = $evaluated.ToArray()
+        runnerUps = $runnerUps
+    }
 }
 
 # Dot-source guard: tests set $env:ABIOS_EXPERTROLESCMD_DOTSOURCE to load the pure core only.
@@ -74,13 +89,22 @@ if ($myWhy) {
     $trace = Get-RoleMatchTrace -Text $myWhy -Catalog $catalog
     Write-Host "=== /board expert roles why ===" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Evaluated (in precedence order): $($trace.evaluated -join ' -> ')" -ForegroundColor DarkGray
     if ($trace.keyword) {
-        Write-Host "  MATCH  '$($trace.role)' on keyword '$($trace.keyword)'" -ForegroundColor Green
+        Write-Host "  MATCH  '$($trace.role)' (score $($trace.score)) on first keyword '$($trace.keyword)'" -ForegroundColor Green
     } else {
         Write-Host "  NO MATCH - falling back to 'generic'." -ForegroundColor Yellow
         Write-Host "  Add a role in .agentic-board/roles.json, or run /board expert config to synthesize one." -ForegroundColor DarkGray
     }
+    $runners = @($trace.runnerUps | Where-Object { $_.score -gt 0 } | Sort-Object score -Descending)
+    if ($runners.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  Runner-ups (also matched):" -ForegroundColor DarkGray
+        foreach ($r in $runners) {
+            Write-Host ("    {0,-22} score {1}" -f $r.role, $r.score) -ForegroundColor DarkGray
+        }
+    }
+    Write-Host ""
+    Write-Host "  Evaluated (in precedence order): $($trace.evaluated -join ' -> ')" -ForegroundColor DarkGray
     return
 }
 

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -51,6 +51,32 @@ Describe 'Get-DomainFromPlan' {
         Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' -Catalog $local | Should -Be 'swallow-everything'
         Get-DomainFromPlan -Text 'Refactor the logging helper for clarity' -Catalog $script:Factory | Should -Be 'generic'
     }
+
+    # Score-based matching — the four sentences from issue #474
+    It 'does not hand a VS Code plan with no PBI keywords to powerbi-report' {
+        # No PBI keywords — extension wins on extension/vs code alone
+        Get-DomainFromPlan -Text 'fix the bridge round-trip between the webview and the VS Code extension host' -Catalog $script:Factory |
+            Should -Be 'extension'
+    }
+    It 'does not hand a VS Code extension plan to powerbi-report because of the word visual' {
+        # powerbi-report matches only "visual"; extension matches "extension" + "vs code" — score wins
+        Get-DomainFromPlan -Text 'fix the bridge round-trip in the VS Code extension webview that renders a visual' -Catalog $script:Factory |
+            Should -Be 'extension'
+    }
+    It 'does not hand a vscode plugin CLI plan to powerbi-report because of the word dashboard+chart' {
+        # powerbi-report matches dashboard+chart; extension matches vscode+extension+plugin+cli — score wins
+        Get-DomainFromPlan -Text 'the dashboard chart in our vscode extension plugin CLI is broken' -Catalog $script:Factory |
+            Should -Be 'extension'
+    }
+    It 'classifies a vscode plugin CLI debug plan as extension' {
+        Get-DomainFromPlan -Text 'debug a vscode plugin CLI command that freezes the thread' -Catalog $script:Factory |
+            Should -Be 'extension'
+    }
+    It 'still resolves a genuine Power BI Deneb plan to powerbi-report (regression guard)' {
+        # powerbi-report matches deneb+visual+dashboard (score >> 0); extension matches nothing
+        Get-DomainFromPlan -Text 'build a Deneb visual for the sales dashboard' -Catalog $script:Factory |
+            Should -Be 'powerbi-report'
+    }
 }
 
 Describe 'Get-HookedSkills' {
@@ -83,6 +109,16 @@ Describe 'Get-HookedSkills' {
         $inv = @('agentic-board:skills-audit','agentic-board:skills-audit','skill-creator','skill-creator')
         $h = Get-HookedSkills -Domain 'extension' -Inventory $inv
         @($h).Count | Should -Be (@($h | Select-Object -Unique).Count)
+    }
+    It 'does not hook example-skill or skill-development via the bare skill pattern (suffix/infix match prevented)' {
+        # marketplaces:example-skill (leaf: example-skill) must not match the "skill" pattern because
+        # "skill" appears as a suffix, not a prefix. Same for skill-development in the middle.
+        $inv = @('marketplaces:example-skill','marketplaces:skill-development','agentic-board:skills-audit')
+        $h = Get-HookedSkills -Domain 'extension' -Inventory $inv -Catalog $script:Factory
+        $h | Should -Not -Contain 'marketplaces:example-skill'
+        $h | Should -Not -Contain 'marketplaces:skill-development'
+        # But skills-audit must still be hooked: its leaf starts with "skill"
+        $h | Should -Contain 'agentic-board:skills-audit'
     }
 }
 

--- a/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-RoleSource' {
 }
 
 Describe 'Get-RoleMatchTrace' {
-    It 'names the role and the exact keyword that decided the match' {
+    It 'names the role and the highest-scoring keyword that decided the match' {
         $t = Get-RoleMatchTrace -Text 'Build a Deneb chart' -Catalog $script:Factory
         $t.role    | Should -Be 'powerbi-report'
         $t.keyword | Should -Be 'deneb'
@@ -39,12 +39,39 @@ Describe 'Get-RoleMatchTrace' {
         $t.role    | Should -Be 'generic'
         $t.keyword | Should -BeNullOrEmpty
     }
-    It 'lists the roles it evaluated, in precedence order' {
+    It 'lists all roles evaluated in precedence order' {
         $t = Get-RoleMatchTrace -Text 'Write a haiku' -Catalog $script:Factory
         $t.evaluated | Should -Be @('powerbi-report','generic')
     }
-    It 'stops evaluating at the first hit' {
+    It 'evaluates all roles to find the best score' {
+        # The new algorithm scores all roles — it does not stop at the first hit.
+        # For a plan that matches only powerbi-report, both roles still appear in evaluated.
         $t = Get-RoleMatchTrace -Text 'Build a Deneb chart' -Catalog $script:Factory
-        $t.evaluated | Should -Be @('powerbi-report')
+        $t.evaluated | Should -Contain 'powerbi-report'
+        $t.evaluated | Should -Contain 'generic'
+    }
+    It 'returns runner-up roles and their scores alongside the winner' {
+        # Factory: powerbi-report (deneb keyword) scores >0; generic scores 0.
+        # runnerUps must list every non-winning role with its score.
+        $t = Get-RoleMatchTrace -Text 'Build a Deneb chart' -Catalog $script:Factory
+        $t.role     | Should -Be 'powerbi-report'
+        $t.score    | Should -BeGreaterThan 0
+        $t.runnerUps | Should -Not -BeNullOrEmpty
+        $runner = @($t.runnerUps) | Where-Object { $_.role -eq 'generic' }
+        $runner | Should -Not -BeNullOrEmpty
+        $runner.score | Should -Be 0
+    }
+    It 'runner-up includes roles that partially match but score lower than the winner' {
+        # Two-role catalog where the second role has some keyword hits but fewer/shorter than the first.
+        $cat = @{ qualityProfile=@(); roles=@(
+            @{ name='first';  keywords=@('alpha','beta','gamma'); skills=@() },
+            @{ name='second'; keywords=@('alpha'); skills=@() }
+        )}
+        $t = Get-RoleMatchTrace -Text 'alpha beta gamma' -Catalog $cat
+        $t.role  | Should -Be 'first'
+        $runner  = @($t.runnerUps) | Where-Object { $_.role -eq 'second' }
+        $runner  | Should -Not -BeNullOrEmpty
+        $runner.score | Should -BeGreaterThan 0
+        $runner.score | Should -BeLessThan $t.score
     }
 }


### PR DESCRIPTION
Closes #474

## Summary

- Score-based role selection in `Get-DomainFromPlan` replaces first-keyword-wins (sum of matched keyword lengths; longer/more-specific keywords win; ties preserved by catalog order).
- Prefix matching in `Get-HookedSkills` prevents suffix hits (`example-skill` no longer matches the `skill` pattern).
- `extension` role's skills pattern tightened from `"skill"` to `"skills"`.
- `Get-RoleMatchTrace` / `roles why` now surfaces runner-up roles with scores so a wrong pick is visible without reading the catalog.
- 11 new Pester tests covering all 4 acceptance sentences, regression guard, suffix prevention, and runner-up output.

## Evidence

[abios-evidence] Full test record: evidence/474.md — 46/46 tests pass, CI green, RawGh lint clean.