### PR TITLE
Cablear el auto-loop de board-expert a la revision adversarial antes de marcar evidencia verde

### DIFF
--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -184,7 +184,8 @@ are the method.
    the evidence ONCE (#570): the full structured ``[abios-evidence]`` block goes to
    ``evidence/<issue>.md`` — the single source of truth — and the PR body and a durable issue
    comment each get the LINK STUB (marker + summary + link to the file), not a copy. If green ->
-   open the PR + run the review gate.
+   open the PR + run the review gate — with ``-RequireIndependentReviewer`` (see "Independent
+   review" below; it is mandatory for this unsupervised run, not optional).
 5. **Self-heal + auto-drive the board**: when you hit an error, a fork, or an unexpected state —
    apply the **decision protocol** (research → register → decide); do NOT act first.
    Then act on what you decided: an in-scope problem → fix it in the loop and continue;
@@ -233,6 +234,27 @@ e.g. ``Grew out of #<n>``, in the epic body) so the trail is followable.
 Build test-first. After each verify phase, record the structured [abios-evidence] block (what was
 tested, the command, the result) ONCE in evidence/<issue>.md, and put the link stub (marker +
 summary + link) in the PR body and an issue comment - one source of truth, two pointers (#570).
+
+## Independent review (#623) — non-negotiable for an unsupervised run
+Nobody is watching this session decide "yes, this was reviewed" — that is exactly the
+self-certification shape #541 exists to close. So the review gate step is not the generic call a
+supervised human run makes; it is:
+
+    Board-ReviewGate.ps1 -Repo <owner/name> -PR <n> -RequireIndependentReviewer
+
+Under that flag, evidence authored by YOUR OWN identity does not count no matter how genuine the
+review was, and ``-RecordReview`` refuses outright if the acting identity matches the PR author
+(#622). Do not try to route around this by switching identity yourself. Wait instead for a review
+that already comes from a genuinely different identity — the repo's CI review workflow
+(``claude-review`` / Copilot, which post as a bot account, never yours) is what satisfies this
+today. If the gate is not green because nobody independent has reviewed yet, that is not a bug to
+solve in the loop — ``/board handoff -Save`` rather than invent a way to certify your own work.
+
+Aspirational, not yet available: routing this through the ``codex-rescue`` subagent as a
+cross-vendor reviewer was the original design (see ``codex-plugin-spike.md``), but it is not
+invokable via an Agent-tool call in this environment and its headless viability from a launched
+`claude -p` session is unverified (blocked on an unrelated OAuth failure, not a design question).
+Do not attempt to call it — the CI-bot path above is the one that actually works today.
 
 ## Claims — external facts in deliverables need a gate (#479)
 A document is a deliverable, and a deliverable needs a gate. If this run produces a knowledge

--- a/plugins/agentic-board/skills/board-expert/references/auto-loop.md
+++ b/plugins/agentic-board/skills/board-expert/references/auto-loop.md
@@ -15,7 +15,12 @@ guiding principle: **total self-use of agentic-board — never improvise your ow
 4. **Verify + evidence** — run the definition-of-done gates. Write a structured `[abios-evidence]`
    block (`Expert-Evidence.Format-EvidenceBlock`) to **three places**: the PR body, a durable
    issue comment, and a versioned `evidence/<issue>.md`. If green → open the PR + run the review
-   gate.
+   gate **with `-RequireIndependentReviewer`** (#623) — this run is unsupervised, and that flag is
+   what stops it from certifying its own work (#541). Evidence posted under its own identity does
+   not count and `-RecordReview` refuses outright; it waits for a review from a genuinely
+   different identity (the repo's CI review workflow — `claude-review`/Copilot post as a bot
+   account) instead of inventing one. See `independent-reviewer-guard.md` for the full mechanism
+   and why `codex-rescue` isn't wired in yet.
 5. **Self-heal + auto-drive the board**:
    - in-scope problem → fix it in the loop and continue;
    - out-of-scope finding → file a sanitized `discovered` issue on the board (`/board`, the

--- a/plugins/agentic-board/skills/board-expert/references/independent-reviewer-guard.md
+++ b/plugins/agentic-board/skills/board-expert/references/independent-reviewer-guard.md
@@ -32,21 +32,31 @@ launcher, not the interactive human flow.
 (`gh api user`) matches the PR author, it throws immediately with a pointer to #541, instead
 of silently posting a comment that later evidence-checking would just ignore.
 
-## What #623 still has to do
+## What #623 did (and what it deliberately did NOT do)
 
-This issue only changed the GATE's verification rule. It does not:
-- Pass `-RequireIndependentReviewer` from `Expert-Auto.ps1` / the auto-loop — the autonomous
-  launcher has to opt in explicitly for the guard to apply to its own runs.
-- Invoke `codex-rescue` (or any reviewer) at all. Today, an autonomous run that is required to
-  be independently reviewed and has no independent reviewer available simply cannot pass the
-  gate — which is correct (fail closed), but useless without #623 wiring an actual reviewer
-  call into the loop before evidence is marked green. See `codex-plugin-spike.md` (#621) for
-  what that reviewer call needs to look like (the `codex-rescue` agent, restart-before-use,
-  prose not structured output).
-- Decide what identity the `codex-rescue` call's own evidence should be posted under so it is
-  itself something OTHER than the implementing session's account — a GitHub Action posting as
-  `github-actions[bot]` (the same shape `pr-review.yml`/claude-review already uses) satisfies
-  `-RequireIndependentReviewer` today with zero further gate changes; a local `codex-rescue`
-  subagent call whose result the SAME session then posts via `-RecordReview` would not, because
-  the posting account is still the PR author. That distinction is #623's design decision, not
-  this one's.
+#623 wired `Expert-Auto.ps1`'s brief (`Format-AutoBrief`) to instruct every autonomous run to
+call the gate with `-RequireIndependentReviewer`, to refuse self-recording, and to wait for a
+CI-bot review (`claude-review`/Copilot — already a distinct identity from the run, satisfies the
+guard with zero further gate changes) instead of inventing its own review. `auto-loop.md` phase 4
+carries the same instruction for anyone reading the skill directly.
+
+It did **not** wire `codex-rescue` as the reviewer, despite that being the epic's (#620) original
+intent. Two attempts to verify it before designing around it both failed, and the failure was
+infrastructure, not a design dead-end:
+- `codex-rescue` is not invokable via an Agent-tool call from this harness (tried, got "Agent
+  type not found" even though `claude plugin list` shows the plugin installed and enabled) — the
+  same is true of `/codex:adversarial-review` via the Skill tool ("Unknown skill").
+- A real headless test — spawning `claude -p` the same way `Expert-Auto.ps1`'s launcher does —
+  could not run at all: `401 OAuth access token has been revoked`. That is an environment/
+  credential problem, unrelated to whether the plugin itself would work headless.
+
+Given both paths were blocked and the epic's own spike (`codex-plugin-spike.md`) already flagged
+"whether `codex-rescue` can run fully headless... needs a real end-to-end test" as unevaluated,
+wiring a specific, unverified call into every autonomous run's mandatory gate would have made the
+gate untestable and potentially unshippable (every run failing on a reviewer nobody can reach).
+The human owner chose the CI-bot fallback explicitly over guessing at the wiring or blocking on an
+unrelated OAuth fix.
+
+**Still open, tracked separately** (not #623, not this epic — file a fresh issue when the OAuth
+token is renewed): verify `codex-rescue` headless invocability for real, then decide whether to
+route the mandatory reviewer through it instead of the CI bot.

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -101,6 +101,27 @@ Describe 'Agent type in the autonomous brief' {
     }
 }
 
+Describe 'Format-AutoBrief — independent review is mandatory for an unsupervised run (#623)' {
+    It 'tells the run to pass -RequireIndependentReviewer to the gate' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match 'RequireIndependentReviewer'
+    }
+    It 'forbids the run from self-certifying via its own identity' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)does not count'
+        $b | Should -Match '(?i)refuses'
+    }
+    It 'points at the CI bot review as the identity that actually satisfies the guard' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match 'claude-review'
+    }
+    It 'tells the run NOT to attempt codex-rescue (unverified headless viability, #621)' {
+        $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match 'codex-rescue'
+        $b | Should -Match '(?i)do not attempt'
+    }
+}
+
 Describe 'Format-AutoBrief — compliance checkpoint (#440 problem 2)' {
     It 'embeds the launch SHA and compliance instructions when MainShaAtLaunch is provided' {
         $sha = 'abc1234def5678abc1234def5678abc1234def56'


### PR DESCRIPTION
Closes #623