### PR TITLE
fix(errors): 85 failures exit 1 with no message and 43 leak raw exceptions (measured over 945 sessions)

### DIFF
--- a/evidence/485.md
+++ b/evidence/485.md
@@ -1,0 +1,91 @@
+# Evidence — #485 fix(errors): silent exit-1 and raw PS exception leaks
+
+[abios-evidence]
+
+## What was tested
+
+Added a top-level `trap` block to each of the six worst-offending scripts so that every unhandled
+terminating error produces a clean `ERROR: <message>` on stdout before exiting 1. This closes
+85 silent exits and 43 raw PowerShell exception leaks measured across 945 sessions (#476 field sweep).
+
+Scripts patched (+8 lines each):
+- `Board-Fill.ps1` — 16 raw exception occurrences in corpus
+- `Board-Work.ps1` — 17 raw exception occurrences in corpus
+- `New-BoardPR.ps1` — 7 raw exception occurrences in corpus
+- `Board-Merge.ps1` — 2 raw exception occurrences in corpus
+- `Board-Triage.ps1` — 2 raw exception occurrences in corpus
+- `Board-Breakdown.ps1` — 1 raw exception occurrence in corpus
+
+New test file: `tests/ErrorBoundary.Tests.ps1` — drives each script into the missing-token failure
+path (guaranteed throw before any `gh` call) and asserts three things:
+1. Exit code is 1 — never silent
+2. stdout contains `"ERROR:"` — the caller can read the reason
+3. stdout does NOT match `CategoryInfo`, `FullyQualifiedErrorId`, or `At *.ps1:\d` — no raw PS dump
+
+## Test evidence
+
+### ErrorBoundary.Tests.ps1 — 6/6 PASS
+
+Command:
+```
+Invoke-Pester plugins/agentic-board/tests/ErrorBoundary.Tests.ps1 -Output Detailed
+```
+
+Result:
+```
+Tests Passed: 6, Failed: 0, Skipped: 0
+Tests completed in 8.85s
+```
+
+Tests run:
+- `Board-Fill.ps1` error boundary — PASS
+- `Board-Work.ps1` error boundary — PASS
+- `New-BoardPR.ps1` error boundary — PASS
+- `Board-Merge.ps1` error boundary — PASS
+- `Board-Triage.ps1` error boundary — PASS
+- `Board-Breakdown.ps1` error boundary — PASS
+
+### Scripts.Parse.Tests.ps1 (85 scripts) + RawGh.Lint.Tests.ps1 — 87/87 PASS
+
+Command:
+```
+Invoke-Pester -Path plugins/agentic-board/tests/Scripts.Parse.Tests.ps1,plugins/agentic-board/tests/RawGh.Lint.Tests.ps1 -Output Normal
+```
+
+Result:
+```
+Tests Passed: 87, Failed: 0, Skipped: 0
+```
+
+No new raw `gh` calls added (baseline frozen).
+
+### Full Pester suite (85 test files) — 2033/2033 PASS
+
+Command:
+```
+Invoke-Pester plugins/agentic-board/tests/ -Output Normal
+```
+
+Result:
+```
+Tests Passed: 2033, Failed: 0, Skipped: 0
+Tests completed in 1124.02s
+```
+
+Zero regressions across the full suite.
+
+### CI gate (PR #610) — PASS
+
+Board-ReviewGate.ps1 confirmed checks green; gate passed.
+
+## Key decisions
+
+- `trap` is placed after any dot-source guard (`if ($env:ABIOS_*_DOTSOURCE) { return }`) so the boundary
+  only fires when the script is run as a top-level command — never during Pester's function-loading phase.
+- For scripts with no dot-source guard (Board-Merge, Board-Breakdown), the trap is placed immediately
+  after `$ErrorActionPreference = "Stop"`.
+- `Write-Host` is used (not `Write-Error`) so the message lands on stream 6 (Information), captured by
+  `*>&1` — the same stream that all other user-visible output uses.
+- Tests force the missing-token path (before any network call) by erasing `ABIOS_ERROR_BOUNDARY_TEST_485`
+  from the User registry and clearing `$env:GH_TOKEN` in BeforeAll. This guarantees a throw on the very
+  first token check in every script, with no live `gh` dependencies.

--- a/plugins/agentic-board/scripts/Board-Breakdown.ps1
+++ b/plugins/agentic-board/scripts/Board-Breakdown.ps1
@@ -46,6 +46,14 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # The single resolver for owner/name from this clone's origin (#281). Do NOT inline the regex
 # again: the copy-pasted version ate any dot in the repo name (midominio.com -> midominio).
 . (Join-Path $PSScriptRoot 'Get-RepoFromOrigin.ps1')

--- a/plugins/agentic-board/scripts/Board-Fill.ps1
+++ b/plugins/agentic-board/scripts/Board-Fill.ps1
@@ -265,6 +265,14 @@ mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!) {
 # the token check or any gh call (same contract as Board-Work.ps1).
 if ($env:ABIOS_BOARDFILL_DOTSOURCE) { return }
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # ── 0. Token ──────────────────────────────────────────────────────────────────
 # Respect a pre-set $env:GH_TOKEN (a business board is reached by exporting
 # GITHUB_TOKEN_BUSINESS first) instead of clobbering it with the personal PAT.

--- a/plugins/agentic-board/scripts/Board-Merge.ps1
+++ b/plugins/agentic-board/scripts/Board-Merge.ps1
@@ -60,6 +60,14 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # ── Brake check (#516) ──────────────────────────────────────────────────────────
 # Defense in depth. The PreToolUse guard already refuses `Board-Merge.ps1` inside a brake-armed
 # worktree, but that guard only exists where the plugin's hooks are installed. This check lives in

--- a/plugins/agentic-board/scripts/Board-Triage.ps1
+++ b/plugins/agentic-board/scripts/Board-Triage.ps1
@@ -168,6 +168,14 @@ function Format-ItemRef {
 # Dot-source guard: tests set $env:ABIOS_TRIAGE_DOTSOURCE to load the pure helpers only.
 if ($env:ABIOS_TRIAGE_DOTSOURCE) { return }
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # ── Side-effecting from here ──────────────────────────────────────────────────
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')
 # Board reads that report their own truncation (#484).

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -2185,6 +2185,14 @@ function Invoke-BatchIssueStart {
 # ==============================================================================
 if ($env:ABIOS_BOARDWORK_DOTSOURCE) { return }
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # ==============================================================================
 # KILL-LAYER MODES (Phase 2, local-only - no GH_TOKEN needed). Every kill goes
 # through the fail-safe Stop-ProcessTree (self + ancestors always excluded) and

--- a/plugins/agentic-board/scripts/New-BoardPR.ps1
+++ b/plugins/agentic-board/scripts/New-BoardPR.ps1
@@ -86,6 +86,14 @@ function Get-ExistingPr {
 # Dot-source guard: tests set $env:ABIOS_NEWBOARDPR_DOTSOURCE to load the pure helper only.
 if ($env:ABIOS_NEWBOARDPR_DOTSOURCE) { return }
 
+# ── Top-level error boundary (#485): any unhandled exception becomes a clean
+# one-line message on stdout so the caller always sees what failed — never a
+# silent exit 1 or a raw PowerShell stack dump going to stderr only.
+trap {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+
 # gh must fail closed on the "is there already an open PR?" read (#336/#303): a swallowed failure
 # used to be indistinguishable from "no PR" and took the silent-skip path above.
 . (Join-Path $PSScriptRoot 'Invoke-Gh.ps1')

--- a/plugins/agentic-board/tests/ErrorBoundary.Tests.ps1
+++ b/plugins/agentic-board/tests/ErrorBoundary.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Modules Pester
+<#  Error-boundary tests — exit 1 with no message and raw exceptions (#485).
+
+    Field sweep (#476): 945 sessions, 295 failed invocations. Two failure shapes
+    account for 128 of the 172 unclassified failures:
+
+      85  exit 1 with no message   — throw goes to stderr only; caller sees nothing.
+      43  raw PowerShell exception — file path + CategoryInfo reaches the user.
+
+    Fix: each of the six worst-offending scripts now has a top-level `trap` block
+    that intercepts every unhandled terminating error and writes a clean one-line
+    "ERROR: <message>" to stdout before exiting 1.
+
+    These tests verify the contract from the outside (no dot-source, no mocks):
+      1. A failure path exits 1 — not 0.
+      2. The output contains "ERROR:" on stdout — not silent.
+      3. The output does NOT contain raw PowerShell exception markers
+         (CategoryInfo, FullyQualifiedErrorId) — not a raw stack dump.
+
+    The "missing token" path is the cheapest forcing function: it fires before any
+    gh call and throws at the very first line of the main body. Passing a var name
+    that is guaranteed absent guarantees the throw every time.
+
+    Tests run the scripts with *>&1 (all streams merged) to capture everything the
+    child process writes. The trap fires in the child's scope and writes "ERROR: …"
+    to stream 1/6 (stdout/Information), which IS captured. Without the trap the
+    throw would go to stream 2 (ErrorRecord), which is also captured but in the raw
+    PS exception format (CategoryInfo, FullyQualifiedErrorId, file:line). #>
+
+BeforeAll {
+    $script:Dir = Join-Path $PSScriptRoot '..' 'scripts' | Resolve-Path
+
+    # A var name guaranteed absent from the Windows USER environment.
+    $script:AbsentVar = 'ABIOS_ERROR_BOUNDARY_TEST_485'
+    [System.Environment]::SetEnvironmentVariable($script:AbsentVar, $null, 'User')
+
+    # Markers that appear in raw PowerShell exception output, never in our clean messages.
+    $script:RawPatterns = @(
+        '(?m)^\s*\+ CategoryInfo\s*:',
+        '(?m)^\s*\+ FullyQualifiedErrorId\s*:',
+        'At .*\.ps1:\d'
+    )
+
+    function script:Assert-CleanError {
+        param([string]$Out, [int]$Code, [string]$Script)
+        $Code | Should -Be 1 -Because "$Script must exit 1 on a forced error"
+        $Out  | Should -Match 'ERROR:' -Because "$Script must print a reason on stdout"
+        foreach ($pat in $script:RawPatterns) {
+            $Out | Should -Not -Match $pat -Because "$Script must not leak a raw PS exception"
+        }
+    }
+
+    # Store and clear GH_TOKEN for the duration of the suite; restore in AfterAll.
+    $script:PrevGH = $env:GH_TOKEN
+    $env:GH_TOKEN = ''
+}
+
+AfterAll {
+    if ($script:PrevGH) { $env:GH_TOKEN = $script:PrevGH }
+    else { Remove-Item Env:\GH_TOKEN -ErrorAction SilentlyContinue }
+}
+
+# ── Board-Fill.ps1 ────────────────────────────────────────────────────────────
+Describe 'Board-Fill.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'Board-Fill.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -TokenVar $script:AbsentVar *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'Board-Fill.ps1'
+    }
+}
+
+# ── Board-Work.ps1 ───────────────────────────────────────────────────────────
+Describe 'Board-Work.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'Board-Work.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -TokenVar $script:AbsentVar -ProjectNum 13 *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'Board-Work.ps1'
+    }
+}
+
+# ── New-BoardPR.ps1 ───────────────────────────────────────────────────────────
+Describe 'New-BoardPR.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'New-BoardPR.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -Issue 1 -TokenVar $script:AbsentVar *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'New-BoardPR.ps1'
+    }
+}
+
+# ── Board-Merge.ps1 ───────────────────────────────────────────────────────────
+Describe 'Board-Merge.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'Board-Merge.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -PR 1 -TokenVar $script:AbsentVar *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'Board-Merge.ps1'
+    }
+}
+
+# ── Board-Triage.ps1 ──────────────────────────────────────────────────────────
+Describe 'Board-Triage.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'Board-Triage.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -TokenVar $script:AbsentVar *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'Board-Triage.ps1'
+    }
+}
+
+# ── Board-Breakdown.ps1 ───────────────────────────────────────────────────────
+Describe 'Board-Breakdown.ps1 error boundary (#485)' {
+    BeforeAll { $script:S = Join-Path $script:Dir 'Board-Breakdown.ps1' }
+
+    It 'exits 1 with a clean ERROR message when the token var is missing — never silent' {
+        $out  = & $script:S -Parent 1 -Tasks 'Task A' -TokenVar $script:AbsentVar *>&1 | Out-String
+        $code = $LASTEXITCODE
+        script:Assert-CleanError -Out $out -Code $code -Script 'Board-Breakdown.ps1'
+    }
+}


### PR DESCRIPTION
Closes #485

[abios-evidence]

Evidence recorded in [`evidence/485.md`](https://github.com/CSalcedoDataBI/agentic-board/blob/issue-485-fix-errors-85-failures-exit-1-with-no/evidence/485.md).

**Summary:** ErrorBoundary.Tests.ps1 6/6 PASS · parse+lint 87/87 PASS · full suite 2033/2033 PASS · CI gate PASSED on PR #610.