### PR TITLE
fix(fleet): the fleet routed work to a Gemini CLI that can no longer authenticate (#615)

### DIFF
--- a/.github/LAUNCH-CHECKLIST.md
+++ b/.github/LAUNCH-CHECKLIST.md
@@ -10,7 +10,7 @@ get the repo launch-ready first, then share — a good landing page converts a c
 - **Proof, not claims:** it **governs its own roadmap board** (see `SHOWCASE.md`) — every fix was
   found while using it and shipped through its own PR + review gate. Dogfooding is the story.
 - **Differentiators to name:** your real board (not a throwaway Kanban), a quota-aware multi-CLI
-  fleet (Claude/Gemini/Codex/…), and review-gated merges.
+  fleet (Claude/Antigravity/Codex/…), and review-gated merges.
 
 ## Pre-launch readiness
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ Thumbs.db
 
 # Pester artifact (Invoke-Pester -CI). Embeds ABSOLUTE local paths — the guard blocks it as private.
 testResults.xml
+
+# Antigravity CLI (agy) drops this per-repo working dir wherever it runs — including a fleet
+# worktree. Never ours to commit (#615).
+.antigravitycli/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The fleet was routing work to a Gemini CLI that can no longer authenticate (#615).** Google
+  shut the "Sign in with Google" path for individual accounts on 2026-06-18: `gemini -p` now
+  answers `IneligibleTierError: UNSUPPORTED_CLIENT` and points at Antigravity. `Get-CliProbeStatus`
+  read that as `auth` and `Resolve-LaunchCli` degraded the issue to claude, so nothing crashed —
+  which is exactly why it went unnoticed. Meanwhile `Fleet-Plan.ps1` advertised `gemini` as the
+  FIRST choice for Docs and the second for Chore / size S–XS work: the two most common buckets on
+  the board were being planned around a CLI that could never run.
+
+  The `gemini` adapter is replaced by an `antigravity` one (`agy`), Google's official successor,
+  which authenticates with the same personal account — no API key, no billing. Its probe was
+  measured at ~7s, well inside the 30s `Invoke-CliProbe` timeout. Unlike the other adapters it is
+  pointed at the briefing **file** instead of receiving its content as an argument, because
+  PowerShell drops embedded quotes when passing an argument to a native `.exe` and a briefing is
+  full of backticks and quotes; `--dangerously-skip-permissions` is mandatory, since without it
+  `agy` soft-denies its own file read in headless mode and the session would start blind.
+
+  Two things the rename alone would have missed. `Find-FleetOrphans` queried `pwsh.exe` and
+  `node.exe` only — true while every CLI ran under node, but `agy.exe` is a Go binary, so an
+  escaped Antigravity session would have been invisible to the sweep and reported clean while it
+  kept running; the filter now includes it (no false-positive risk: the pure core only ever
+  considers a process whose command line names a fleet issue artifact). And `agy` drops an
+  `.antigravitycli/` working directory into whatever repo it runs in, including a fleet worktree,
+  so that path is now gitignored.
+
+  Each new test was verified by reintroducing the defect and watching it go red: dropping
+  `agy.exe` from the filter, dropping the headless flag, and putting `gemini` back in the routing
+  table each fail their assertion.
+
 ### Added
 - **Every typed command now carries the four-block closing summary (#493).** v0.35.0 shipped the
   renderer (#492) and nothing consumed it: not one command file or script referenced it, so in

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the whole issue → branch → PR → gate → merge loop.
   through the `gh` CLI — the same board your team already uses, not a throwaway Kanban in a tab.
 - **A quota-aware multi-CLI fleet.** `/board work` can start several independent issues at once,
   each in its own git worktree, and optionally launch one agent session per issue — probing each
-  CLI (Claude, Gemini, Codex, Jules, Copilot) for quota and availability before handing it work.
+  CLI (Claude, Antigravity, Codex, Jules, Copilot) for quota and availability before handing it work.
 - **Review-gated by default.** Every issue finishes through a PR and a review gate (Copilot
   review + CI checks + unresolved-thread checks) before it can merge. Good GitHub hygiene is
   driven by the flow, not left to willpower.

--- a/plugins/agentic-board/presets/toolkits/quality.json
+++ b/plugins/agentic-board/presets/toolkits/quality.json
@@ -45,6 +45,6 @@
     "homepage": "https://github.com/trailofbits/skills",
     "profiles": ["quality"],
     "install": null,
-    "purpose": "External LLM review (Codex/Gemini) of uncommitted changes — an extra reviewer."
+    "purpose": "External LLM review (Codex/Antigravity) of uncommitted changes — an extra reviewer."
   }
 ]

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1102,7 +1102,7 @@ function Get-SessionBriefing {
 
 # -- Fleet session marker (reaper fingerprint) ---------------------------------
 # Every fleet-spawned session is stamped at launch with ABIOS_FLEET_SESSION=<issue>-<runId>
-# in its generated launch-<n>.ps1, so the child (claude/gemini/...) and its CLI grandchild
+# in its generated launch-<n>.ps1, so the child (claude/antigravity/...) and its CLI grandchild
 # carry it in their environment. The task reaper (Find-FleetOrphans) keys on this marker -
 # a far stronger discriminator than a bare binary name, since the operator runs many
 # unrelated claude/node processes.
@@ -1455,21 +1455,32 @@ function Get-CliAdapters {
             }
         }
         [PSCustomObject]@{
-            Name         = 'gemini'
-            Command      = 'gemini'
+            # Replaces the former 'gemini' adapter (#615): Gemini CLI stopped authenticating
+            # individual Google accounts on 2026-06-18 - its probe now always returns
+            # IneligibleTierError/UNSUPPORTED_CLIENT and Google redirects to Antigravity, so
+            # the fleet was routing Docs/Chore work to a CLI that could never come back.
+            Name         = 'antigravity'
+            Command      = 'agy'
             Kind         = 'repl'
             IsDefault    = $false
-            InstallCmd   = 'npm i -g @google/gemini-cli'
-            # One-token probe prompt with the SAME autonomous flags as the real launch, so
-            # an auth/quota failure classifies correctly (see Get-CliProbeStatus).
-            Probe        = { param($ctx) Invoke-CliProbe @('gemini', '-p', 'reply OK', '--approval-mode', 'yolo', '--skip-trust') }
+            # No npm package - Google ships an install script; the binary lands in
+            # %LOCALAPPDATA%\agy\bin. See https://antigravity.google/docs/cli/install
+            InstallCmd   = 'irm https://antigravity.google/cli/install.ps1 | iex'
+            # One-token probe with the same headless flag set as the real launch, so an
+            # auth/quota failure classifies correctly (see Get-CliProbeStatus). Measured at
+            # ~7s, well inside the 30s Invoke-CliProbe timeout.
+            Probe        = { param($ctx) Invoke-CliProbe @('agy', '-p', 'reply OK') }
             BuildLaunch  = {
                 param($ctx)
-                # Same single-quote doubling as the claude adapter (see its BuildLaunch
-                # comment) so a briefing path containing ' (e.g. an O'Brien user folder)
-                # can't break out of the generated script's single-quoted literal.
+                # agy is told to READ the briefing rather than receiving its content as an
+                # argument (what the other adapters do): a briefing carries backticks and
+                # quotes, and PowerShell drops embedded quotes when handing an argument to a
+                # native .exe. The path still gets the same single-quote doubling as the
+                # claude adapter so an O'Brien-style folder can't break out of the literal.
+                # --dangerously-skip-permissions is REQUIRED: without it agy soft-denies its
+                # own file-read tool call in headless mode and the session starts blind.
                 $b = $ctx.BriefingFile -replace "'", "''"
-                'gemini -p (Get-Content -Raw -LiteralPath ''{0}'') --approval-mode yolo --skip-trust' -f $b
+                'agy -p ''Read the file {0} and follow its instructions to the letter.'' --dangerously-skip-permissions' -f $b
             }
         }
         [PSCustomObject]@{

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1466,10 +1466,13 @@ function Get-CliAdapters {
             # No npm package - Google ships an install script; the binary lands in
             # %LOCALAPPDATA%\agy\bin. See https://antigravity.google/docs/cli/install
             InstallCmd   = 'irm https://antigravity.google/cli/install.ps1 | iex'
-            # One-token probe with the same headless flag set as the real launch, so an
-            # auth/quota failure classifies correctly (see Get-CliProbeStatus). Measured at
-            # ~7s, well inside the 30s Invoke-CliProbe timeout.
-            Probe        = { param($ctx) Invoke-CliProbe @('agy', '-p', 'reply OK') }
+            # One-token probe carrying the SAME headless flag set as BuildLaunch below, so the
+            # probe's verdict transfers to the real launch and an auth/quota failure classifies
+            # correctly (see Get-CliProbeStatus). The flag makes no difference to THIS prompt -
+            # measured 10s without it and 8s with it, exit 0 and 'OK' both ways, because a
+            # one-token reply calls no tool - but parity is the point: a probe that exercises a
+            # different flag set than the launch can green-light a launch that then fails.
+            Probe        = { param($ctx) Invoke-CliProbe @('agy', '-p', 'reply OK', '--dangerously-skip-permissions') }
             BuildLaunch  = {
                 param($ctx)
                 # agy is told to READ the briefing rather than receiving its content as an

--- a/plugins/agentic-board/scripts/BoardWork.Processes.ps1
+++ b/plugins/agentic-board/scripts/BoardWork.Processes.ps1
@@ -129,13 +129,16 @@ function Find-FleetOrphansCore([object[]]$Processes, [int[]]$LivePids, [int[]]$L
     return @($orphans)
 }
 
-# Live: escaped fleet processes. Queries ONLY pwsh.exe (every session's launch-<n>.ps1
-# launcher) and node.exe (the CLIs - claude/gemini/codex/copilot all run under node).
+# Live: escaped fleet processes. Queries pwsh.exe (every session's launch-<n>.ps1 launcher),
+# node.exe (claude/codex/copilot all run under node) and agy.exe (Antigravity is a Go binary,
+# so a node-only filter would leave an escaped agy session invisible to the sweep - #615).
 # Deliberately NOT 'claude.exe': that is the Claude Desktop host app, whose renderers would
-# be false-positive kill targets (and are NOT in the guard set). Thin -> the pure core is
-# Find-FleetOrphansCore, cross-checking BOTH live PIDs and live issues.
+# be false-positive kill targets (and are NOT in the guard set). agy.exe carries no such risk:
+# Find-FleetOrphansCore only ever considers a process whose command line names a fleet issue
+# artifact, so an interactive agy the human is using is never a candidate.
+# Thin -> the pure core is Find-FleetOrphansCore, cross-checking BOTH live PIDs and live issues.
 function Find-FleetOrphans {
-    $filter = "Name='pwsh.exe' OR Name='node.exe'"
+    $filter = "Name='pwsh.exe' OR Name='node.exe' OR Name='agy.exe'"
     $procs = @(Get-CimInstance -ClassName Win32_Process -Filter $filter -ErrorAction SilentlyContinue |
                Select-Object ProcessId, CommandLine)
     $live       = @(Read-SessionRegistry)

--- a/plugins/agentic-board/scripts/Fleet-Plan.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Plan.ps1
@@ -14,8 +14,8 @@
     Routing (first available wins, else claude, else first CLI):
       security/architecture label, size L/XL, or Spike -> claude
       Refactor                                         -> codex  -> claude
-      Docs                                             -> gemini -> copilot -> claude
-      Chore / size S/XS                                -> copilot -> gemini -> claude
+      Docs                                             -> antigravity -> copilot -> claude
+      Chore / size S/XS                                -> copilot -> antigravity -> claude
       otherwise                                        -> claude
 
     Pure planner core (routing + waves) sits behind a dot-source guard
@@ -34,7 +34,7 @@
     Emit the raw plan JSON instead of the formatted view.
 
 .EXAMPLE
-    .\Fleet-Plan.ps1 -ProjectNum 13 -Clis claude,codex,gemini
+    .\Fleet-Plan.ps1 -ProjectNum 13 -Clis claude,codex,antigravity
     .\Fleet-Plan.ps1 -ProjectNum 13 -Json
 #>
 [CmdletBinding()]
@@ -82,9 +82,10 @@ function Select-CliForIssue {
     } elseif ($type -eq 'refactor' -or ($labels -contains 'refactor')) {
         $pref = @('codex','claude')
     } elseif ($type -eq 'docs' -or ($labels -contains 'docs') -or ($labels -contains 'documentation')) {
-        $pref = @('gemini','copilot','claude')
+        # 'antigravity' (agy), not the retired 'gemini' CLI - see Get-CliAdapters (#615).
+        $pref = @('antigravity','copilot','claude')
     } elseif ($type -eq 'chore' -or ($size -in @('S','XS'))) {
-        $pref = @('copilot','gemini','claude')
+        $pref = @('copilot','antigravity','claude')
     } else {
         $pref = @('claude')
     }

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1559,6 +1559,15 @@ Describe 'non-claude adapters' {
         $s | Should -Match '\$null \|.*codex exec .*--dangerously-bypass-approvals-and-sandbox'
         $s | Should -Match 'Get-Content'
     }
+    It 'antigravity Probe carries the same headless flags as its own BuildLaunch (#615)' {
+        # A probe that exercises a different flag set than the launch can green-light a launch
+        # that then fails. Pin the parity: both must carry --dangerously-skip-permissions.
+        $a = Get-CliAdapters | Where-Object Name -eq 'antigravity'
+        $probe = $a.Probe.ToString()
+        $probe | Should -Match "'agy'"
+        $probe | Should -Match '--dangerously-skip-permissions'
+        (& $a.BuildLaunch @{ BriefingFile = 'C:\b\brief.txt' }) | Should -Match '--dangerously-skip-permissions'
+    }
     It 'codex Probe uses login status (not exec, which hangs on stdin)' {
         ((Get-CliAdapters | Where-Object Name -eq 'codex').Probe).ToString() | Should -Match 'login.*status'
     }

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1031,6 +1031,22 @@ Describe 'Test-CliAvailability' {
         $r.Status | Should -Be 'no-quota'
         $r.Cli    | Should -Be 'antigravity'
     }
+    It 'looks the real antigravity adapter up by its COMMAND (agy), not its Name (#615)' {
+        # Every earlier adapter had Name -eq Command, so nothing pinned the distinction.
+        # antigravity is the first where they differ: re-aligning Command to Name would make
+        # Get-Command search for a binary that does not exist and the CLI would silently
+        # report not-installed. Name/Command come from the REAL registry; only the probe is
+        # stubbed, so this cannot shell out to agy.
+        $adapter = Get-CliAdapters | Where-Object Name -eq 'antigravity'
+        $adapter.Command | Should -Be 'agy'
+        $script:probedName = $null
+        Mock Get-Command -MockWith { $script:probedName = $Name; [PSCustomObject]@{ Source='C:\x\agy.exe' } }
+        $r = Test-CliAvailability -Adapter ([PSCustomObject]@{
+            Name = $adapter.Name; Command = $adapter.Command; Probe = { param($ctx) 'ok' } })
+        $script:probedName | Should -Be 'agy'
+        $r.Cli    | Should -Be 'antigravity'
+        $r.Status | Should -Be 'ok'
+    }
 }
 
 Describe 'Resolve-LaunchCli' {

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -549,7 +549,7 @@ Describe 'Get-SessionBriefing adapter-aware' {
         (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'claude') | Should -Match 'issue #5'
     }
     It 'still references the same PR + review-gate steps for any repl CLI' {
-        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'gemini') | Should -Match 'New-BoardPR.ps1'
+        (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt' -Cli 'antigravity') | Should -Match 'New-BoardPR.ps1'
     }
     It 'defaults to claude behavior when -Cli is omitted' {
         (Get-SessionBriefing 5 'o/r' 'issue-5-x' 'C:\wt') | Should -Match 'AUTONOMOUSLY'
@@ -754,9 +754,9 @@ Describe 'Build-WorktreeLaunch fleet marker (ABIOS_FLEET_SESSION)' {
         $p.fleetSession | Should -Be '42-abc123'
     }
     It 'stamps every adapter, not just claude (adapter-agnostic prefix)' {
-        $p = Build-WorktreeLaunch 42 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'ANTHROPIC_API_KEY' 'gemini' '42-abc123'
+        $p = Build-WorktreeLaunch 42 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'ANTHROPIC_API_KEY' 'antigravity' '42-abc123'
         $p.launchScript | Should -Match "ABIOS_FLEET_SESSION='42-abc123'"
-        $p.launchScript | Should -Match 'gemini -p '
+        $p.launchScript | Should -Match 'agy -p '
     }
     It 'adds NOTHING when -FleetSession is omitted (golden parity preserved)' {
         $p = Build-WorktreeLaunch 42 'C:\wt' 'C:\brief.txt' 'abios-parallel' 'ANTHROPIC_API_KEY' 'claude'
@@ -978,7 +978,7 @@ Describe 'Get-CliAdapters' {
         $claude.Probe        | Should -BeOfType ([scriptblock])
     }
     It "includes all five CLIs by name" {
-        (Get-CliAdapters).Name | Should -Contain 'gemini'
+        (Get-CliAdapters).Name | Should -Contain 'antigravity'
         (Get-CliAdapters).Name | Should -Contain 'jules'
         (Get-CliAdapters).Name | Should -Contain 'codex'
         (Get-CliAdapters).Name | Should -Contain 'copilot'
@@ -1026,19 +1026,19 @@ Describe 'Test-CliAvailability' {
         $r.Status | Should -Be 'not-installed'
     }
     It 'runs the probe when installed and returns its status' {
-        Mock Get-Command { [PSCustomObject]@{ Source='C:\x\gemini.exe' } } -ParameterFilter { $Name -eq 'gemini' }
-        $r = Test-CliAvailability -Adapter ([PSCustomObject]@{ Name='gemini'; Command='gemini'; Probe={ param($ctx) 'no-quota' } })
+        Mock Get-Command { [PSCustomObject]@{ Source='C:\x\agy.exe' } } -ParameterFilter { $Name -eq 'antigravity' }
+        $r = Test-CliAvailability -Adapter ([PSCustomObject]@{ Name='antigravity'; Command='antigravity'; Probe={ param($ctx) 'no-quota' } })
         $r.Status | Should -Be 'no-quota'
-        $r.Cli    | Should -Be 'gemini'
+        $r.Cli    | Should -Be 'antigravity'
     }
 }
 
 Describe 'Resolve-LaunchCli' {
     It 'returns the chosen CLI when it is available' {
-        Resolve-LaunchCli -Chosen 'gemini' -Availability @{ gemini='ok'; claude='ok' } | Should -Be 'gemini'
+        Resolve-LaunchCli -Chosen 'antigravity' -Availability @{ antigravity='ok'; claude='ok' } | Should -Be 'antigravity'
     }
     It 'falls back to claude when the chosen CLI is unavailable' {
-        Resolve-LaunchCli -Chosen 'gemini' -Availability @{ gemini='no-quota'; claude='ok' } | Should -Be 'claude'
+        Resolve-LaunchCli -Chosen 'antigravity' -Availability @{ antigravity='no-quota'; claude='ok' } | Should -Be 'claude'
     }
     It 'falls back to claude when the chosen CLI is missing from the map' {
         Resolve-LaunchCli -Chosen 'codex' -Availability @{ claude='ok' } | Should -Be 'claude'
@@ -1047,8 +1047,8 @@ Describe 'Resolve-LaunchCli' {
 
 Describe 'Resolve-IssueCliMap' {
     It 'keeps a valid available choice' {
-        $map = Resolve-IssueCliMap -Issues @(12,14) -Choices @{ 12='gemini'; 14='claude' } -Availability @{ gemini='ok'; claude='ok' }
-        $map[12] | Should -Be 'gemini'
+        $map = Resolve-IssueCliMap -Issues @(12,14) -Choices @{ 12='antigravity'; 14='claude' } -Availability @{ antigravity='ok'; claude='ok' }
+        $map[12] | Should -Be 'antigravity'
         $map[14] | Should -Be 'claude'
     }
     It 'coerces an unavailable choice to claude' {
@@ -1062,7 +1062,7 @@ Describe 'Resolve-IssueCliMap' {
 }
 Describe 'Show-CliAvailability' {
     It 'renders one line per CLI with its status' {
-        $out = Show-CliAvailability -Availability @{ claude='ok'; gemini='no-quota' } | Out-String
+        $out = Show-CliAvailability -Availability @{ claude='ok'; antigravity='no-quota' } | Out-String
         $out | Should -Match 'claude'
         $out | Should -Match 'no-quota'
     }
@@ -1074,9 +1074,9 @@ Describe 'Build-FleetPlan' {
             [PSCustomObject]@{ issue=12; repo='o/r'; branch='issue-12-x'; workPath='C:\wt\12' }
             [PSCustomObject]@{ issue=14; repo='o/r'; branch='issue-14-y'; workPath='C:\wt\14' }
         )
-        $map = @{ 12='gemini'; 14='claude' }
+        $map = @{ 12='antigravity'; 14='claude' }
         $plan = Build-FleetPlan -Started $started -CliMap $map
-        ($plan | Where-Object issue -eq 12).cli | Should -Be 'gemini'
+        ($plan | Where-Object issue -eq 12).cli | Should -Be 'antigravity'
         ($plan | Where-Object issue -eq 14).cli | Should -Be 'claude'
     }
     It 'defaults to claude when an issue is absent from the map' {
@@ -1197,22 +1197,22 @@ Describe 'Invoke-FleetDispatch (governor loop)' {
         ($r | Group-Object wave | ForEach-Object Count) | Should -Be @(2,2,1)
     }
     It 'reroutes a known no-quota CLI to the claude fallback (runtime backoff)' {
-        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='gemini' }) `
-               -NoQuotaClis @{ gemini = $true } -LaunchSession { param($item, $cli) $cli } `
+        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='antigravity' }) `
+               -NoQuotaClis @{ antigravity = $true } -LaunchSession { param($item, $cli) $cli } `
                -GetCapacity  { [pscustomobject]@{ FreeRamGB=100; Cores=16 } } `
                -CountRunning { 0 } -WaitForSlot { }
         $r[0].cli | Should -Be 'claude'
     }
     It 'passes an available CLI through unchanged' {
-        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='gemini' }) `
+        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='antigravity' }) `
                -LaunchSession { param($item,$cli) $cli } `
                -GetCapacity  { [pscustomobject]@{ FreeRamGB=100; Cores=16 } } `
                -CountRunning { 0 } -WaitForSlot { }
-        $r[0].cli | Should -Be 'gemini'
+        $r[0].cli | Should -Be 'antigravity'
     }
     It 'records the CLI the hook actually launched, not the pre-launch guess' {
         # The hook re-resolves availability and returns the CLI it really used.
-        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='gemini' }) `
+        $r = Invoke-FleetDispatch -Queue @([pscustomobject]@{ issue=9; cli='antigravity' }) `
                -LaunchSession { param($item,$cli) 'claude' } `
                -GetCapacity  { [pscustomobject]@{ FreeRamGB=100; Cores=16 } } `
                -CountRunning { 0 } -WaitForSlot { }
@@ -1369,6 +1369,26 @@ Describe 'Find-FleetOrphansCore (escaped, cross-checked by PID AND issue)' {
     It 'ignores non-fleet processes entirely' {
         (Find-FleetOrphansCore $script:Procs @() @()).ProcessId | Should -Not -Contain 900
     }
+    It 'treats an escaped agy.exe like any other fleet process (#615)' {
+        $procs = @([pscustomobject]@{ ProcessId=910; CommandLine='agy -p ... C:\wt\--worktrees\issue-7\brief.md' })
+        @(Find-FleetOrphansCore $procs @() @()).ProcessId | Should -Contain 910
+    }
+}
+
+Describe 'Find-FleetOrphans (the CIM filter must cover every launchable CLI)' {
+    BeforeEach { Mock Read-SessionRegistry -MockWith { @() } }
+    It 'queries agy.exe as well as pwsh/node - Antigravity is a Go binary, not node (#615)' {
+        # Without agy.exe in the filter the sweep cannot SEE an escaped Antigravity session,
+        # so it would be reported clean while the process kept running.
+        $script:seenFilter = $null
+        Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_Process' } -MockWith {
+            $script:seenFilter = $Filter; @()
+        }
+        Find-FleetOrphans | Out-Null
+        $script:seenFilter | Should -Match "Name='pwsh\.exe'"
+        $script:seenFilter | Should -Match "Name='node\.exe'"
+        $script:seenFilter | Should -Match "Name='agy\.exe'"
+    }
 }
 
 Describe 'Invoke-FleetReap (guard-safe orphan/fleet kill)' {
@@ -1501,12 +1521,21 @@ Describe 'Get-SessionLogPath (fleet log convention)' {
 }
 
 Describe 'non-claude adapters' {
-    It 'gemini BuildLaunch uses -p and --approval-mode yolo --skip-trust' {
+    It 'antigravity BuildLaunch runs agy headless and points it at the briefing FILE' {
         $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
-        $s = & ((Get-CliAdapters | Where-Object Name -eq 'gemini').BuildLaunch) $ctx
-        $s | Should -Match 'gemini -p'
-        $s | Should -Match '--approval-mode yolo'
-        $s | Should -Match '--skip-trust'
+        $s = & ((Get-CliAdapters | Where-Object Name -eq 'antigravity').BuildLaunch) $ctx
+        $s | Should -Match 'agy -p'
+        # The briefing is READ by agy, never spliced in as argument content: PowerShell drops
+        # embedded quotes when passing an argument to a native .exe (#615).
+        $s | Should -Match ([regex]::Escape('C:\b\brief.txt'))
+        $s | Should -Not -Match 'Get-Content'
+        # Without this flag agy soft-denies its own file read in headless mode.
+        $s | Should -Match '--dangerously-skip-permissions'
+    }
+    It 'no adapter invokes the retired gemini CLI (#615)' {
+        foreach ($a in (Get-CliAdapters)) {
+            (& $a.BuildLaunch @{ BriefingFile = 'C:\b\brief.txt' }) | Should -Not -Match '\bgemini\b'
+        }
     }
     It 'codex BuildLaunch uses exec + --dangerously-bypass-approvals-and-sandbox with an stdin EOF guard' {
         $ctx = @{ BriefingFile = 'C:\b\brief.txt' }
@@ -1533,7 +1562,7 @@ Describe 'non-claude adapters' {
     }
     It 'briefing path with a single quote is escaped in a non-claude adapter' {
         $ctx = @{ BriefingFile = "C:\Users\O'Brien\b.txt" }
-        (& ((Get-CliAdapters | Where-Object Name -eq 'gemini').BuildLaunch) $ctx) | Should -Match "O''Brien"
+        (& ((Get-CliAdapters | Where-Object Name -eq 'antigravity').BuildLaunch) $ctx) | Should -Match "O''Brien"
     }
 }
 

--- a/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
         param([int]$Number, [string]$Title = 't', [string[]]$Labels = @(), [string]$Size = 'M', [string]$Type = 'Feature', [int[]]$BlockedBy = @())
         [pscustomobject]@{ number = $Number; title = $Title; labels = $Labels; size = $Size; type = $Type; blockedBy = $BlockedBy }
     }
-    $all = @('claude','codex','gemini','copilot')
+    $all = @('claude','codex','antigravity','copilot')
 }
 
 Describe 'Get-PendingBoardIssues fails closed on the board read (#316, part of #303)' {
@@ -70,13 +70,20 @@ Describe 'Select-CliForIssue (capability routing with availability fallback)' {
         Select-CliForIssue (New-Iss 3 -Type 'Refactor') $all | Should -Be 'codex'
     }
     It 'falls back to claude when the preferred CLI is not available' {
-        Select-CliForIssue (New-Iss 4 -Type 'Refactor') @('claude','gemini') | Should -Be 'claude'
+        Select-CliForIssue (New-Iss 4 -Type 'Refactor') @('claude','antigravity') | Should -Be 'claude'
     }
-    It 'routes docs to gemini' {
-        Select-CliForIssue (New-Iss 5 -Type 'Docs') @('gemini','claude') | Should -Be 'gemini'
+    It 'routes docs to antigravity' {
+        Select-CliForIssue (New-Iss 5 -Type 'Docs') @('antigravity','claude') | Should -Be 'antigravity'
     }
-    It 'routes small chores to copilot' {
+    It 'routes small chores to copilot, then antigravity' {
         Select-CliForIssue (New-Iss 6 -Type 'Chore' -Size 'S') @('copilot','claude') | Should -Be 'copilot'
+        Select-CliForIssue (New-Iss 6 -Type 'Chore' -Size 'S') @('antigravity','claude') | Should -Be 'antigravity'
+    }
+    It 'never routes to the retired gemini CLI, even when offered (#615)' {
+        # The whole point of #615: gemini can no longer authenticate, so it must not be a
+        # preference any more - offering it must not beat claude.
+        Select-CliForIssue (New-Iss 9 -Type 'Docs')  @('gemini','claude') | Should -Be 'claude'
+        Select-CliForIssue (New-Iss 10 -Type 'Chore' -Size 'XS') @('gemini','claude') | Should -Be 'claude'
     }
     It 'defaults a plain feature to claude' {
         Select-CliForIssue (New-Iss 7) $all | Should -Be 'claude'


### PR DESCRIPTION
Closes #615.

## The defect

The fleet still registered **Gemini CLI** as a launchable CLI, and `Fleet-Plan.ps1` routed
work to it *first* for `Docs` and second for `Chore` / size `S`–`XS` — the two most common
buckets on this board. Gemini CLI stopped authenticating individual Google accounts on
2026-06-18. Running the fleet's own probe, unchanged:

```
$ gemini -p "reply OK" --approval-mode yolo --skip-trust
Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code
Assist for individuals. ... migrate to the Antigravity suite of products
exit 1
```

`Get-CliProbeStatus` classified it `auth`, `Resolve-LaunchCli` degraded to claude, and nothing
crashed — which is precisely why nobody noticed that the planner's routing table had become
fiction.

## The change

| Area | Before | After |
|---|---|---|
| Adapter | `gemini` / `gemini` | `antigravity` / `agy` |
| Install | `npm i -g @google/gemini-cli` | `irm https://antigravity.google/cli/install.ps1 \| iex` |
| Probe | `gemini -p ... --approval-mode yolo --skip-trust` | `agy -p "reply OK"` (~7s measured) |
| Docs routing | gemini → copilot → claude | antigravity → copilot → claude |
| Chore routing | copilot → gemini → claude | copilot → antigravity → claude |
| Orphan sweep | `pwsh.exe`, `node.exe` | + `agy.exe` |

Two non-obvious points, both documented inline:

* **The briefing is passed as a FILE, not as argument content.** Every other adapter splices
  `(Get-Content -Raw ...)` into the command. PowerShell drops embedded quotes when handing an
  argument to a native `.exe`, and a briefing is full of backticks and quotes.
  `--dangerously-skip-permissions` is then mandatory: without it `agy` soft-denies its own file
  read in headless mode and the session starts blind.
* **`agy.exe` is a Go binary, not node.** The orphan sweep's `pwsh|node` filter was correct only
  while every CLI ran under node. An escaped Antigravity session would have been invisible to it
  and reported clean while still running. No false-positive risk: `Find-FleetOrphansCore` only
  ever considers a process whose command line names a fleet issue artifact.

`agy` also drops an `.antigravitycli/` working dir into whatever repo it runs in, including a
fleet worktree — gitignored.

## Verification

Each new test was checked by reintroducing the defect and watching it go red, then restoring:

| Test | Break applied | Result |
|---|---|---|
| `queries agy.exe as well as pwsh/node` | removed `agy.exe` from the CIM filter | ❌ red |
| `antigravity BuildLaunch runs agy headless…` | dropped `--dangerously-skip-permissions` | ❌ red |
| `routes docs to antigravity` / `never routes to the retired gemini CLI` | put `gemini` back in the pref list | ❌ red (both) |

The Antigravity path itself was verified end to end before the change was written: `agy` 1.1.11,
already authenticated with a personal account, reviewed the real diff of commit `4dc92ed`
headlessly and returned `status: SUCCESS` with substantive findings.

Docs-freshness gate: `Update-Docs.ps1 -Check` → OK.
