### PR TITLE
chore(roles): rename the local software-engineer role to agentic-board-core

### DIFF
--- a/.agentic-board/roles.json
+++ b/.agentic-board/roles.json
@@ -25,7 +25,7 @@
         "writing-skills"
       ],
       "knowledgeDomain": "Claude-Code",
-      "name": "software-engineer"
+      "name": "agentic-board-core"
     }
   ],
   "version": 1


### PR DESCRIPTION
Renames the existing local board-expert role (same keywords/skills, already covers agentic-board/pester/worktree/board/expert) to `agentic-board-core` — the name the project now uses in conversation for the expert that knows how to operate/extend agentic-board itself.