### PR TITLE
Agregar una opcion de lote al script de board work para que las sub-tareas chicas y secuenciales de un mismo epic salgan en UN solo branch, PR, gate y merge en vez de un ciclo completo por cada una

### DIFF
--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -136,6 +136,12 @@ param(
     # thousands separator -> 129130), NOT a 2-element array. Get-ParallelQueue
     # splits each token on ',' so both `-File` and native-array calls work.
     [string[]] $Parallel = @(),
+    # Batch start (#633): several small, sequential sub-issues of the same epic share ONE
+    # branch/worktree instead of each getting its own -Start cycle, so they close through ONE
+    # PR/gate/merge. Same tolerant parsing as -Parallel (Get-ParallelQueue), for the same
+    # `pwsh -File` flattening reason. Mutually exclusive with -Start and -Parallel: those are
+    # two other, different ways of starting issues.
+    [string[]] $StartGroup = @(),
     [switch]$Launch,
     [switch]$Fleet,
     [switch]$Sessions,
@@ -2299,6 +2305,13 @@ if (-not $env:GH_TOKEN) { throw "$TokenVar not set in Windows USER environment (
 # branch on a base the caller did not ask for - the exact class of bug #294 was.
 if ($Base -and $BaseCurrent) { throw "-Base and -BaseCurrent are mutually exclusive: pick the ref, or the current HEAD." }
 
+# -StartGroup is a third, distinct way to start issues (#633) - combining it with -Start or
+# -Parallel would leave it ambiguous which mode actually ran.
+$groupQueue = @(Get-ParallelQueue $StartGroup)
+if ($groupQueue.Count -gt 0 -and ($Start -gt 0 -or $Parallel.Count -gt 0)) {
+    throw "-StartGroup es mutuamente exclusivo con -Start y -Parallel: son tres modos distintos de arrancar issues."
+}
+
 # ==============================================================================
 # LOCK MODE: -Lock <n> / -Unlock <n>  -> in ONE step mark an issue owned-elsewhere
 # (post the [abios-claim] fingerprint, move Status, AND assign the owner) WITHOUT
@@ -2590,7 +2603,7 @@ $boardUrl = Get-BoardUrl $ProjectNum
 # ==============================================================================
 # MODE 2: -ProjectNum  -> pending items of one board
 # ==============================================================================
-if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0) {
+if ($Start -le 0 -and $ToReview -le 0 -and $Parallel.Count -eq 0 -and $groupQueue.Count -eq 0) {
     Write-Host "=== Pendientes del board #$ProjectNum de $Owner ===" -ForegroundColor Cyan
     Write-Host ""
 
@@ -2966,6 +2979,65 @@ if ($Parallel.Count -gt 0) {
         Invoke-SessionWatch -PollSec $WatchPollSec -TimeoutSec $WatchTimeoutSec -AutoClean:$AutoClean -ForceDeleteBranch:$ForceDeleteBranch -ForceRemoveWorktree:$ForceRemoveWorktree | Out-Null
     }
 
+    Write-Host ""
+    Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+    exit 0
+}
+
+# ==============================================================================
+# MODE 3b: -ProjectNum -StartGroup <n1,n2,...>  -> ONE shared branch for several small,
+# sequential sub-issues of the same epic (#633), so they close through ONE PR/gate/merge
+# instead of a full start->PR->gate->merge cycle per issue.
+#
+# The FIRST issue in the group is the leader: it gets the branch/worktree exactly like a
+# normal -Start (board mechanics + New-IssueWorkspace). The rest only get the board mechanics
+# (Status -> In Progress, assignee, [abios-claim] comment) via the same Invoke-IssueStart,
+# just without -MakeBranch - then a session-registry row is added for each, pointing at the
+# leader's branch/workPath, so /board watch and cleanup see the whole group as one session.
+# ==============================================================================
+if ($groupQueue.Count -gt 0) {
+    Write-Host "=== Empezando lote de issues $($groupQueue -join ', ') (board #$ProjectNum de $Owner) ===" -ForegroundColor Cyan
+    Write-Host ""
+
+    $ctx = Resolve-BoardStatus $Owner $ProjectNum
+    $lead = Invoke-IssueStart -IssueNum $groupQueue[0] -Ctx $ctx -Owner $Owner -MakeBranch:$Branch `
+                              -Base $Base -BaseCurrent:$BaseCurrent `
+                              -DryRunStart:$DryRun -IgnoreBlocked:$IgnoreBlocked -TakeOver:$TakeOver
+    if ($lead.skipped) {
+        Write-Host ""
+        Write-Host "Lote ABORTADO: el issue lider #$($groupQueue[0]) no pudo empezar - ningun issue del lote fue tocado." -ForegroundColor Red
+        Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+        exit 1
+    }
+
+    $started = @($lead)
+    foreach ($n in ($groupQueue | Select-Object -Skip 1)) {
+        $r = Invoke-IssueStart -IssueNum $n -Ctx $ctx -Owner $Owner `
+                               -Base $Base -BaseCurrent:$BaseCurrent `
+                               -DryRunStart:$DryRun -IgnoreBlocked:$IgnoreBlocked -TakeOver:$TakeOver
+        if ($r.skipped) {
+            Write-Host "  (#$n queda fuera del lote - la rama compartida sigue siendo valida para el resto)" -ForegroundColor DarkYellow
+            continue
+        }
+        if (-not $DryRun -and $lead.workPath) {
+            Write-SessionRegistryEntry -IssueNum $n -Branch $lead.branch -WorkPath $lead.workPath -Repo $lead.repo
+        }
+        $started += $r
+    }
+
+    if ($DryRun) {
+        Write-Host ""
+        Write-Host "Modo DRY-RUN - ningun cambio ejecutado." -ForegroundColor Gray
+        Write-Host ""
+        Write-Host "Board: $boardUrl" -ForegroundColor Cyan
+        exit 0
+    }
+
+    $startedNums = ($started | ForEach-Object { $_.issue }) -join ','
+    Write-Host ""
+    Write-Host ("Lote listo: {0} de {1} issue(s) en UNA sola rama ({2})." -f $started.Count, $groupQueue.Count, $lead.branch) -ForegroundColor Green
+    Write-Host "AL TERMINAR (un solo PR para todo el lote): New-BoardPR.ps1 -Issue $startedNums" -ForegroundColor Yellow
+    Write-Host "(un solo Board-ReviewGate.ps1 + un solo Board-Merge.ps1 cierran los $($started.Count) issues a la vez)" -ForegroundColor DarkGray
     Write-Host ""
     Write-Host "Board: $boardUrl" -ForegroundColor Cyan
     exit 0

--- a/plugins/agentic-board/scripts/New-BoardPR.ps1
+++ b/plugins/agentic-board/scripts/New-BoardPR.ps1
@@ -25,7 +25,12 @@
     through Board-ReviewGate.ps1.
 
 .PARAMETER Issue
-    Issue number the PR closes. Mandatory - board PRs always track an issue.
+    One or more issue numbers the PR closes. Mandatory - board PRs always track at least
+    one issue. Pass several (`-Issue 631,632`) to close a batch of small, related sub-issues
+    with a SINGLE PR instead of one PR per issue (#633) - the body gets one 'Closes #<n>' line
+    per issue. Accepts comma-separated strings too (`-Issue '631,632'`), the same tolerant
+    parsing `-Parallel` uses in Board-Work.ps1, so a cross-process `pwsh -File` call that would
+    otherwise flatten a PowerShell array into one string still works.
 
 .PARAMETER Repo
     owner/name. Default: derived from the origin remote of the cwd.
@@ -37,10 +42,11 @@
     Base branch for the PR. Default: the repo's default branch.
 
 .PARAMETER Title
-    PR title. Default: the issue's title.
+    PR title. Default: the first issue's title - pass this explicitly for a batch PR closing
+    more than one issue, since no single issue's title describes the whole batch.
 
 .PARAMETER Body
-    Extra body text appended after the mandatory 'Closes #<n>' line.
+    Extra body text appended after the mandatory 'Closes #<n>' line(s).
 
 .PARAMETER Draft
     Open the PR as a draft.
@@ -57,10 +63,11 @@
     .\New-BoardPR.ps1 -Issue 13
     .\New-BoardPR.ps1 -Issue 42 -Repo PAL-Devs/fabric-reports -Draft
     .\New-BoardPR.ps1 -Issue 13 -DryRun
+    .\New-BoardPR.ps1 -Issue 631,632 -Title "Group small sequential sub-issues into one PR"
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)][int]$Issue,
+    [Parameter(Mandatory)][string[]]$Issue,
     [string]$Repo     = "",
     [string]$Branch   = "",
     [string]$Base     = "",
@@ -73,7 +80,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# ── Pure helper (unit-testable; no gh/network) ────────────────────────────────
+# ── Pure helpers (unit-testable; no gh/network) ───────────────────────────────
 # A PR "already exists" ONLY when the read returned a row with a positive-integer number (#336). The
 # old guard was `@($existing).Count -gt 0`, which counted a phantom element with a null `.number` as
 # "exists" and SKIPPED `gh pr create` — the run then reported success with a blank PR number and no PR
@@ -81,6 +88,32 @@ $ErrorActionPreference = "Stop"
 function Get-ExistingPr {
     param($PrList)
     @($PrList) | Where-Object { $_ -and (($_.number -as [int]) -gt 0) } | Select-Object -First 1
+}
+
+# Parses -Issue the same tolerant way Board-Work.ps1's Get-ParallelQueue parses -Parallel:
+# comma-split each token, keep positive integers only, dedupe, preserve first-seen order (#633).
+# Order matters here - the FIRST issue drives the default -Title when none is given.
+function Get-IssueNumbers {
+    param($Raw)
+    $seen = New-Object System.Collections.Generic.HashSet[int]
+    $out  = @()
+    foreach ($tok in @($Raw)) {
+        foreach ($piece in ("$tok" -split ',')) {
+            $n = 0
+            if ([int]::TryParse($piece.Trim(), [ref]$n) -and $n -gt 0 -and $seen.Add($n)) {
+                $out += $n
+            }
+        }
+    }
+    return $out
+}
+
+# Builds the mandatory 'Closes #<n>' block - one line per issue - plus any extra -Body text (#633).
+function Format-ClosesBody {
+    param([int[]]$Issues, [string]$Extra = "")
+    $closes = ($Issues | ForEach-Object { "Closes #$_" }) -join "`n"
+    if ($Extra) { return "$closes`n`n$Extra" }
+    return $closes
 }
 
 # Dot-source guard: tests set $env:ABIOS_NEWBOARDPR_DOTSOURCE to load the pure helper only.
@@ -145,13 +178,19 @@ if (-not $Branch) { $Branch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() }
 if (-not $Branch -or $Branch -eq 'HEAD') { throw "No pude resolver la rama actual - usa -Branch." }
 if ($Branch -eq $Base) { throw "Estas en '$Base' (la base). Trabaja el issue en su rama issue-<num>-<slug> - nunca PR desde la base a si misma." }
 
-# -- 5. Issue -> title / body ----------------------------------------------------
-$iss = gh api "repos/$Repo/issues/$Issue" 2>$null | ConvertFrom-Json
-if (-not $iss) { throw "Issue #$Issue no existe en $Repo." }
-if ($iss.state -ne 'open') { Write-Host "AVISO: issue #$Issue esta '$($iss.state)' - el PR igual lo referencia." -ForegroundColor Yellow }
-if (-not $Title) { $Title = $iss.title }
-$prBody = "Closes #$Issue"
-if ($Body) { $prBody = "$prBody`n`n$Body" }
+# -- 5. Issue(s) -> title / body -------------------------------------------------
+$issueNums = @(Get-IssueNumbers $Issue)
+if ($issueNums.Count -eq 0) { throw "-Issue no trajo ningun numero de issue valido (recibi '$($Issue -join ',')')." }
+
+$issues = @()
+foreach ($n in $issueNums) {
+    $one = gh api "repos/$Repo/issues/$n" 2>$null | ConvertFrom-Json
+    if (-not $one) { throw "Issue #$n no existe en $Repo." }
+    if ($one.state -ne 'open') { Write-Host "AVISO: issue #$n esta '$($one.state)' - el PR igual lo referencia." -ForegroundColor Yellow }
+    $issues += $one
+}
+if (-not $Title) { $Title = $issues[0].title }
+$prBody = Format-ClosesBody -Issues $issueNums -Extra $Body
 
 # -- Existing open PR for this branch? (re-run = iterate on it) ------------------
 # Fail closed (Invoke-Gh -Json) then require a positive-integer number: a phantom/null-number row is
@@ -164,7 +203,7 @@ Write-Host "=== Cross-account PR  $Repo ===" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "  Identidad : $login  (via $TokenVar)"
 Write-Host "  Rama      : $Branch -> $Base"
-Write-Host "  Issue     : #$Issue $($iss.title)"
+foreach ($one in $issues) { Write-Host ("  Issue     : #{0} {1}" -f $one.number, $one.title) }
 if ($existingPr) {
     Write-Host "  PR        : #$($existingPr.number) ya abierto - solo push (iteracion)" -ForegroundColor Yellow
 } else {

--- a/plugins/agentic-board/skills/projects-admin/references/verbs-work.md
+++ b/plugins/agentic-board/skills/projects-admin/references/verbs-work.md
@@ -161,11 +161,19 @@ and wait for; never assume the account or the scope:
 | 2. Pick a board | `Board-Work.ps1 -ListBoards [-Repo <owner/name>]` | With `-Repo`: only boards LINKED to that repo (`repository.projectsV2`) — exactly one result skips this pick. Without: every board of the owner (backups excluded). Both show pending count (Backlog or no Status) + URL, most pending first |
 | 3. Pick an issue | `Board-Work.ps1 -ProjectNum <n>` | That board's pending items sorted by Priority; drafts flagged (convert via `/board fill` first) |
 | 4. Start it | `Board-Work.ps1 -ProjectNum <n> -Start <issueNum> -Branch` | Status → In Progress, assign owner, create + checkout branch `issue-<num>-<slug>`, print full issue context (body, labels, sub-issues) |
-| 5. Finish it | push branch → PR with `Closes #<num>` → `Board-ReviewGate.ps1 -Repo <owner/name> -PR <n>` → merge-confirmation summary → user confirms → `Board-Merge.ps1 -PR <n>` only on exit 0 AND confirmation | Review gate (GitHub flow: merge only after approval): requests Copilot review when available, waits for CI checks + review, reports decision/feedback/unresolved threads. **Exit 1 = blocked** → fix, push, re-run. **Exit 2 = nobody reviewed** (#510) → see below. On exit 0, present the mandatory merge-confirmation summary (#630/#631, four parts, above) and WAIT for the user's answer before merging — gate green is a precondition for asking, never a reason to skip asking. Merge via `Board-Merge.ps1` (auto `--admin` when the `pr-before-merge` ruleset marks the PR blocked). Then GitHub fills **Linked pull requests** by itself |
+| 4b. Start a batch | `Board-Work.ps1 -ProjectNum <n> -StartGroup <n1,n2,...> -Branch` | Same as step 4, but for several SMALL, SEQUENTIAL sub-issues of the same epic (#633): the first issue gets the branch/worktree, the rest only get the board mechanics (Status/assignee/claim) on that SAME branch. Use this instead of running step 4 once per sub-issue when they're too small/related to justify a PR each — mirrors what #631+#632 did by hand in PR #634 |
+| 5. Finish it | push branch → PR with `Closes #<num>` (or `New-BoardPR.ps1 -Issue <n1,n2,...>` for a batch — one `Closes #<n>` line per issue) → `Board-ReviewGate.ps1 -Repo <owner/name> -PR <n>` → merge-confirmation summary → user confirms → `Board-Merge.ps1 -PR <n>` only on exit 0 AND confirmation | Review gate (GitHub flow: merge only after approval): requests Copilot review when available, waits for CI checks + review, reports decision/feedback/unresolved threads. **Exit 1 = blocked** → fix, push, re-run. **Exit 2 = nobody reviewed** (#510) → see below. On exit 0, present the mandatory merge-confirmation summary (#630/#631, four parts, above) and WAIT for the user's answer before merging — gate green is a precondition for asking, never a reason to skip asking. Merge via `Board-Merge.ps1` (auto `--admin` when the `pr-before-merge` ruleset marks the PR blocked). Then GitHub fills **Linked pull requests** by itself for every closed issue |
 
 Notes:
 - Step 4 supports `-DryRun` (preview, no mutation). A CLOSED issue is refused with a reopen hint.
   It retries once (4s) if the issue was added to the board seconds ago (eventual consistency).
+- **Step 4b / batch (#633)**: `-StartGroup` is mutually exclusive with `-Start` and `-Parallel` —
+  three different ways to start issues, never combined. If the FIRST (leader) issue can't start
+  (blocked, already claimed, etc.) the whole batch aborts untouched; a later issue in the group
+  that can't start is just dropped from it with a warning — the rest still share the branch. Judge
+  "small and sequential" the way #631+#632 were: same epic, no PR-worthy risk on its own, nobody
+  else likely to want to review them separately. Don't batch issues that are independently risky
+  or that different people should be able to approve/reject on their own.
 - After step 4, the agent continues working the issue in-session — the printed context is the briefing.
 - **Gate exit 2 — "GATE SIN REVISAR" (#510).** Checks are green but *nobody looked at the code*: no
   GitHub review, no registered external review. This used to print `GATE PASSED` with a reminder

--- a/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
+++ b/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
@@ -39,3 +39,39 @@ Describe 'Get-ExistingPr — a phantom row is not an existing PR (#336)' {
         $r.number | Should -Be 7
     }
 }
+
+Describe 'Get-IssueNumbers — batch -Issue parsing (#633)' {
+    It 'passes through a native int array' {
+        (Get-IssueNumbers @(631, 632)) | Should -Be @(631, 632)
+    }
+    It 'splits a single comma-separated string (the pwsh -File flattening case)' {
+        (Get-IssueNumbers '631,632') | Should -Be @(631, 632)
+    }
+    It 'trims whitespace around commas' {
+        (Get-IssueNumbers '631, 632 ,633') | Should -Be @(631, 632, 633)
+    }
+    It 'dedupes while preserving first-seen order' {
+        (Get-IssueNumbers @('631,632,631')) | Should -Be @(631, 632)
+    }
+    It 'drops non-positive and non-numeric tokens' {
+        (Get-IssueNumbers @('0,-3,abc,632')) | Should -Be @(632)
+    }
+    It 'returns an empty array for no valid tokens' {
+        @(Get-IssueNumbers @('abc,0')).Count | Should -Be 0
+    }
+}
+
+Describe 'Format-ClosesBody — one Closes line per issue, extra body appended (#633)' {
+    It 'formats a single issue exactly like the pre-#633 behavior' {
+        Format-ClosesBody -Issues @(13) | Should -Be "Closes #13"
+    }
+    It 'formats one Closes line per issue in the given order' {
+        Format-ClosesBody -Issues @(631, 632) | Should -Be "Closes #631`nCloses #632"
+    }
+    It 'appends extra body text after a blank line' {
+        Format-ClosesBody -Issues @(13) -Extra 'Some context.' | Should -Be "Closes #13`n`nSome context."
+    }
+    It 'omits the blank-line separator when there is no extra body' {
+        Format-ClosesBody -Issues @(13) -Extra '' | Should -Be "Closes #13"
+    }
+}


### PR DESCRIPTION
Closes #633