### PR TITLE
Surface the codex-rescue opt-in review path in /board expert config, not just reference docs

### DIFF
--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -151,6 +151,48 @@ Reach "PR ready + review gate green" and STOP there. Do NOT merge, deploy, refre
 delete on your own.
 "@ }
 
+    # (#646) The contract now RECORDS the human's choice at config time instead of leaving it to
+    # the run's judgment — two distinct branches, not one paragraph that mentions codex-rescue as
+    # a footnote regardless of what was actually configured.
+    $preferCodex = [bool]($Contract.review -and $Contract.review.preferCodexRescue)
+    $reviewSection = if ($preferCodex) { @"
+## Independent review (#623/#644) — non-negotiable for an unsupervised run, via codex-rescue
+Nobody is watching this session decide "yes, this was reviewed" — that is exactly the
+self-certification shape #541 exists to close. This run's contract opted into the stricter
+codex-rescue path (``/board expert config`` recorded it) — the review gate step is:
+
+1. Invoke the Agent tool with ``subagent_type: 'codex:codex-rescue'`` (the qualified name is
+   required — the unqualified ``codex-rescue`` is rejected) against this PR's diff.
+2. Record its rollout file path and thread id: ``Board-ReviewGate.ps1 -RecordReview
+   -Reviewer 'codex-rescue' -Summary '<what it found>' -RolloutPath <path> -ThreadId <id>``.
+3. Gate with both flags together: ``Board-ReviewGate.ps1 -Repo <owner/name> -PR <n>
+   -RequireIndependentReviewer -PreferCodexRescue`` — it re-verifies the marker against disk, so a
+   claim it cannot check does not count.
+
+Do not fall back to the CI-bot path unless codex-rescue is genuinely unreachable this run — say so
+plainly in your final report if that happens. The contract's choice is what you were configured to
+do, not a suggestion to weigh against the alternative.
+"@ } else { @"
+## Independent review (#623) — non-negotiable for an unsupervised run
+Nobody is watching this session decide "yes, this was reviewed" — that is exactly the
+self-certification shape #541 exists to close. So the review gate step is not the generic call a
+supervised human run makes; it is:
+
+    Board-ReviewGate.ps1 -Repo <owner/name> -PR <n> -RequireIndependentReviewer
+
+Under that flag, evidence authored by YOUR OWN identity does not count no matter how genuine the
+review was, and ``-RecordReview`` refuses outright if the acting identity matches the PR author
+(#622). Do not try to route around this by switching identity yourself. Wait instead for a review
+that already comes from a genuinely different identity — the repo's CI review workflow
+(``claude-review`` / Copilot, which post as a bot account, never yours) is what satisfies this
+today. If the gate is not green because nobody independent has reviewed yet, that is not a bug to
+solve in the loop — ``/board handoff -Save`` rather than invent a way to certify your own work.
+
+A stricter, disk-verified path exists (``codex-rescue``, #637/#644), but this run's contract did
+not opt into it — that is a human decision made in ``/board expert config``, not yours to make
+mid-run. Do not switch to it on your own judgment.
+"@ }
+
     @"
 # Autonomous brief — /board expert auto
 
@@ -235,30 +277,7 @@ Build test-first. After each verify phase, record the structured [abios-evidence
 tested, the command, the result) ONCE in evidence/<issue>.md, and put the link stub (marker +
 summary + link) in the PR body and an issue comment - one source of truth, two pointers (#570).
 
-## Independent review (#623) — non-negotiable for an unsupervised run
-Nobody is watching this session decide "yes, this was reviewed" — that is exactly the
-self-certification shape #541 exists to close. So the review gate step is not the generic call a
-supervised human run makes; it is:
-
-    Board-ReviewGate.ps1 -Repo <owner/name> -PR <n> -RequireIndependentReviewer
-
-Under that flag, evidence authored by YOUR OWN identity does not count no matter how genuine the
-review was, and ``-RecordReview`` refuses outright if the acting identity matches the PR author
-(#622). Do not try to route around this by switching identity yourself. Wait instead for a review
-that already comes from a genuinely different identity — the repo's CI review workflow
-(``claude-review`` / Copilot, which post as a bot account, never yours) is what satisfies this
-today. If the gate is not green because nobody independent has reviewed yet, that is not a bug to
-solve in the loop — ``/board handoff -Save`` rather than invent a way to certify your own work.
-
-Optional, stricter path (#637/#644): the ``codex-rescue`` subagent — the original cross-vendor
-design (see ``codex-plugin-spike.md``) — IS invokable headless via the Agent tool with the
-qualified name ``codex:codex-rescue`` (the unqualified ``codex-rescue`` is rejected; this was the
-actual cause of the earlier "not invokable" finding, not an infrastructure limit). If this run
-chooses to use it: invoke ``codex:codex-rescue``, then record its rollout file path and thread id
-with ``Board-ReviewGate.ps1 -RecordReview -RolloutPath <path> -ThreadId <id> ...`` and gate with
-``-PreferCodexRescue`` added to the ``-RequireIndependentReviewer`` call above — the gate then
-re-verifies the marker against disk instead of trusting the claim. This is OPT-IN: the CI-bot path
-above remains the default and keeps working unchanged when you do not reach for this.
+$reviewSection
 
 ## Claims — external facts in deliverables need a gate (#479)
 A document is a deliverable, and a deliverable needs a gate. If this run produces a knowledge

--- a/plugins/agentic-board/scripts/Expert-Config.ps1
+++ b/plugins/agentic-board/scripts/Expert-Config.ps1
@@ -25,24 +25,42 @@
     Reserved: version the contract instead of leaving it in gitignored state (handled by the
     caller/skill — this script only writes the file).
 
+.PARAMETER PreferCodexRescue
+    (#646) Opt into the stricter codex-rescue review path (Board-ReviewGate.ps1
+    -PreferCodexRescue, #637/#644) for the run this contract configures — the CI-bot fallback
+    stays the default when this is not passed. The skill asks the user this BEFORE passing it;
+    this script does not prompt. Silently ignored (with a loud warning, never a silent write of
+    `true`) when the `codex@openai-codex` plugin is not detected as installed — an unreachable
+    opt-in would just make the review gate fail for a reason the run cannot fix itself.
+
+.PARAMETER InstalledPlugins
+    Injectable for tests: the lowercase plugin/marketplace identifiers `Get-InstalledPlugins.ps1`
+    would have returned. Defaults to actually running it.
+
 .EXAMPLE
     .\Expert-Config.ps1 -PlanText "Power BI Deneb visual" -PlanGoal "Ship a bar chart"
+    .\Expert-Config.ps1 -PlanText "..." -PlanGoal "..." -PreferCodexRescue
 #>
 [CmdletBinding()]
 param(
     [string]$PlanText = "",
     [string]$PlanGoal = "",
     [string]$Path = "",
-    [switch]$Commit
+    [switch]$Commit,
+    [switch]$PreferCodexRescue,
+    [string[]]$InstalledPlugins
 )
 
 $ErrorActionPreference = "Stop"
 
 # Capture our own arguments BEFORE any dot-source. A dot-sourced script's param() block executes
 # in THIS scope: Expert-RoleSynthesis declares $PlanGoal, so dot-sourcing it resets ours to "".
-$myPlanText = $PlanText
-$myPlanGoal = $PlanGoal
-$myPath     = $Path
+$myPlanText            = $PlanText
+$myPlanGoal            = $PlanGoal
+$myPath                = $Path
+$myPreferCodexRescue   = [bool]$PreferCodexRescue
+$myInstalledPluginsSet = $PSBoundParameters.ContainsKey('InstalledPlugins')
+$myInstalledPlugins    = $InstalledPlugins
 
 # Load the sibling pure cores with THEIR guards set, so dot-sourcing does not run their CLIs.
 $prevC = $env:ABIOS_EXPERTCONTRACT_DOTSOURCE
@@ -55,10 +73,20 @@ $env:ABIOS_EXPERTROLE_DOTSOURCE = '1'
 . (Join-Path $PSScriptRoot 'Expert-RoleSynthesis.ps1')
 $env:ABIOS_EXPERTROLE_DOTSOURCE = $prevR
 
+# (#646) Is `codex@openai-codex` installed? Pure given the plugin-id list Get-InstalledPlugins.ps1
+# would have produced — kept separate so it is unit-testable without shelling out to `claude`.
+function Test-CodexRescueAvailable {
+    param([string[]]$InstalledPlugins = @())
+    return [bool](@($InstalledPlugins) | Where-Object { "$_".ToLowerInvariant() -eq 'codex' })
+}
+
 # ── Pure core ───────────────────────────────────────────────────────────────────
 function New-ExpertConfig {
     [CmdletBinding()]
-    param([string]$PlanText, [string]$PlanGoal, [string[]]$Inventory = @(), [hashtable]$Catalog)
+    param(
+        [string]$PlanText, [string]$PlanGoal, [string[]]$Inventory = @(), [hashtable]$Catalog,
+        [bool]$PreferCodexRescue = $false, [string[]]$InstalledPlugins = @()
+    )
     if (-not $Catalog) { $Catalog = Get-ExpertRoles }
     $domain  = Get-DomainFromPlan -Text $PlanText -Catalog $Catalog
     $role    = @($Catalog.roles) | Where-Object { $_.name -eq $domain } | Select-Object -First 1
@@ -68,6 +96,15 @@ function New-ExpertConfig {
     $c.role        = Format-RoleObjective -Domain $domain -HookedSkills $hooked -PlanGoal $PlanGoal -Persona $persona
     $c.roleMatched = ($domain -ne 'generic')
     if ($role -and $role.agent) { $c.roleAgent = [string]$role.agent }
+
+    # (#646) Never silently write `true` when the run cannot actually reach codex-rescue — an
+    # unreachable opt-in would fail the review gate for a reason the launched run has no way to
+    # fix on its own. `codexRescueAvailable` is a computed signal (same pattern as `roleMatched`),
+    # not a knob - it says whether the CLI request could be honoured, for `config`'s own printout.
+    $available = Test-CodexRescueAvailable -InstalledPlugins $InstalledPlugins
+    $c.review.preferCodexRescue = ($PreferCodexRescue -and $available)
+    $c.codexRescueAvailable     = $available
+    $c.codexRescueRequestedButUnavailable = ($PreferCodexRescue -and -not $available)
     $c
 }
 
@@ -77,7 +114,13 @@ if ($env:ABIOS_EXPERTCONFIG_DOTSOURCE) { return }
 # ── CLI ─────────────────────────────────────────────────────────────────────────
 $inventory = Resolve-SkillInventory
 
-$contract = New-ExpertConfig -PlanText $myPlanText -PlanGoal $myPlanGoal -Inventory $inventory
+if (-not $myInstalledPluginsSet) {
+    $pl = Join-Path $PSScriptRoot 'Get-InstalledPlugins.ps1'
+    $myInstalledPlugins = if (Test-Path $pl) { @(& $pl) } else { @() }
+}
+
+$contract = New-ExpertConfig -PlanText $myPlanText -PlanGoal $myPlanGoal -Inventory $inventory `
+                              -PreferCodexRescue $myPreferCodexRescue -InstalledPlugins $myInstalledPlugins
 $target = if ($myPath) { $myPath } else { Get-ExpertContractPath }
 
 Write-Host "=== /board expert config ===" -ForegroundColor Cyan
@@ -96,5 +139,17 @@ $written = Write-ExpertContract -Contract $contract -Path $target
 Write-Host "  OK  contract written -> $written" -ForegroundColor Green
 Write-Host "      autonomy brakes only on: $($contract.autonomy.irreversible -join ', ')" -ForegroundColor DarkGray
 Write-Host "      evidence -> PR + issue comment + versioned file" -ForegroundColor DarkGray
+# (#646) State the review-independence choice as plainly as the autonomy brakes above it - this
+# is the one line meant to make the codex-rescue path discoverable to a human BEFORE launch,
+# instead of only living in a reference doc nobody reads until something goes wrong.
+if ($contract.codexRescueRequestedButUnavailable) {
+    Write-Host "      independent review -> CI-bot fallback (codex-rescue was REQUESTED but the 'codex@openai-codex' plugin is not installed - install it, then re-run config to actually enable this)" -ForegroundColor Yellow
+} elseif ($contract.review.preferCodexRescue) {
+    Write-Host "      independent review -> codex-rescue (disk-verified marker, #637/#644) - the run will be told to use it" -ForegroundColor DarkGray
+} elseif ($contract.codexRescueAvailable) {
+    Write-Host "      independent review -> CI-bot fallback (codex-rescue is installed and available - pass -PreferCodexRescue to opt in)" -ForegroundColor DarkGray
+} else {
+    Write-Host "      independent review -> CI-bot fallback (the default; codex-rescue is not installed)" -ForegroundColor DarkGray
+}
 Write-Host ""
 Write-Host "Next: review/edit the role, then run  /board expert auto <issue>" -ForegroundColor Cyan

--- a/plugins/agentic-board/scripts/ExpertContractIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertContractIo.ps1
@@ -36,6 +36,11 @@ function New-ExpertContract {
         workClass = @{ visualPatterns = @(); humanApproves = @('visual') }
         dod      = @{ ci = $true; build = $true; lint = $true; tests = $true; bpa = $true; tmdlBreaking = $true }
         evidence = @{ pr = $true; issueComment = $true; file = $true }
+        # (#646) Off by default: an unsupervised run uses the CI-bot fallback unless the human
+        # opted into the stricter codex-rescue path in `config` (see Board-ReviewGate.ps1's
+        # -PreferCodexRescue, #637/#644). Keyed under its own object so a future review setting
+        # has somewhere to live without another top-level contract key.
+        review   = @{ preferCodexRescue = $false }
         boardSelfDrive = @{ createIssues = $true; label = 'discovered'; cap = 10 }
         budget   = @{ maxIterations = 8; maxMinutes = 120 }
         capabilities = @{ knowledge = $true; skillsBootstrap = $true; toolsInstall = $false; scan = $true }

--- a/plugins/agentic-board/skills/board-expert/SKILL.md
+++ b/plugins/agentic-board/skills/board-expert/SKILL.md
@@ -24,6 +24,15 @@ typed with a slash.
 Show the role preview and let the user edit before running `auto`. See `references/contract.md`
 for every contract field and its default.
 
+**Independent-review path (#646).** Before writing the contract, check whether the
+`codex@openai-codex` plugin is installed (`Get-InstalledPlugins.ps1` — reused, do not re-detect by
+hand) and ASK the user whether this run should opt into the stricter `codex:codex-rescue` review
+path (`references/independent-reviewer-guard.md`) instead of the CI-bot fallback that is the
+default. If the plugin is not installed, say so plainly instead of silently skipping the question
+— offer the one-line install (`claude plugin marketplace add openai/codex-plugin-cc` +
+`claude plugin install codex@openai-codex`) as the alternative to asking. Pass the user's answer
+as `Expert-Config.ps1 -PreferCodexRescue`; never pass it without having asked.
+
 If `config` reports **NO ROLE MATCHED**, research the plan's domain (via `/knowledge`, and
 `/tools` for ready-made agent definitions such as `wshobson/agents`), then propose a complete
 role — `name`, `keywords`, `skills`, and an `agent` pointer when a fitting definition exists.

--- a/plugins/agentic-board/skills/board-expert/references/contract.md
+++ b/plugins/agentic-board/skills/board-expert/references/contract.md
@@ -11,6 +11,7 @@ on read (`ExpertContractIo.Read-ExpertContract`), so `auto` never hits a missing
 | `autonomy.irreversible` | `merge, deploy, refresh, publish, delete` | The ONLY actions that stop the run for the human. Anything not here and not explicitly safe is treated as irreversible (fail-safe). |
 | `dod` | `ci, build, lint, tests, bpa, tmdlBreaking` all `true` | The definition of done the loop drives toward ("everything passes"). |
 | `evidence.pr` / `.issueComment` / `.file` | all `true` | The three evidence surfaces. Since #570 only `.file` (`evidence/<issue>.md`) carries the FULL block — the single source of truth; `.pr` and `.issueComment` carry the link stub (marker + summary + link), so nothing is written three times. |
+| `review.preferCodexRescue` | `false` | (#646) Opt-in: route independent review through the `codex:codex-rescue` agent (a disk-verified marker, #637/#644) instead of the CI-bot fallback. `config -PreferCodexRescue` sets it — and only ever to `true` when the `codex@openai-codex` plugin is actually detected installed; a request with the plugin missing is refused and reported, never written as a silent `true` the launched run could not honour. |
 | `boardSelfDrive.createIssues` | `true` | May file issues for out-of-scope findings on its own. |
 | `boardSelfDrive.label` | `discovered` | Label applied to self-filed issues. |
 | `boardSelfDrive.cap` | `10` | Max issues one run may create (beyond it, group findings). |

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -115,13 +115,35 @@ Describe 'Format-AutoBrief — independent review is mandatory for an unsupervis
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
         $b | Should -Match 'claude-review'
     }
-    It 'documents codex-rescue as an optional, verified-headless path - not a forbidden one (#637/#644)' {
+    It 'mentions codex-rescue exists but tells the run NOT to switch to it on its own judgment, when the contract did not opt in (#646)' {
+        # $script:Contract carries no `review` key at all - the same as a contract written before
+        # #646, or one where config never enabled it. Both must resolve to the CI-bot path.
         $b = Format-AutoBrief -Contract $script:Contract -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match '(?i)codex-rescue'
+        $b | Should -Match '(?is)did\s+not opt into it'   # here-string wraps mid-phrase; tolerate the line break
+        $b | Should -Not -Match '(?i)do not attempt'          # #637 corrected the old "not invokable" finding
+        $b | Should -Not -Match 'subagent_type'                # the concrete invocation steps are NOT prescribed here
+    }
+}
+
+Describe 'Format-AutoBrief — the contract''s codex-rescue choice is INSTRUCTED, not left to the run (#646)' {
+    BeforeAll {
+        $script:ContractCodex = $script:Contract.Clone()
+        $script:ContractCodex.review = @{ preferCodexRescue = $true }
+    }
+    It 'gives concrete, mandatory steps to invoke codex:codex-rescue when the contract opted in' {
+        $b = Format-AutoBrief -Contract $script:ContractCodex -PlanBody 'x' -RoleObjective 'r'
         $b | Should -Match 'codex:codex-rescue'
         $b | Should -Match 'PreferCodexRescue'
-        # #637 corrected the earlier "not invokable" finding - the brief must not tell the run to
-        # avoid it any more, only that using it is optional (the CI-bot path stays the default).
-        $b | Should -Not -Match '(?i)do not attempt'
+        $b | Should -Match '(?i)RolloutPath'
+    }
+    It 'still requires -RequireIndependentReviewer alongside the codex-rescue flag' {
+        $b = Format-AutoBrief -Contract $script:ContractCodex -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Match 'RequireIndependentReviewer'
+    }
+    It 'does NOT print the CI-bot-only branch text when the contract opted into codex-rescue' {
+        $b = Format-AutoBrief -Contract $script:ContractCodex -PlanBody 'x' -RoleObjective 'r'
+        $b | Should -Not -Match '(?i)did not opt into it'
     }
 }
 

--- a/plugins/agentic-board/tests/Expert-Config.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Config.Tests.ps1
@@ -53,6 +53,46 @@ Describe 'New-ExpertConfig role selection' {
     }
 }
 
+Describe 'Test-CodexRescueAvailable (#646)' {
+    It 'is available when the plugin list contains "codex"' {
+        Test-CodexRescueAvailable -InstalledPlugins @('board', 'codex', 'other') | Should -BeTrue
+    }
+    It 'is unavailable when the plugin list does not contain it' {
+        Test-CodexRescueAvailable -InstalledPlugins @('board', 'other') | Should -BeFalse
+    }
+    It 'is unavailable on an empty list' {
+        Test-CodexRescueAvailable -InstalledPlugins @() | Should -BeFalse
+    }
+    It 'matches case-insensitively' {
+        Test-CodexRescueAvailable -InstalledPlugins @('CODEX') | Should -BeTrue
+    }
+}
+
+Describe 'New-ExpertConfig - the codex-rescue opt-in never writes a silent lie (#646)' {
+    It 'defaults preferCodexRescue to false when not requested' {
+        $c = New-ExpertConfig -PlanText 'x' -PlanGoal 'g' -Inventory $script:Inv -InstalledPlugins @('codex')
+        $c.review.preferCodexRescue | Should -BeFalse
+    }
+    It 'honours the opt-in when requested AND the plugin is available' {
+        $c = New-ExpertConfig -PlanText 'x' -PlanGoal 'g' -Inventory $script:Inv `
+                              -PreferCodexRescue $true -InstalledPlugins @('codex')
+        $c.review.preferCodexRescue | Should -BeTrue
+        $c.codexRescueAvailable     | Should -BeTrue
+        $c.codexRescueRequestedButUnavailable | Should -BeFalse
+    }
+    It 'refuses to write true when requested but the plugin is NOT installed - reports why instead' {
+        $c = New-ExpertConfig -PlanText 'x' -PlanGoal 'g' -Inventory $script:Inv `
+                              -PreferCodexRescue $true -InstalledPlugins @()
+        $c.review.preferCodexRescue | Should -BeFalse
+        $c.codexRescueAvailable     | Should -BeFalse
+        $c.codexRescueRequestedButUnavailable | Should -BeTrue
+    }
+    It 'not requesting it is never reported as "requested but unavailable", even when the plugin is absent' {
+        $c = New-ExpertConfig -PlanText 'x' -PlanGoal 'g' -Inventory $script:Inv -InstalledPlugins @()
+        $c.codexRescueRequestedButUnavailable | Should -BeFalse
+    }
+}
+
 Describe 'Expert-Config.ps1 (CLI wiring)' {
     # The unit tests above call New-ExpertConfig directly, so they never exercise the script's own
     # argument handling or inventory resolution — where both #441 and #442 lived.
@@ -82,5 +122,45 @@ Describe 'Expert-Config.ps1 (CLI wiring)' {
     It 'does not leak the inventory object into stdout' {
         $script:Stdout | Should -Not -Match 'byScope'
         $script:Stdout | Should -Not -Match 'is not recognized as a name of a cmdlet'
+    }
+    It 'defaults the review path to the CI-bot fallback when -PreferCodexRescue is never passed' {
+        $script:Cli.review.preferCodexRescue | Should -BeFalse
+    }
+}
+
+Describe 'Expert-Config.ps1 (CLI wiring) - codex-rescue opt-in surfaced, not silent (#646)' {
+    # Single-element arrays only: passing a MULTI-element array as CLI args through a nested
+    # `pwsh -File` invocation collapses unreliably (a Windows/PowerShell native-argv quirk, proven
+    # by hand while writing this test - a real array variable came through as a single joined
+    # string, or lost elements, depending on quoting). One element is all this needs to prove the
+    # CLI wiring: does a truthy -InstalledPlugins value reach Test-CodexRescueAvailable intact.
+    BeforeAll {
+        $script:OutAvail = Join-Path ([System.IO.Path]::GetTempPath()) ("expcli-avail-" + [guid]::NewGuid().ToString('N') + ".json")
+        $script:StdoutAvail = & pwsh -NoProfile -File $script:Script `
+            -PlanText 'x' -PlanGoal 'g' -Path $script:OutAvail -PreferCodexRescue -InstalledPlugins codex 2>&1 | Out-String
+        $script:CliAvail = if (Test-Path $script:OutAvail) { Get-Content -Raw $script:OutAvail | ConvertFrom-Json } else { $null }
+
+        $script:OutMissing = Join-Path ([System.IO.Path]::GetTempPath()) ("expcli-missing-" + [guid]::NewGuid().ToString('N') + ".json")
+        $script:StdoutMissing = & pwsh -NoProfile -File $script:Script `
+            -PlanText 'x' -PlanGoal 'g' -Path $script:OutMissing -PreferCodexRescue -InstalledPlugins none 2>&1 | Out-String
+        $script:CliMissing = if (Test-Path $script:OutMissing) { Get-Content -Raw $script:OutMissing | ConvertFrom-Json } else { $null }
+    }
+    AfterAll {
+        if (Test-Path $script:OutAvail)   { Remove-Item $script:OutAvail -Force }
+        if (Test-Path $script:OutMissing) { Remove-Item $script:OutMissing -Force }
+    }
+
+    It 'writes the opt-in to the contract when the plugin is available' {
+        $script:CliAvail.review.preferCodexRescue | Should -BeTrue
+    }
+    It 'says so in the printed summary, not only in the file' {
+        $script:StdoutAvail | Should -Match '(?i)codex-rescue'
+    }
+    It 'does NOT write the opt-in when requested but the plugin is unavailable - refuses the silent lie' {
+        $script:CliMissing.review.preferCodexRescue | Should -BeFalse
+    }
+    It 'tells the human WHY it was not enabled, instead of quietly falling back' {
+        $script:StdoutMissing | Should -Match '(?i)REQUESTED but'
+        $script:StdoutMissing | Should -Match '(?i)not installed'
     }
 }

--- a/plugins/agentic-board/tests/ExpertContractIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertContractIo.Tests.ps1
@@ -35,6 +35,9 @@ Describe 'New-ExpertContract (defaults)' {
         $b.label | Should -Be 'discovered'
         $b.cap | Should -BeGreaterThan 0
     }
+    It 'defaults the codex-rescue review path to OFF (#646) - opt-in, never silent' {
+        (New-ExpertContract).review.preferCodexRescue | Should -BeFalse
+    }
 }
 
 Describe 'Write/Read round-trip' {
@@ -57,6 +60,11 @@ Describe 'Read-ExpertContract default-merge' {
         $r.role | Should -Be 'partial only'
         $r.evidence.pr | Should -BeTrue          # filled from defaults
         $r.autonomy.irreversible | Should -Contain 'merge'
+        $r.review.preferCodexRescue | Should -BeFalse   # (#646) a contract older than this key still resolves off, not missing
+    }
+    It 'preserves an explicit opt-in written by an older or hand-edited contract (#646)' {
+        '{ "review": { "preferCodexRescue": true } }' | Set-Content -Path $script:Tmp -Encoding utf8
+        (Read-ExpertContract -Path $script:Tmp).review.preferCodexRescue | Should -BeTrue
     }
     It 'returns full defaults when the file does not exist' {
         $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("nope-" + [guid]::NewGuid().ToString('N') + ".json")


### PR DESCRIPTION
Closes #646