### PR TITLE
feat(doctor): name the worktree orphan git cannot see, and sweep the empty ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **A worktree the doctor could not see was quietly costing a git process every 30 minutes
+  (#618).** The ghost check trusted git's own `prunable` marker, which only ever means "metadata
+  present, directory gone". The inverse never had a name: the directory survives under
+  `.claude/worktrees/` with a broken `.git` link, git has already pruned its metadata, and the
+  worktree therefore never appears in `git worktree list` at all. Never listed → never a record →
+  never `prunable` → invisible.
+
+  Invisible but not inert. The agent host keeps those entries in a machine-wide registry and
+  retries pruning them on a timer, so a handful of them can accumulate hundreds of failed git
+  invocations over a week. Where the repos live on a mechanical disk, that is felt.
+
+  `Worktree-Ghosts.ps1` gives the four states names — `ok`, `prunable`, `orphan-empty`,
+  `orphan-content` — and only `orphan-empty` is ever removed without asking. A new SessionStart
+  hook sweeps those (startup and resume, never compact, where the worktrees are still in use);
+  the doctor reports the rest, including registry entries pointing at other repos, since the
+  retry loop is machine-wide and no single per-repo invocation would ever have seen them.
+
+  The removal is a **non-recursive** delete: .NET refuses to delete a directory that is not
+  empty, so the filesystem — not a check this code performs and then trusts — is what guarantees
+  no work is lost. A file appearing between the check and the delete costs nothing; the delete
+  simply fails.
+
+  Two bugs shipped past a fully green pure test suite and were caught only by running it against
+  a real repo, which is why `Worktree-Ghosts.Integration.Tests.ps1` now exists alongside the pure
+  one. Comparing absolute paths looked obvious and was wrong — git prints the path it recorded
+  while the filesystem returns whatever alias you walked in through (8.3 short name, junction,
+  subst drive), so a **live** worktree was classified as an orphan; matching by name within the
+  managed directory sidesteps the aliased prefix entirely. And `[string]$Porcelain` left unbound
+  arrives as `''`, never `$null`, so the "should I call git?" guard never fired and the known-set
+  stayed empty — which orphaned every worktree in the repo.
 
 ## [0.37.0] - 2026-08-19
 
@@ -45,6 +78,7 @@ role) can be declared once instead of copy-pasted into each project (#640).
 - **Routing the independent-review requirement through the official Codex plugin
   (`codex-rescue`) as a cross-vendor reviewer is not yet invokable in this harness** (#621, spike;
   tracked as #637). The CI review bot (`claude-review` / Copilot) satisfies the gate today.
+
 
 ## [0.36.0] - 2026-08-10
 

--- a/plugins/agentic-board/hooks/hooks.json
+++ b/plugins/agentic-board/hooks/hooks.json
@@ -18,6 +18,15 @@
             "command": "pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/scripts/Handoff-SessionStartHook.ps1\""
           }
         ]
+      },
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/scripts/Worktree-SessionStartHook.ps1\""
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/plugins/agentic-board/scripts/Board-Doctor.ps1
+++ b/plugins/agentic-board/scripts/Board-Doctor.ps1
@@ -305,6 +305,29 @@ $wtByBranch = @{}
 foreach ($w in $wtRecords) { if ($w.Branch) { $wtByBranch[$w.Branch] = $w } }
 # Ghost worktrees: git itself flags a registered worktree whose directory is gone.
 $ghosts = @($wtRecords | Where-Object { $_.Prunable })
+# The INVERSE case git cannot flag, because it no longer knows the worktree exists: the
+# directory survives under .claude/worktrees/ with a broken .git link, so it never appears in
+# the porcelain above and never becomes a record to mark prunable (#618). Reported, not fixed
+# here - the empty ones are swept by the SessionStart hook, and the ones with content need a
+# human. Best-effort: a failure to inventory orphans must never sink the branch audit.
+$orphans = @()
+$staleRegistry = @()
+try {
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = '1'
+    . (Join-Path $PSScriptRoot 'Worktree-Ghosts.ps1')
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = ''
+
+    $orphans = @(Get-WorktreeGhosts -RepoRoot '.' -Porcelain $wtPorcelain)
+
+    # The retry loop these orphans feed is driven by a MACHINE-WIDE registry, so an orphan in
+    # another repo keeps it running where no single invocation of this command would ever look.
+    $regEntries = @(Get-RegistryWorktrees)
+    $existsMap = @{}
+    foreach ($e in $regEntries) {
+        if ($e.Path) { $existsMap[(ConvertTo-ComparablePath $e.Path)] = (Test-Path -LiteralPath $e.Path) }
+    }
+    $staleRegistry = @(Select-StaleRegistryEntries -Entries $regEntries -ExistsMap $existsMap)
+} catch { }
 # Never offer to tear down the worktree we are standing in.
 $here = ""
 try { $here = (Resolve-Path (git rev-parse --show-toplevel 2>$null) -ErrorAction SilentlyContinue).Path } catch { }
@@ -382,6 +405,8 @@ if ($Json) {
     [pscustomobject]@{
         repo = $Repo; generatedAt = $now.ToString('o'); staleDays = $StaleDays
         branches = @($rows); ghostWorktrees = @($ghosts | Select-Object Path, Prunable)
+        orphanWorktrees = @($orphans | Select-Object Name, Path, Class, AutoRemovable)
+        staleRegistryEntries = @($staleRegistry | Select-Object Name, Path)
     } | ConvertTo-Json -Depth 6
     exit 0
 }
@@ -414,14 +439,48 @@ if ($ghosts.Count -gt 0) {
     Write-Host ""
 }
 
+# The inverse ghosts (#618). Split by class, because the two demand opposite responses: the
+# empty ones are already handled automatically, the ones with content are a question for you.
+$orphanContent = @($orphans | Where-Object { $_.Class -eq 'orphan-content' })
+$orphanEmpty   = @($orphans | Where-Object { $_.Class -eq 'orphan-empty' })
+
+if ($orphanContent.Count -gt 0) {
+    Write-Host "--- Worktrees huerfanos CON CONTENIDO (carpeta presente, git no los conoce) ($($orphanContent.Count)) ---" -ForegroundColor Red
+    foreach ($o in $orphanContent) { Write-Host ("   {0,-52} {1}" -f $o.Name, $o.Path) }
+    Write-Host "    Git ya podo su metadata, asi que 'git worktree prune' no los ve." -ForegroundColor DarkGray
+    Write-Host "    Tienen archivos: revisalos a mano antes de borrar nada." -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+if ($orphanEmpty.Count -gt 0) {
+    Write-Host "--- Worktrees huerfanos vacios ($($orphanEmpty.Count)) ---" -ForegroundColor Yellow
+    foreach ($o in $orphanEmpty) { Write-Host ("   {0,-52} {1}" -f $o.Name, $o.Path) }
+    Write-Host "    El hook de SessionStart los barre solo en el proximo arranque." -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+if ($staleRegistry.Count -gt 0) {
+    Write-Host "--- Entradas muertas en el registro global ($($staleRegistry.Count)) ---" -ForegroundColor Yellow
+    Write-Host "    Su ruta ya no existe. Alimentan el ciclo de reintentos desde CUALQUIER repo," -ForegroundColor DarkGray
+    Write-Host "    no solo este, por eso aparecen aunque no sean de aqui." -ForegroundColor DarkGray
+    foreach ($s in $staleRegistry) { Write-Host ("   {0,-36} {1}" -f $s.Name, $s.Path) }
+    Write-Host ""
+}
+
 $deletable = @($rows | Where-Object { $_.Deletable })
 $decide    = @($rows | Where-Object { $_.Class -in @('closed-unmerged','stale') -and -not $_.HasLiveSession })
 
 if (-not $Fix) {
     Write-Host "Read-only: no se cambio nada." -ForegroundColor DarkGray
-    if ($deletable.Count -gt 0 -or $ghosts.Count -gt 0 -or $decide.Count -gt 0) {
+    if ($deletable.Count -gt 0 -or $ghosts.Count -gt 0 -or $decide.Count -gt 0 -or $orphans.Count -gt 0 -or $staleRegistry.Count -gt 0) {
         Write-Host "  $($deletable.Count) rama(s) mergeadas borrables, $($decide.Count) por decidir, $($ghosts.Count) worktree(s) fantasma." -ForegroundColor DarkGray
+        if ($orphans.Count -gt 0 -or $staleRegistry.Count -gt 0) {
+            Write-Host "  $($orphanContent.Count) huerfano(s) con contenido, $($orphanEmpty.Count) vacio(s), $($staleRegistry.Count) entrada(s) muerta(s) en el registro global." -ForegroundColor DarkGray
+        }
         Write-Host "  Ejecuta con -Fix para limpiarlas (confirma rama por rama; -Fix -DryRun para ver el plan)." -ForegroundColor DarkGray
+        if ($orphanContent.Count -gt 0) {
+            Write-Host "  -Fix NO toca los huerfanos con contenido: revisalos tu." -ForegroundColor DarkGray
+        }
     } else {
         Write-Host "  Nada que limpiar." -ForegroundColor Green
     }

--- a/plugins/agentic-board/scripts/Worktree-Ghosts.ps1
+++ b/plugins/agentic-board/scripts/Worktree-Ghosts.ps1
@@ -1,0 +1,239 @@
+<#  Worktree-Ghosts.ps1 - inventory of managed worktree directories that git no longer knows.
+
+    THE GAP THIS CLOSES (#618). The doctor's existing ghost check trusts git's own `prunable`
+    marker, which git sets when the METADATA survives but the DIRECTORY is gone. The inverse
+    case is invisible to it: the directory is still on disk under `.claude/worktrees/`, but its
+    `.git` link is broken, so git already pruned its metadata and the worktree does not appear
+    in `git worktree list` at all. Never listed -> never a record -> never `prunable`.
+
+    Those orphans are not inert. The agent host keeps them in a machine-wide registry and
+    retries pruning them on a timer; every attempt fails and the cycle repeats, piling up failed
+    git invocations. On repos that live on slow disks the cost is felt, not theoretical.
+
+    They are born from abnormal session termination: the directory survives, the lease is never
+    released.
+
+    FOUR STATES, and the difference between the last two is the whole safety story:
+
+      ok             git lists it, directory present            leave alone
+      prunable       git lists it, directory gone               `git worktree prune` (existing)
+      orphan-empty   directory present + EMPTY, git blind       safe to auto-remove
+      orphan-content directory present + FILES, git blind       REPORT ONLY - may hold work
+
+    `orphan-empty` is the only class anything here removes automatically, and the removal is a
+    NON-RECURSIVE delete that fails when the directory is not empty. The emptiness check and the
+    delete are therefore not a promise made twice - the filesystem enforces it. A race that drops
+    a file between the two loses nothing: the delete simply fails.
+
+    Dot-source guard: set $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE=1 to load the helpers for Pester
+    without touching git or the filesystem.
+#>
+[CmdletBinding()]
+param()
+
+# The directory an agent host manages inside a repo. Worktrees anywhere else are somebody
+# else's business and are never classified, never reported and never removed.
+$script:ManagedRelPath = '.claude/worktrees'
+
+# ------------------------------------------------------------------------------
+# PURE CORE. Every fact arrives as an argument - no git, no gh, no filesystem.
+# ------------------------------------------------------------------------------
+
+# Classify ONE worktree from facts the caller gathered.
+#
+#   $KnownToGit   does `git worktree list` mention this path?
+#   $PathExists   is the directory on disk?
+#   $IsEmpty      does it contain zero files? (only meaningful when $PathExists)
+#
+# `prunable` is deliberately derived from (known + absent) rather than read from git's marker,
+# so one predicate covers both directions and the tests can pin them side by side.
+function Get-WorktreeGhostClass {
+    param(
+        [Parameter(Mandatory)][bool]$KnownToGit,
+        [Parameter(Mandatory)][bool]$PathExists,
+        [bool]$IsEmpty = $false
+    )
+    if ($KnownToGit) {
+        if ($PathExists) { return 'ok' }
+        return 'prunable'
+    }
+    # Not known to git. A path that does not exist is not an orphan directory - there is
+    # nothing on disk to orphan, and saying otherwise would invent work.
+    if (-not $PathExists) { return 'ok' }
+    if ($IsEmpty) { return 'orphan-empty' }
+    return 'orphan-content'
+}
+
+# Is this class safe to delete without asking a human? Exactly one is.
+#
+# AllowEmptyString is deliberate: a malformed or missing class must RETURN false, not throw.
+# This sits on the delete path inside a hook that swallows exceptions, so a throw here would
+# read as "skipped" and hide a real bug. Refusing is the answer that is safe either way, and
+# the comparison is case-sensitive so a near-miss like 'Orphan-Empty' is refused too.
+function Test-WorktreeAutoRemovable {
+    param([AllowEmptyString()][string]$Class)
+    return $Class -ceq 'orphan-empty'
+}
+
+# Normalize a path for comparison against `git worktree list`, which reports forward slashes
+# on Windows while the filesystem hands back backslashes. Casing is folded because Windows
+# paths are case-insensitive; on case-sensitive filesystems this can only merge entries that
+# the agent host would not have created differently anyway.
+function ConvertTo-ComparablePath {
+    param([string]$Path)
+    if (-not $Path) { return '' }
+    return ($Path -replace '\\', '/').TrimEnd('/').ToLowerInvariant()
+}
+
+# Parse the paths out of `git worktree list --porcelain` output. Pure: takes the text.
+function Get-WorktreePathsFromPorcelain {
+    param([string]$Porcelain)
+    if (-not $Porcelain) { return @() }
+    $paths = @()
+    foreach ($line in ($Porcelain -split "`r?`n")) {
+        if ($line -match '^worktree\s+(.+)$') { $paths += (ConvertTo-ComparablePath $matches[1]) }
+    }
+    return $paths
+}
+
+# The NAMES of the worktrees git knows that live in a managed directory.
+#
+# WHY NAMES AND NOT PATHS. Comparing absolute paths looked obvious and is wrong: git prints the
+# path it recorded while the filesystem hands back whatever alias you walked in through - an 8.3
+# short name (C:\Users\CRISTO~1\...), a junction, a substituted drive. The two strings differ for
+# the same directory, the worktree looks unknown to git, and a LIVE worktree gets classified as
+# an orphan. An empty one would then be swept. Caught by running it against a real repo.
+#
+# Every managed worktree is a direct child of `.claude/worktrees/`, so within that one directory
+# a name is unique and is the only part of the path both sides agree on. Matching the parent by
+# SUFFIX keeps the comparison clear of the aliased prefix entirely.
+function Get-KnownWorktreeNames {
+    param(
+        [string]$Porcelain,
+        [string]$ManagedRelPath = '.claude/worktrees'
+    )
+    $suffix = ConvertTo-ComparablePath $ManagedRelPath
+    $names = @()
+    foreach ($p in (Get-WorktreePathsFromPorcelain $Porcelain)) {
+        $parent = ConvertTo-ComparablePath (Split-Path $p -Parent)
+        if ($parent.EndsWith($suffix)) { $names += (Split-Path $p -Leaf) }
+    }
+    return $names
+}
+
+# Decide which registry entries are stale. Pure: the caller supplies the existence verdict,
+# so this stays testable without a filesystem.
+#
+# $Entries: objects with .Name and .Path; $ExistsMap: hashtable comparable-path -> [bool].
+function Select-StaleRegistryEntries {
+    param(
+        [object[]]$Entries = @(),
+        [hashtable]$ExistsMap = @{}
+    )
+    $stale = @()
+    foreach ($e in $Entries) {
+        if (-not $e.Path) { continue }
+        $key = ConvertTo-ComparablePath $e.Path
+        if (-not $ExistsMap.ContainsKey($key) -or -not $ExistsMap[$key]) { $stale += $e }
+    }
+    return $stale
+}
+
+# ------------------------------------------------------------------------------
+# IMPURE EDGE. Thin wrappers that gather the facts the pure core consumes.
+# ------------------------------------------------------------------------------
+
+# Where the agent host keeps its machine-wide worktree registry. Returns $null when the host
+# is not installed - a perfectly normal state that must not be an error.
+function Get-WorktreeRegistryPath {
+    $roots = @()
+    if ($env:APPDATA) { $roots += (Join-Path $env:APPDATA 'Claude') }
+    if ($env:HOME)    { $roots += (Join-Path $env:HOME 'Library/Application Support/Claude') }
+    if ($HOME)        { $roots += (Join-Path $HOME '.config/Claude') }
+    foreach ($r in $roots) {
+        $p = Join-Path $r 'git-worktrees.json'
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    return $null
+}
+
+# Read the registry into {Name, Path} objects. Never throws: an unreadable or malformed
+# registry means "no entries", not a failed audit.
+function Get-RegistryWorktrees {
+    param([string]$RegistryPath)
+    if (-not $RegistryPath) { $RegistryPath = Get-WorktreeRegistryPath }
+    if (-not $RegistryPath -or -not (Test-Path -LiteralPath $RegistryPath)) { return @() }
+    try {
+        $json = Get-Content -LiteralPath $RegistryPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    } catch { return @() }
+    if (-not $json.worktrees) { return @() }
+    $out = @()
+    foreach ($p in $json.worktrees.PSObject.Properties) {
+        $out += [pscustomobject]@{ Name = $p.Name; Path = [string]$p.Value.path }
+    }
+    return $out
+}
+
+# Does this directory hold zero files? Recursive, because a worktree whose only content is an
+# empty nested directory still holds nothing worth protecting.
+function Test-DirectoryEmpty {
+    param([Parameter(Mandatory)][string]$Path)
+    try {
+        $f = Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction Stop
+        return (@($f).Count -eq 0)
+    } catch {
+        # Unreadable -> treat as NOT empty. Refusing to call something empty is the safe
+        # failure: the worst outcome is that a human is asked about a directory that was junk.
+        return $false
+    }
+}
+
+# The full inventory for ONE repo: every directory under the managed path, classified.
+function Get-WorktreeGhosts {
+    param(
+        [string]$RepoRoot = '.',
+        [string]$Porcelain
+    )
+    $managed = Join-Path $RepoRoot ($script:ManagedRelPath -replace '/', [IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path -LiteralPath $managed)) { return @() }
+
+    # IsNullOrEmpty, NOT `$null -eq`: an unbound [string] parameter arrives as '', never $null,
+    # so the null check silently skipped the git call and left the known-set empty - which
+    # classifies EVERY live worktree as an orphan. The pure tests could not see it because they
+    # all pass -Porcelain explicitly; only running it against a real repo showed it.
+    if ([string]::IsNullOrEmpty($Porcelain)) {
+        $Porcelain = (& git -C $RepoRoot worktree list --porcelain 2>$null) -join "`n"
+    }
+    # Names, not paths - see Get-KnownWorktreeNames for why the obvious version was unsafe.
+    $known = @(Get-KnownWorktreeNames -Porcelain $Porcelain -ManagedRelPath $script:ManagedRelPath)
+
+    $out = @()
+    foreach ($d in (Get-ChildItem -LiteralPath $managed -Directory -Force -ErrorAction SilentlyContinue)) {
+        $isKnown = $known -contains $d.Name
+        $empty   = if ($isKnown) { $false } else { Test-DirectoryEmpty $d.FullName }
+        $class   = Get-WorktreeGhostClass -KnownToGit $isKnown -PathExists $true -IsEmpty $empty
+        if ($class -eq 'ok') { continue }
+        $out += [pscustomobject]@{
+            Name          = $d.Name
+            Path          = $d.FullName
+            Class         = $class
+            AutoRemovable = (Test-WorktreeAutoRemovable $class)
+        }
+    }
+    return $out
+}
+
+# Remove ONE orphan directory. The delete is non-recursive on purpose: .NET refuses to delete a
+# non-empty directory, so the filesystem - not this code - is what guarantees no work is lost.
+# Returns $true only when the directory is actually gone.
+function Remove-EmptyWorktreeOrphan {
+    param([Parameter(Mandatory)][string]$Path)
+    try {
+        [System.IO.Directory]::Delete($Path, $false)   # $false = non-recursive
+        return -not (Test-Path -LiteralPath $Path)
+    } catch {
+        return $false
+    }
+}
+
+if ($env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE) { return }

--- a/plugins/agentic-board/scripts/Worktree-SessionStartHook.ps1
+++ b/plugins/agentic-board/scripts/Worktree-SessionStartHook.ps1
@@ -1,0 +1,93 @@
+<#  Worktree-SessionStartHook.ps1 - sweep empty orphan worktree directories at session start (#618).
+
+    WHY A HOOK AND NOT A COMMAND. These orphans are born from abnormal session termination, so
+    the moment a new session starts is exactly when the previous one's wreckage is on disk and
+    nothing is using it. Waiting for someone to remember to run the doctor is what let a repo
+    accumulate them for a week.
+
+    WHAT IT TOUCHES. Only directories under `.claude/worktrees/` in the CURRENT repo that git
+    does not know about AND that contain zero files. Never a worktree git still lists, never one
+    with content. The removal is non-recursive, so a directory that gained a file between the
+    check and the delete simply survives - the filesystem is the guard, not this script's timing.
+
+    Everything else - orphans WITH content, and stale entries in the machine-wide registry - is
+    left for `/board doctor` to report, because deciding those needs a human.
+
+    A SessionStart hook that fails would disrupt startup, so every path is wrapped and the script
+    always exits 0. Silence is the normal outcome: context is emitted only when something was
+    actually removed.
+
+    Dot-source guard: set $env:ABIOS_WORKTREE_HOOK_DOTSOURCE=1 to load the pure helpers for
+    Pester without reading stdin or touching the filesystem.
+#>
+[CmdletBinding()]
+param()
+
+# Should this source run the sweep? Startup and resume both follow a previous session's exit,
+# which is precisely when wreckage exists. `compact` is the same live session continuing - its
+# worktrees are in use, so sweeping there would be pure risk for no gain.
+function Test-ShouldSweepWorktrees {
+    param([string]$Source)
+    return $Source -in @('startup', 'resume')
+}
+
+# The message shown after a sweep. Pure so a test can pin the wording without a filesystem.
+# Names the count and the paths: a silent delete of something a human never knew existed is
+# how a "cleanup" becomes indistinguishable from data loss in someone's memory.
+function Get-SweepContext {
+    param([string[]]$Removed = @())
+    if (-not $Removed -or @($Removed).Count -eq 0) { return '' }
+    $n = @($Removed).Count
+    $list = ($Removed | ForEach-Object { "  - $_" }) -join "`n"
+    @"
+agentic-board removed $n empty orphan worktree director$(if ($n -eq 1) { 'y' } else { 'ies' }) left
+behind by a previous session. Each was absent from 'git worktree list' and contained zero files;
+the delete was non-recursive, so nothing with content could have been touched.
+
+$list
+
+Mention this to the user in one short line, then continue with their request.
+"@
+}
+
+if ($env:ABIOS_WORKTREE_HOOK_DOTSOURCE) { return }
+
+try {
+    # No redirected stdin (run by hand) -> no hook payload; bail before ReadToEnd blocks.
+    if (-not [Console]::IsInputRedirected) { exit 0 }
+
+    $raw = ""
+    try { $raw = [Console]::In.ReadToEnd() } catch { $raw = "" }
+    $in = $null
+    if ($raw) { try { $in = $raw | ConvertFrom-Json } catch { $in = $null } }
+
+    $source = if ($in -and $in.source) { [string]$in.source } else { "" }
+    if (-not (Test-ShouldSweepWorktrees $source)) { exit 0 }
+
+    $cwd = if ($in -and $in.cwd) { [string]$in.cwd } else { (Get-Location).Path }
+
+    # Only act inside a git repo - outside one there is no managed worktree directory to sweep.
+    $inRepo = (& git -C $cwd rev-parse --is-inside-work-tree 2>$null)
+    if ($LASTEXITCODE -ne 0 -or "$inRepo".Trim() -ne 'true') { exit 0 }
+
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = '1'
+    . (Join-Path $PSScriptRoot 'Worktree-Ghosts.ps1')
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = ''
+
+    $ghosts = @(Get-WorktreeGhosts -RepoRoot $cwd | Where-Object { $_.AutoRemovable })
+    if ($ghosts.Count -eq 0) { exit 0 }
+
+    $removed = @()
+    foreach ($g in $ghosts) {
+        if (Remove-EmptyWorktreeOrphan -Path $g.Path) { $removed += $g.Path }
+    }
+    if ($removed.Count -eq 0) { exit 0 }
+
+    $out = @{ hookSpecificOutput = @{ hookEventName = 'SessionStart'; additionalContext = (Get-SweepContext $removed) } } |
+        ConvertTo-Json -Compress
+    Write-Output $out
+}
+catch {
+    # A SessionStart hook must never fail the session - swallow everything.
+}
+exit 0

--- a/plugins/agentic-board/tests/Worktree-Ghosts.Integration.Tests.ps1
+++ b/plugins/agentic-board/tests/Worktree-Ghosts.Integration.Tests.ps1
@@ -1,0 +1,128 @@
+#Requires -Modules Pester
+<#  Integration tests for Worktree-Ghosts.ps1 against a REAL git repo (#618).
+
+    WHY THIS FILE EXISTS, separate from the pure suite. Two bugs shipped past a fully green pure
+    suite because every pure test supplied the porcelain by hand:
+
+      1. Absolute-path comparison. Git prints the path it recorded; the filesystem returns the
+         alias you walked in through (8.3 short name, junction, subst drive). A LIVE worktree was
+         classified as an orphan.
+      2. `[string]$Porcelain` defaulting. An unbound [string] parameter is '', never $null, so the
+         "should I call git?" guard never fired, the known-set stayed empty, and EVERY worktree
+         looked orphaned.
+
+    Both are invisible to a test that hands the function its inputs. The only thing that catches
+    them is walking a real repo through the real entry point - so that is what this does.
+
+    Skipped wholesale when git is unavailable, so the pure suite still runs anywhere.
+#>
+
+# Evaluated during DISCOVERY, which is when Pester 5 reads every -Skip: expression - a full
+# phase before any BeforeAll runs. Computing this inside BeforeAll leaves the flag $null at
+# discovery, `-not $null` is $true, and the whole file silently skips while reporting success.
+$HasGit = [bool](Get-Command git -ErrorAction SilentlyContinue)
+$IsWindowsHost = ($env:OS -eq 'Windows_NT')
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Worktree-Ghosts.ps1' | Resolve-Path
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = ''
+
+    $script:HasGit = [bool](Get-Command git -ErrorAction SilentlyContinue)
+
+    if ($script:HasGit) {
+        $script:Repo = Join-Path ([IO.Path]::GetTempPath()) ("abios-wt-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        New-Item -ItemType Directory -Path $script:Repo -Force | Out-Null
+
+        Push-Location $script:Repo
+        git init -q .                          2>&1 | Out-Null
+        git config user.email 'test@example.invalid'
+        git config user.name  'test'
+        git config commit.gpgsign false
+        Set-Content -Path (Join-Path $script:Repo 'a.txt') -Value 'seed'
+        git add .                              2>&1 | Out-Null
+        git commit -qm 'seed'                  2>&1 | Out-Null
+
+        $wtRoot = Join-Path $script:Repo '.claude/worktrees'
+        New-Item -ItemType Directory -Path $wtRoot -Force | Out-Null
+
+        # A worktree git genuinely manages.
+        git worktree add -q (Join-Path $wtRoot 'live') -b live-branch 2>&1 | Out-Null
+        # An orphan with nothing in it - the sweepable class.
+        New-Item -ItemType Directory -Path (Join-Path $wtRoot 'orphan-empty') -Force | Out-Null
+        # An orphan holding a file - must never be swept.
+        $withWork = Join-Path $wtRoot 'orphan-with-work'
+        New-Item -ItemType Directory -Path $withWork -Force | Out-Null
+        Set-Content -Path (Join-Path $withWork 'uncommitted.txt') -Value 'work nobody wants to lose'
+        Pop-Location
+    }
+}
+
+AfterAll {
+    if ($script:Repo -and (Test-Path $script:Repo)) {
+        Push-Location $script:Repo
+        git worktree remove --force (Join-Path $script:Repo '.claude/worktrees/live') 2>&1 | Out-Null
+        Pop-Location
+        Remove-Item -LiteralPath $script:Repo -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-WorktreeGhosts against a real repo' -Skip:(-not $HasGit) {
+
+    It 'does NOT report the worktree git is managing' {
+        # Bug #1 and #2 both surfaced right here: `live` came back as an orphan.
+        $g = @(Get-WorktreeGhosts -RepoRoot $script:Repo)
+        ($g | Where-Object { $_.Name -eq 'live' }) | Should -BeNullOrEmpty
+    }
+
+    It 'finds the empty orphan and marks it auto-removable' {
+        $g = @(Get-WorktreeGhosts -RepoRoot $script:Repo) | Where-Object { $_.Name -eq 'orphan-empty' }
+        $g              | Should -Not -BeNullOrEmpty
+        $g.Class        | Should -Be 'orphan-empty'
+        $g.AutoRemovable| Should -BeTrue
+    }
+
+    It 'finds the orphan holding a file and refuses to mark it auto-removable' {
+        $g = @(Get-WorktreeGhosts -RepoRoot $script:Repo) | Where-Object { $_.Name -eq 'orphan-with-work' }
+        $g              | Should -Not -BeNullOrEmpty
+        $g.Class        | Should -Be 'orphan-content'
+        $g.AutoRemovable| Should -BeFalse
+    }
+
+    It 'calls git when no porcelain is supplied (an unbound [string] is "", not $null)' {
+        # Pin the exact defaulting bug: omitting -Porcelain must mean "go ask git", never
+        # "assume there are no worktrees" - the latter orphans everything.
+        $g = @(Get-WorktreeGhosts -RepoRoot $script:Repo)
+        @($g).Count | Should -Be 2      # the two orphans, and never `live`
+    }
+
+    It 'reaches the same verdict through an 8.3-shortened path' -Skip:(-not $IsWindowsHost) {
+        # The alias trap, exercised for real: same directory, different string.
+        $fso = New-Object -ComObject Scripting.FileSystemObject
+        $short = $fso.GetFolder($script:Repo).ShortPath
+        if ($short -and $short -ne $script:Repo) {
+            $g = @(Get-WorktreeGhosts -RepoRoot $short)
+            ($g | Where-Object { $_.Name -eq 'live' }) | Should -BeNullOrEmpty
+            @($g).Count | Should -Be 2
+        }
+    }
+}
+
+Describe 'Remove-EmptyWorktreeOrphan is guarded by the filesystem' -Skip:(-not $HasGit) {
+
+    It 'refuses a directory that holds a file, and leaves the file untouched' {
+        $withWork = Join-Path $script:Repo '.claude/worktrees/orphan-with-work'
+        $file     = Join-Path $withWork 'uncommitted.txt'
+        Remove-EmptyWorktreeOrphan -Path $withWork | Should -BeFalse
+        Test-Path $withWork | Should -BeTrue
+        Test-Path $file     | Should -BeTrue
+        Get-Content $file   | Should -Be 'work nobody wants to lose'
+    }
+
+    It 'removes an empty orphan' {
+        $empty = Join-Path $script:Repo '.claude/worktrees/orphan-empty'
+        Remove-EmptyWorktreeOrphan -Path $empty | Should -BeTrue
+        Test-Path $empty | Should -BeFalse
+    }
+}

--- a/plugins/agentic-board/tests/Worktree-Ghosts.Tests.ps1
+++ b/plugins/agentic-board/tests/Worktree-Ghosts.Tests.ps1
@@ -1,0 +1,186 @@
+#Requires -Modules Pester
+<#  Pester tests for Worktree-Ghosts.ps1 - the orphan-worktree classifier (#618).
+
+    The bug being pinned: the doctor's original check trusted git's `prunable` marker, which
+    only ever describes "metadata present, directory gone". The directory that SURVIVES while
+    git forgets it is the inverse, and it was invisible - so the two directions are asserted
+    side by side here, and a regression that collapses them fails loudly.
+
+    The second thing pinned is the safety line: `orphan-content` must never be auto-removable.
+    That single predicate is what stands between an automatic sweep and somebody's work.
+
+    Everything under test is pure - facts arrive as arguments, so no git, no gh, no filesystem.
+#>
+
+BeforeAll {
+    $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Worktree-Ghosts.ps1' | Resolve-Path
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = '1'
+    . $script:Script
+    $env:ABIOS_WORKTREE_GHOSTS_DOTSOURCE = ''
+
+    $script:HookScript = Join-Path $PSScriptRoot '..' 'scripts' 'Worktree-SessionStartHook.ps1' | Resolve-Path
+    $env:ABIOS_WORKTREE_HOOK_DOTSOURCE = '1'
+    . $script:HookScript
+    $env:ABIOS_WORKTREE_HOOK_DOTSOURCE = ''
+}
+
+Describe 'Get-WorktreeGhostClass - the two directions of "ghost"' {
+    It 'calls a listed worktree whose directory is present ok' {
+        Get-WorktreeGhostClass -KnownToGit $true -PathExists $true | Should -Be 'ok'
+    }
+    It 'calls a listed worktree whose directory is gone prunable (git can see this one)' {
+        Get-WorktreeGhostClass -KnownToGit $true -PathExists $false | Should -Be 'prunable'
+    }
+    It 'calls an EMPTY directory git does not know orphan-empty (the case that was invisible)' {
+        Get-WorktreeGhostClass -KnownToGit $false -PathExists $true -IsEmpty $true |
+            Should -Be 'orphan-empty'
+    }
+    It 'calls a directory WITH FILES that git does not know orphan-content' {
+        Get-WorktreeGhostClass -KnownToGit $false -PathExists $true -IsEmpty $false |
+            Should -Be 'orphan-content'
+    }
+    It 'does not invent an orphan when neither git nor the filesystem has anything' {
+        Get-WorktreeGhostClass -KnownToGit $false -PathExists $false | Should -Be 'ok'
+    }
+    It 'never confuses the two ghost directions' {
+        $prunable = Get-WorktreeGhostClass -KnownToGit $true  -PathExists $false
+        $orphan   = Get-WorktreeGhostClass -KnownToGit $false -PathExists $true -IsEmpty $true
+        $prunable | Should -Not -Be $orphan
+    }
+}
+
+Describe 'Test-WorktreeAutoRemovable - the safety line' {
+    It 'allows exactly one class to be removed without asking' {
+        Test-WorktreeAutoRemovable -Class 'orphan-empty' | Should -BeTrue
+    }
+    It 'REFUSES to auto-remove an orphan that holds files' {
+        # If this ever passes, the sweep can eat uncommitted work. It is the whole point.
+        Test-WorktreeAutoRemovable -Class 'orphan-content' | Should -BeFalse
+    }
+    It 'refuses every other class' {
+        foreach ($c in @('ok', 'prunable', '', 'ORPHAN-EMPTY')) {
+            Test-WorktreeAutoRemovable -Class $c | Should -BeFalse
+        }
+    }
+}
+
+Describe 'ConvertTo-ComparablePath' {
+    It 'makes the porcelain forward slashes match a Windows filesystem path' {
+        $git = ConvertTo-ComparablePath 'C:/repo/.claude/worktrees/thing'
+        $fs  = ConvertTo-ComparablePath 'C:\repo\.claude\worktrees\thing'
+        $git | Should -Be $fs
+    }
+    It 'ignores a trailing separator and casing' {
+        ConvertTo-ComparablePath 'C:\Repo\WT\' | Should -Be (ConvertTo-ComparablePath 'c:/repo/wt')
+    }
+    It 'survives an empty or null path without throwing' {
+        ConvertTo-ComparablePath ''   | Should -Be ''
+        ConvertTo-ComparablePath $null | Should -Be ''
+    }
+}
+
+Describe 'Get-WorktreePathsFromPorcelain' {
+    It 'extracts every worktree path and ignores the other porcelain fields' {
+        $p = @(
+            'worktree C:/repo'
+            'HEAD abc123'
+            'branch refs/heads/main'
+            ''
+            'worktree C:/repo/.claude/worktrees/alpha'
+            'HEAD def456'
+            'detached'
+        ) -join "`n"
+        $paths = Get-WorktreePathsFromPorcelain $p
+        @($paths).Count | Should -Be 2
+        $paths | Should -Contain (ConvertTo-ComparablePath 'C:/repo/.claude/worktrees/alpha')
+    }
+    It 'returns nothing for empty input instead of throwing' {
+        @(Get-WorktreePathsFromPorcelain '').Count | Should -Be 0
+    }
+}
+
+Describe 'Get-KnownWorktreeNames - the path-aliasing trap' {
+    # Regression: the first version compared ABSOLUTE paths. Git prints the path it recorded,
+    # the filesystem returns whatever alias you walked in through, the strings differ for the
+    # same directory - and a LIVE worktree was classified orphan-content. Had it been empty the
+    # hook would have deleted a worktree in use. Found by running it, not by reading it.
+    It 'matches a live worktree even when git and the filesystem disagree on the prefix' {
+        $porcelain = 'worktree C:/Users/Cristobal/repo/.claude/worktrees/sano'
+        $names = Get-KnownWorktreeNames -Porcelain $porcelain
+        $names | Should -Contain 'sano'
+        # The disk side supplies only the leaf, so the 8.3 / junction prefix cannot break it.
+        Get-WorktreeGhostClass -KnownToGit ($names -contains 'sano') -PathExists $true -IsEmpty $true |
+            Should -Be 'ok'
+    }
+    It 'ignores worktrees that live outside the managed directory' {
+        $porcelain = @(
+            'worktree C:/repo'
+            'worktree C:/repo--worktrees/manual-one'
+            'worktree C:/repo/.claude/worktrees/managed-one'
+        ) -join "`n"
+        $names = Get-KnownWorktreeNames -Porcelain $porcelain
+        $names | Should -Contain 'managed-one'
+        $names | Should -Not -Contain 'manual-one'
+        @($names).Count | Should -Be 1
+    }
+    It 'tolerates backslashes from a Windows-shaped porcelain' {
+        $names = Get-KnownWorktreeNames -Porcelain 'worktree C:\repo\.claude\worktrees\alpha'
+        $names | Should -Contain 'alpha'
+    }
+    It 'returns nothing when no worktree is managed' {
+        @(Get-KnownWorktreeNames -Porcelain 'worktree C:/repo').Count | Should -Be 0
+    }
+}
+
+Describe 'Select-StaleRegistryEntries - the machine-wide half' {
+    It 'flags an entry whose path no longer exists' {
+        $entries = @([pscustomobject]@{ Name = 'gone'; Path = 'C:/other-repo/.claude/worktrees/gone' })
+        $map = @{ (ConvertTo-ComparablePath 'C:/other-repo/.claude/worktrees/gone') = $false }
+        @(Select-StaleRegistryEntries -Entries $entries -ExistsMap $map).Count | Should -Be 1
+    }
+    It 'leaves an entry whose path is still there' {
+        $entries = @([pscustomobject]@{ Name = 'live'; Path = 'C:/other-repo/.claude/worktrees/live' })
+        $map = @{ (ConvertTo-ComparablePath 'C:/other-repo/.claude/worktrees/live') = $true }
+        @(Select-StaleRegistryEntries -Entries $entries -ExistsMap $map).Count | Should -Be 0
+    }
+    It 'treats an unknown path as stale rather than silently assuming it is fine' {
+        $entries = @([pscustomobject]@{ Name = 'unmapped'; Path = 'C:/x/y' })
+        @(Select-StaleRegistryEntries -Entries $entries -ExistsMap @{}).Count | Should -Be 1
+    }
+    It 'skips entries with no path at all' {
+        $entries = @([pscustomobject]@{ Name = 'broken'; Path = '' })
+        @(Select-StaleRegistryEntries -Entries $entries -ExistsMap @{}).Count | Should -Be 0
+    }
+    It 'returns nothing for an empty registry' {
+        @(Select-StaleRegistryEntries -Entries @() -ExistsMap @{}).Count | Should -Be 0
+    }
+}
+
+Describe 'Worktree-SessionStartHook gating' {
+    It 'sweeps after a session ended - startup and resume' {
+        Test-ShouldSweepWorktrees 'startup' | Should -BeTrue
+        Test-ShouldSweepWorktrees 'resume'  | Should -BeTrue
+    }
+    It 'does NOT sweep on compact, where the worktrees are still in use' {
+        Test-ShouldSweepWorktrees 'compact' | Should -BeFalse
+    }
+    It 'does not sweep on an unknown or empty source' {
+        Test-ShouldSweepWorktrees ''        | Should -BeFalse
+        Test-ShouldSweepWorktrees 'unknown' | Should -BeFalse
+    }
+}
+
+Describe 'Get-SweepContext' {
+    It 'says nothing when nothing was removed - silence is the normal outcome' {
+        Get-SweepContext @() | Should -BeNullOrEmpty
+    }
+    It 'names every removed path, so a delete is never invisible to the user' {
+        $ctx = Get-SweepContext @('C:/repo/.claude/worktrees/alpha', 'C:/repo/.claude/worktrees/beta')
+        $ctx | Should -Match 'alpha'
+        $ctx | Should -Match 'beta'
+        $ctx | Should -Match '2 empty orphan'
+    }
+    It 'uses the singular for one directory' {
+        Get-SweepContext @('C:/repo/.claude/worktrees/solo') | Should -Match '1 empty orphan worktree directory'
+    }
+}


### PR DESCRIPTION
Closes #618

## Qué cambia

El doctor detectaba worktrees fantasma filtrando por la marca `Prunable` de git, que solo
significa «metadata presente, carpeta ausente». El caso inverso no tenía nombre: la carpeta
sobrevive bajo `.claude/worktrees/` con el enlace `.git` roto, git ya podó su metadata y el
worktree no aparece en `git worktree list`. Nunca listado → nunca un registro → nunca
`Prunable` → invisible.

Invisible pero no inerte: el host mantiene esas entradas en un registro global y reintenta
podarlas periódicamente, de modo que un puñado acumula cientos de invocaciones de git fallidas.

## Cómo

- **`Worktree-Ghosts.ps1`** nombra cuatro estados: `ok`, `prunable`, `orphan-empty`,
  `orphan-content`. Solo `orphan-empty` se borra sin preguntar.
- **`Worktree-SessionStartHook.ps1`** los barre en `startup` y `resume` — nunca en `compact`,
  donde los worktrees siguen en uso.
- **`Board-Doctor.ps1`** reporta el resto, incluidas entradas del registro que apuntan a otros
  repos: el ciclo de reintentos es global de la máquina y ninguna invocación por repo las vería.

El borrado es **no recursivo**: .NET se niega a borrar un directorio no vacío, así que la
garantía de que no se pierde trabajo la da el filesystem, no una comprobación que este código
haga y luego se crea. Si aparece un archivo entre la comprobación y el borrado, el borrado
simplemente falla.

## Dos bugs que la suite pura no vio

Ambos pasaron con 29 tests puros en verde y solo aparecieron al ejecutar contra un repo git
real. Por eso existe `Worktree-Ghosts.Integration.Tests.ps1` junto a la suite pura, en vez de
haberlos arreglado en silencio:

1. **Comparación de rutas absolutas.** Git imprime la ruta que registró; el filesystem devuelve
   el alias por el que entraste (nombre 8.3, junction, unidad `subst`). Un worktree **vivo**
   quedaba clasificado como huérfano — y de haber estado vacío, el hook lo habría borrado.
   Ahora se compara por nombre dentro del directorio gestionado, lo que esquiva el prefijo
   aliasado por completo.
2. **`[string]$Porcelain` sin enlazar llega como `''`, nunca `$null`.** La guarda
   `if ($null -eq ...)` nunca se cumplía, así que jamás se llamaba a git y el conjunto de
   conocidos quedaba vacío, lo que convertía en huérfano a **todos** los worktrees del repo.

## Verificación

- `Worktree-Ghosts.Tests.ps1` — 29 tests puros (sin git, sin gh)
- `Worktree-Ghosts.Integration.Tests.ps1` — 7 tests contra un repo git real, incluido el caso
  de ruta 8.3 y la negativa a borrar un huérfano con archivos
- `Scripts.Parse.Tests.ps1` y `Board-Doctor.Tests.ps1` sin regresión — **179/179 en verde**
- Ejecución real de `Board-Doctor.ps1` con huérfanos fabricados: ambas secciones nuevas
  renderizan y los worktrees sanos no aparecen (cero falsos positivos)
