### PR TITLE
fix: stamp a UTF-8 BOM on every shipped PowerShell script (Windows PowerShell 5.1 could not parse them)

### DIFF
--- a/.github/assets/board-demo.ps1
+++ b/.github/assets/board-demo.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # board-demo.ps1 — scripted playback for the README hero GIF (issue #210).
 #
 # This is NOT a live Claude Code session: it reproduces, with simulated typing,

--- a/.github/assets/board-demo.ps1
+++ b/.github/assets/board-demo.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # board-demo.ps1 — scripted playback for the README hero GIF (issue #210).
 #
 # This is NOT a live Claude Code session: it reproduces, with simulated typing,

--- a/.github/assets/board-loop.ps1
+++ b/.github/assets/board-loop.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # board-loop.ps1 — scripted playback for the SECOND README GIF (issue #210).
 #
 # Shows agentic-board IN USE: the natural-language work loop

--- a/.github/assets/board-loop.ps1
+++ b/.github/assets/board-loop.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # board-loop.ps1 — scripted playback for the SECOND README GIF (issue #210).
 #
 # Shows agentic-board IN USE: the natural-language work loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Every shipped PowerShell script now carries a UTF-8 BOM, so Windows PowerShell 5.1 can read
+  it.** A session on a Spanish Windows could not run `Board-Fill.ps1` at all: it died at parse
+  time with "Unexpected token '}'" on lines 370 and 508. The script was fine — the reader was
+  not. All 185 tracked `.ps1` files were UTF-8 *without* a BOM, and they are full of box-drawing
+  rules (U+2500) and em dashes (U+2014); both encode to a byte sequence containing `0x94`.
+  Windows PowerShell 5.1 reads a BOM-less file as the machine's ANSI codepage, and on cp1252
+  `0x94` is a curly closing quote — which the PowerShell tokenizer accepts as a *string
+  delimiter*. An odd number of them opens a string that swallows real code, and the next closing
+  brace lands inside a literal. 28 shipped files failed to parse this way; the rest silently
+  printed mojibake. `Scripts.Parse.Tests.ps1` had been parsing every script all along and stayed
+  green, because it runs under pwsh 7, which assumes UTF-8 for a BOM-less file: same parse,
+  different host, and the host was the whole bug. A BOM makes each file self-describing, so 5.1
+  and 7.x both read it correctly on any codepage.
+- **The docs no longer point contributors at the interpreter that breaks.** `README.md`,
+  `CONTRIBUTING.md`, `install-guard.ps1` and the `projects-admin` board-ops reference all said
+  `powershell -File` — Windows PowerShell 5.1. Everything else in the repo, CI included, targets
+  `pwsh` 7, and four scripts use pwsh-7-only operators (`??`, `? :`) that 5.1 cannot parse at
+  all. They now say `pwsh -File`.
+
+### Added
+- **`ScriptEncoding.Tests.ps1` — an encoding ratchet.** Asserts every git-tracked PowerShell file
+  starts with a UTF-8 BOM, and then proves it end-to-end by having Windows PowerShell 5.1 itself
+  parse all of them. The four scripts that genuinely require pwsh 7 are declared by name, and the
+  test fails if that exemption ever goes stale. CI runs Pester on `windows-latest`, so 5.1 is
+  present and the check is not vacuous there.
+
 ## [0.38.0] - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@
   all. They now say `pwsh -File`.
 
 ### Added
-- **`ScriptEncoding.Tests.ps1` — an encoding ratchet.** Asserts every git-tracked PowerShell file
-  starts with a UTF-8 BOM, and then proves it end-to-end by having Windows PowerShell 5.1 itself
-  parse all of them. The four scripts that genuinely require pwsh 7 are declared by name, and the
-  test fails if that exemption ever goes stale. CI runs Pester on `windows-latest`, so 5.1 is
-  present and the check is not vacuous there.
+- **`ScriptEncoding.Tests.ps1` — an encoding ratchet.** Every git-tracked PowerShell file must
+  declare its own interpreter: a UTF-8 BOM, or a shebang, never both. A BOM in front of `#!`
+  occupies the same first bytes and hides the shebang from the Unix loader, so the two VHS demo
+  assets under `.github/assets` keep their `#!/usr/bin/env pwsh` and everything else takes the BOM.
+  The test then proves it end-to-end by having Windows PowerShell 5.1 itself parse every file. Six
+  files are declared unreadable-by-5.1 on purpose, each with its reason — four use pwsh-7-only
+  operators, two are the shebang assets — and the test fails if any of those exemptions goes stale.
+  CI runs Pester on `windows-latest`, so 5.1 is present and the check is not vacuous there.
 
 ## [0.38.0] - 2026-08-28
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Two layers protect the repo — please keep both honest:
    tool. When you file an issue or open a PR, describe the *general* problem, not the private case.
 2. **A guard you can't forget.** After cloning, run once:
    ```
-   powershell -File scripts/install-guard.ps1
+   pwsh -File scripts/install-guard.ps1
    ```
    This wires `pre-commit` + `pre-push` hooks that **block** any commit/push whose added lines
    contain a known secret pattern or a term from your local `.abios/private-denylist.txt`

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Two layers protect this repo:
    tool (no repo names, client names, data, GUIDs, or paths).
 2. **A guard you can't forget** — after cloning, run once:
    ```
-   powershell -File scripts/install-guard.ps1
+   pwsh -File scripts/install-guard.ps1
    ```
    This wires a `pre-commit` + `pre-push` hook that **blocks** any commit/push whose added lines
    contain a known secret pattern or a term from your local `.abios/private-denylist.txt`

--- a/plugins/agentic-board/scripts/Add-KnowledgeRef.ps1
+++ b/plugins/agentic-board/scripts/Add-KnowledgeRef.ps1
@@ -1,4 +1,4 @@
-<#  Add-KnowledgeRef.ps1 — add one reference to the project knowledge registry.
+﻿<#  Add-KnowledgeRef.ps1 — add one reference to the project knowledge registry.
     Inits the registry (seeded taxonomy) if absent. Enforces the domain guard
     (declared or -NewDomain) and, for local refs, that the path exists (never invent
     references). Appends the record and regenerates KNOWLEDGE.md.

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -1,4 +1,4 @@
-<#  Apply-FieldPreset.ps1 — idempotently create the fields of a preset on a Projects
+﻿<#  Apply-FieldPreset.ps1 — idempotently create the fields of a preset on a Projects
     board AND apply the preset's canonical single-select option colors.
 
     `gh project field-create` cannot set option colors (GitHub auto-assigns random

--- a/plugins/agentic-board/scripts/Apply-LabelPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-LabelPreset.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Apply the label taxonomy preset to a repository (/board labels).
 

--- a/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
+++ b/plugins/agentic-board/scripts/Assert-BoardComplete.ps1
@@ -1,4 +1,4 @@
-<#  Assert-BoardComplete.ps1 — the pass/fail check for "the board is fully worked" (no pending items).
+﻿<#  Assert-BoardComplete.ps1 — the pass/fail check for "the board is fully worked" (no pending items).
 
     A runnable gate that answers one question: does board <ProjectNum> still have any PENDING work?
     "Pending" is the SAME definition /board work uses to list what to start (Board-Work.ps1

--- a/plugins/agentic-board/scripts/Backup-Board.ps1
+++ b/plugins/agentic-board/scripts/Backup-Board.ps1
@@ -1,4 +1,4 @@
-<#  Backup-Board.ps1 - make a COMPLETE backup of a Projects board. ALWAYS run before delete.
+﻿<#  Backup-Board.ps1 - make a COMPLETE backup of a Projects board. ALWAYS run before delete.
     Writes a JSON snapshot (project meta + fields + items) AND creates a restorable live clone.
     Requires $env:GH_TOKEN (via gh-account). Backups go to $env:ABIOS_BACKUP_DIR or ~/.agentic-board/backups.
     Usage: ./Backup-Board.ps1 -Number 13 -Owner CSalcedoDataBI

--- a/plugins/agentic-board/scripts/Board-Breakdown.ps1
+++ b/plugins/agentic-board/scripts/Board-Breakdown.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Break a large issue into native sub-issues (/board work breakdown).
 

--- a/plugins/agentic-board/scripts/Board-Changelog.ps1
+++ b/plugins/agentic-board/scripts/Board-Changelog.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Generate a Keep-a-Changelog block from closed board items (M4.2).
 

--- a/plugins/agentic-board/scripts/Board-Doctor.ps1
+++ b/plugins/agentic-board/scripts/Board-Doctor.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Inventory and classify every local branch and worktree from GIT REALITY - not from
     the session registry. Read-only by default; `-Fix` cleans up, confirming per branch.

--- a/plugins/agentic-board/scripts/Board-Fill.ps1
+++ b/plugins/agentic-board/scripts/Board-Fill.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Detect and fill gaps in a GitHub Projects v2 board.
 

--- a/plugins/agentic-board/scripts/Board-Handoff.ps1
+++ b/plugins/agentic-board/scripts/Board-Handoff.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Write a verified session handoff (/board handoff save) so work can resume in a
     fresh session days later - even on another machine.

--- a/plugins/agentic-board/scripts/Board-Merge.ps1
+++ b/plugins/agentic-board/scripts/Board-Merge.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Merge a gated PR for /board work step 5d - handling the pr-before-merge ruleset.
 

--- a/plugins/agentic-board/scripts/Board-Plan.ps1
+++ b/plugins/agentic-board/scripts/Board-Plan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Turn a plan into a tracked epic + native sub-issues on the repo board (/board plan).
 

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Review gate for /board work step 5: no PR merges blind.
 

--- a/plugins/agentic-board/scripts/Board-RunLedger.ps1
+++ b/plugins/agentic-board/scripts/Board-RunLedger.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Maintain a durable "run-ledger" for a long /board work run so it SURVIVES
     auto-compaction (epic #348).

--- a/plugins/agentic-board/scripts/Board-Summary.ps1
+++ b/plugins/agentic-board/scripts/Board-Summary.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     The closing summary every user-facing flow ends with — four blocks, always the same four.
 

--- a/plugins/agentic-board/scripts/Board-Triage.ps1
+++ b/plugins/agentic-board/scripts/Board-Triage.ps1
@@ -1,4 +1,4 @@
-<#  Board-Triage.ps1 — fill an item's TRIAGE fields from evidence, and PROPOSE (never silently
+﻿<#  Board-Triage.ps1 — fill an item's TRIAGE fields from evidence, and PROPOSE (never silently
     write) its Priority (#306).
 
     The board's pending items — the only part anyone plans from — sit blank on Type / Area /

--- a/plugins/agentic-board/scripts/Board-Work.ps1
+++ b/plugins/agentic-board/scripts/Board-Work.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Show pending work across boards and start working an issue (single or parallel).
 

--- a/plugins/agentic-board/scripts/BoardWork.Capacity.ps1
+++ b/plugins/agentic-board/scripts/BoardWork.Capacity.ps1
@@ -1,4 +1,4 @@
-# BoardWork.Capacity.ps1 - the machine-capacity governor, extracted VERBATIM from
+﻿# BoardWork.Capacity.ps1 - the machine-capacity governor, extracted VERBATIM from
 # Board-Work.ps1 (#575). Function definitions only; Board-Work dot-sources this file
 # before its own dot-source guard, so tests and callers see the same surface as before.
 

--- a/plugins/agentic-board/scripts/BoardWork.Processes.ps1
+++ b/plugins/agentic-board/scripts/BoardWork.Processes.ps1
@@ -1,4 +1,4 @@
-# BoardWork.Processes.ps1 - process supervision (tree kill, orphan reaper), extracted
+﻿# BoardWork.Processes.ps1 - process supervision (tree kill, orphan reaper), extracted
 # VERBATIM from Board-Work.ps1 (#575). Function definitions only; Board-Work dot-sources
 # this file before its own dot-source guard, so the surface is unchanged.
 

--- a/plugins/agentic-board/scripts/Bpa-GateReview.ps1
+++ b/plugins/agentic-board/scripts/Bpa-GateReview.ps1
@@ -1,4 +1,4 @@
-<#  Bpa-GateReview.ps1 — run Tabular Editor's Best Practice Analyzer against a PBIP/TMDL model and,
+﻿<#  Bpa-GateReview.ps1 — run Tabular Editor's Best Practice Analyzer against a PBIP/TMDL model and,
     on request, BLOCK a merge when it reports rule violations (M3.3, issue #16).
 
     The review gate already runs Tmdl-DiffReview.ps1 (breaking schema changes) warn-only. M3.3 adds

--- a/plugins/agentic-board/scripts/Brake-Guard.ps1
+++ b/plugins/agentic-board/scripts/Brake-Guard.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     The irreversible brake, as a mechanical control (#440 / #516).
 

--- a/plugins/agentic-board/scripts/Brake-PreToolUseHook.ps1
+++ b/plugins/agentic-board/scripts/Brake-PreToolUseHook.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     PreToolUse hook: refuse an irreversible command inside a brake-armed autonomous run (#516).
 

--- a/plugins/agentic-board/scripts/Clear-AbiosState.ps1
+++ b/plugins/agentic-board/scripts/Clear-AbiosState.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Garbage-collect .agentic-board/ — the state dir nothing ever cleaned (#574).
 

--- a/plugins/agentic-board/scripts/Compact-PreCompactHook.ps1
+++ b/plugins/agentic-board/scripts/Compact-PreCompactHook.ps1
@@ -1,4 +1,4 @@
-<#  Compact-PreCompactHook.ps1 - snapshot the transcript before a compaction (epic #348).
+﻿<#  Compact-PreCompactHook.ps1 - snapshot the transcript before a compaction (epic #348).
 
     Wired as a Claude Code PreCompact hook. It is the belt-and-suspenders half of the
     compaction-survival feature: the run-ledger (Board-RunLedger.ps1) is the primary

--- a/plugins/agentic-board/scripts/CopilotAvailability.ps1
+++ b/plugins/agentic-board/scripts/CopilotAvailability.ps1
@@ -1,4 +1,4 @@
-<#  CopilotAvailability.ps1 — remember, per GitHub account, that Copilot code review is unavailable so
+﻿<#  CopilotAvailability.ps1 — remember, per GitHub account, that Copilot code review is unavailable so
     the review gate stops requesting + WAITING for it on every PR (#367).
 
     The gate used to request a Copilot review and wait up to -TimeoutMinutes for it on EVERY PR, even

--- a/plugins/agentic-board/scripts/Expert-Auto.ps1
+++ b/plugins/agentic-board/scripts/Expert-Auto.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     /board expert `auto` — compose the autonomous brief and launch the auto-expert run.
 

--- a/plugins/agentic-board/scripts/Expert-Autonomy.ps1
+++ b/plugins/agentic-board/scripts/Expert-Autonomy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Autonomy gate for /board expert — decide whether an action is irreversible (stop for the
     human) or safe to perform autonomously.

--- a/plugins/agentic-board/scripts/Expert-ClaimsGate.ps1
+++ b/plugins/agentic-board/scripts/Expert-ClaimsGate.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Claims verification gate for /board expert deliverables (#479).
 

--- a/plugins/agentic-board/scripts/Expert-Config.ps1
+++ b/plugins/agentic-board/scripts/Expert-Config.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     /board expert `config` — build the auto-expert contract with a synthesized role and persist it.
 

--- a/plugins/agentic-board/scripts/Expert-EndToEnd.ps1
+++ b/plugins/agentic-board/scripts/Expert-EndToEnd.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Decide whether an autonomous run may close its own work end-to-end (#530, part of #526).
 

--- a/plugins/agentic-board/scripts/Expert-Evidence.ps1
+++ b/plugins/agentic-board/scripts/Expert-Evidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Evidence logging for /board expert — format the recorded test evidence and pick its
     destinations (PR body, [abios-evidence] issue comment, versioned file).

--- a/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
+++ b/plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Role synthesis for /board expert — map a plan to a domain, hook the relevant installed
     skills/profiles, and render the "role-as-objective" block the auto-expert adopts.

--- a/plugins/agentic-board/scripts/Expert-Roles.ps1
+++ b/plugins/agentic-board/scripts/Expert-Roles.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     /board expert `roles` — show the effective role catalog and explain how a plan matches.
 

--- a/plugins/agentic-board/scripts/Expert-RunVerify.ps1
+++ b/plugins/agentic-board/scripts/Expert-RunVerify.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Completion check for /board expert runs — prove the run used the tool instead of asserting it.
 

--- a/plugins/agentic-board/scripts/Expert-WorkClass.ps1
+++ b/plugins/agentic-board/scripts/Expert-WorkClass.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Classify a change as CODE or VISUAL, so the autonomy boundary can follow the owner's actual
     rule instead of a flat action list (#529, part of #526).

--- a/plugins/agentic-board/scripts/ExpertContractIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertContractIo.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Read/write the /board expert contract — the settings `config` writes and `auto` reads.
 

--- a/plugins/agentic-board/scripts/ExpertRolesIo.ps1
+++ b/plugins/agentic-board/scripts/ExpertRolesIo.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Load and merge the /board expert role catalog — shipped preset + optional global + project-local file.
 

--- a/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
+++ b/plugins/agentic-board/scripts/Export-BoardSnapshot.ps1
@@ -1,4 +1,4 @@
-<#  Export-BoardSnapshot.ps1 - render a Projects board as a Markdown table (a publishable snapshot).
+﻿<#  Export-BoardSnapshot.ps1 - render a Projects board as a Markdown table (a publishable snapshot).
     Requires $env:GH_TOKEN (via gh-account). ASCII-only source.
     Usage: ./Export-BoardSnapshot.ps1 -Number 13 -Owner CSalcedoDataBI -OutFile snapshot.md  #>
 [CmdletBinding()]

--- a/plugins/agentic-board/scripts/Find-InternalVocabularyLeak.ps1
+++ b/plugins/agentic-board/scripts/Find-InternalVocabularyLeak.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Detect internal implementation vocabulary (script filenames, bare extensions, version-pinned
     cache paths) in a string meant for a user to read.

--- a/plugins/agentic-board/scripts/Fleet-Findings.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Findings.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Fleet shared-findings blackboard (Phase 3, P3-1) - a shared brain for the /board
     work parallel fleet.

--- a/plugins/agentic-board/scripts/Fleet-Handoff.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Handoff.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Dependency-aware hand-off (Phase 3, P3-4) for the /board work fleet.
 

--- a/plugins/agentic-board/scripts/Fleet-Ownership.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Ownership.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Fleet file-ownership guard (Phase 3, P3-3) - "one owner per file" for the parallel
     /board work fleet.

--- a/plugins/agentic-board/scripts/Fleet-Plan.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Plan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Advisory board-lead planner (Phase 3, P3-2) - the "who does what" for the /board work
     fleet.

--- a/plugins/agentic-board/scripts/Fleet-Supervisor.ps1
+++ b/plugins/agentic-board/scripts/Fleet-Supervisor.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Fleet supervisor: stall detection + fleet termination policy (Phase 3, P3-5).
 

--- a/plugins/agentic-board/scripts/Get-AbiosStateDir.ps1
+++ b/plugins/agentic-board/scripts/Get-AbiosStateDir.ps1
@@ -1,4 +1,4 @@
-<#  Get-AbiosStateDir.ps1 — the SINGLE resolver for the internal state directory.
+﻿<#  Get-AbiosStateDir.ps1 — the SINGLE resolver for the internal state directory.
 
     Dot-source this file (never invoke it): `. (Join-Path $PSScriptRoot 'Get-AbiosStateDir.ps1')`
     then call `Get-AbiosStateDir`.

--- a/plugins/agentic-board/scripts/Get-BoardConfig.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardConfig.ps1
@@ -1,4 +1,4 @@
-<#  Get-BoardConfig.ps1 - the SINGLE reader/writer of the per-repo preference file.
+﻿<#  Get-BoardConfig.ps1 - the SINGLE reader/writer of the per-repo preference file.
 
     Dot-source it (never invoke it): `. (Join-Path $PSScriptRoot 'Get-BoardConfig.ps1')`
 

--- a/plugins/agentic-board/scripts/Get-BoardItems.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardItems.ps1
@@ -1,4 +1,4 @@
-<#  Get-BoardItems.ps1 - read EVERY item of a board, or say out loud that it could not (#484).
+﻿<#  Get-BoardItems.ps1 - read EVERY item of a board, or say out loud that it could not (#484).
 
     Why this exists. `gh project item-list` takes a `--limit` and, on reaching it, returns exactly
     that many items with no warning, no error and exit 0. It also returns them OLDEST-FIRST, so on a

--- a/plugins/agentic-board/scripts/Get-BoardVocabulary.ps1
+++ b/plugins/agentic-board/scripts/Get-BoardVocabulary.ps1
@@ -1,4 +1,4 @@
-<#  Get-BoardVocabulary.ps1 - the single source of truth for the board's option
+﻿<#  Get-BoardVocabulary.ps1 - the single source of truth for the board's option
     vocabulary: the CANONICAL option names (presets/fields.en.json) plus the
     LEGACY names that mean the same thing (GitHub's default Projects template,
     older hand-made boards).

--- a/plugins/agentic-board/scripts/Get-DeepWikiStatus.ps1
+++ b/plugins/agentic-board/scripts/Get-DeepWikiStatus.ps1
@@ -1,4 +1,4 @@
-<#  Get-DeepWikiStatus.ps1 — report DeepWiki indexing status for the current repo (#416).
+﻿<#  Get-DeepWikiStatus.ps1 — report DeepWiki indexing status for the current repo (#416).
 
     Resolves the repo from `origin`, checks GitHub visibility, probes DeepWiki,
     and returns one of four statuses:

--- a/plugins/agentic-board/scripts/Get-FieldEpisodes.ps1
+++ b/plugins/agentic-board/scripts/Get-FieldEpisodes.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Stage 2 of /board telemetry (#476) — turn transcript events into candidate episodes.
 

--- a/plugins/agentic-board/scripts/Get-FieldLedger.ps1
+++ b/plugins/agentic-board/scripts/Get-FieldLedger.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Ledger and incremental watermark for /board telemetry — the field-observation sweep.
 

--- a/plugins/agentic-board/scripts/Get-GhAccount.ps1
+++ b/plugins/agentic-board/scripts/Get-GhAccount.ps1
@@ -1,4 +1,4 @@
-<#  Get-GhAccount.ps1 — resolve GitHub account + token for agentic-board.
+﻿<#  Get-GhAccount.ps1 — resolve GitHub account + token for agentic-board.
     Default account: CSalcedoDataBI. Override: -Account pal-devs.
     Reads the PAT from the Windows USER registry (not $env:, which can be stale).
     Verifies the 'project' scope. Emits an object with .Token to set $env:GH_TOKEN.  #>

--- a/plugins/agentic-board/scripts/Get-InstalledMcpServers.ps1
+++ b/plugins/agentic-board/scripts/Get-InstalledMcpServers.ps1
@@ -1,4 +1,4 @@
-<#  Get-InstalledMcpServers.ps1 — installed Claude Code MCP servers as match keys.
+﻿<#  Get-InstalledMcpServers.ps1 — installed Claude Code MCP servers as match keys.
 
     Parses `claude mcp list` output into a flat, de-duplicated list of lowercase server
     names a catalog's `detect`/`name` can be matched against. Each line is expected in the

--- a/plugins/agentic-board/scripts/Get-InstalledPlugins.ps1
+++ b/plugins/agentic-board/scripts/Get-InstalledPlugins.ps1
@@ -1,4 +1,4 @@
-<#  Get-InstalledPlugins.ps1 — installed Claude Code plugins as match keys.
+﻿<#  Get-InstalledPlugins.ps1 — installed Claude Code plugins as match keys.
 
     Parses `claude plugin list` into a flat, de-duplicated list of lowercase identifiers a
     catalog's `detect`/`name` can be matched against. For each installed `<plugin>@<marketplace>`

--- a/plugins/agentic-board/scripts/Get-KnowledgeInventory.ps1
+++ b/plugins/agentic-board/scripts/Get-KnowledgeInventory.ps1
@@ -1,4 +1,4 @@
-<#  Get-KnowledgeInventory.ps1 — read-only inventory of the project knowledge registry.
+﻿<#  Get-KnowledgeInventory.ps1 — read-only inventory of the project knowledge registry.
     Reads knowledge/registry.json under -Root, normalizes it, and computes a health
     report (broken local paths, duplicate refs, orphan domains, missing notes). If the
     registry is absent, returns an empty inventory seeded with the default BI taxonomy.

--- a/plugins/agentic-board/scripts/Get-RepoFromOrigin.ps1
+++ b/plugins/agentic-board/scripts/Get-RepoFromOrigin.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     The single resolver for "which owner/name is this clone?" — dot-source it, never invoke it.
 
     WHY THIS FILE EXISTS (#281). The derivation was copy-pasted into eleven scripts in two

--- a/plugins/agentic-board/scripts/Get-SkillGaps.ps1
+++ b/plugins/agentic-board/scripts/Get-SkillGaps.ps1
@@ -1,4 +1,4 @@
-<#  Get-SkillGaps.ps1 — which catalog tools are missing for a profile?
+﻿<#  Get-SkillGaps.ps1 — which catalog tools are missing for a profile?
 
     Reads a curated PROFILE catalog (presets/toolkits/<profile>.json), compares it against
     what is actually installed, and reports installed vs gaps. It NEVER installs anything and

--- a/plugins/agentic-board/scripts/Get-SkillInventory.ps1
+++ b/plugins/agentic-board/scripts/Get-SkillInventory.ps1
@@ -1,4 +1,4 @@
-<#  Get-SkillInventory.ps1 — read-only inventory of Agent Skills across the 3 scopes.
+﻿<#  Get-SkillInventory.ps1 — read-only inventory of Agent Skills across the 3 scopes.
 
     Enumerates every SKILL.md in:
       - plugin   : ~/.claude/plugins/**/skills/<skill>/SKILL.md   (namespace plugin:skill)

--- a/plugins/agentic-board/scripts/Get-ToolkitFreshness.ps1
+++ b/plugins/agentic-board/scripts/Get-ToolkitFreshness.ps1
@@ -1,4 +1,4 @@
-<#  Get-ToolkitFreshness.ps1 — is each installed toolkit skill still current with upstream?
+﻿<#  Get-ToolkitFreshness.ps1 — is each installed toolkit skill still current with upstream?
 
     REPORT-ONLY. Scans the skills dir for `<skill>/.abios-provenance.json` markers written by
     Install-SkillFromRepo.ps1, and for each compares the installed commit SHA against the latest

--- a/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
+++ b/plugins/agentic-board/scripts/Get-ToolsCatalog.ps1
@@ -1,4 +1,4 @@
-<#  Get-ToolsCatalog.ps1 — the unified referenced-tools catalog resolver (#385).
+﻿<#  Get-ToolsCatalog.ps1 — the unified referenced-tools catalog resolver (#385).
 
     Merges the two sources that describe the external tools a project references and can install:
       - the knowledge registry  (knowledge/registry.json)   — the *references* (what exists / why)

--- a/plugins/agentic-board/scripts/Handoff-SessionStartHook.ps1
+++ b/plugins/agentic-board/scripts/Handoff-SessionStartHook.ps1
@@ -1,4 +1,4 @@
-<#  Handoff-SessionStartHook.ps1 - surface a saved handoff when a session begins.
+﻿<#  Handoff-SessionStartHook.ps1 - surface a saved handoff when a session begins.
 
     Meant to be wired as a Claude Code SessionStart hook (OPT-IN - see
     skills/projects-admin/references/handoff-hook.md). When RESUMING a prior session

--- a/plugins/agentic-board/scripts/Install-RepoTemplates.ps1
+++ b/plugins/agentic-board/scripts/Install-RepoTemplates.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Install issue forms + PR template into a repository (/board templates).
 

--- a/plugins/agentic-board/scripts/Install-SkillFromRepo.ps1
+++ b/plugins/agentic-board/scripts/Install-SkillFromRepo.ps1
@@ -1,4 +1,4 @@
-<#  Install-SkillFromRepo.ps1 — clean-clone a single skill from a GitHub repo.
+﻿<#  Install-SkillFromRepo.ps1 — clean-clone a single skill from a GitHub repo.
 
     Shallow-clones the source repo to a temp dir, copies ONLY the requested skill folder
     into the personal skills dir (~/.claude/skills/<name>), preserves the source LICENSE

--- a/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
+++ b/plugins/agentic-board/scripts/Install-ToolFromCatalog.ps1
@@ -1,4 +1,4 @@
-<#  Install-ToolFromCatalog.ps1 — install referenced tools from the unified catalog (#387).
+﻿<#  Install-ToolFromCatalog.ps1 — install referenced tools from the unified catalog (#387).
 
     Resolves items through Get-ToolsCatalog and installs by KIND, never duplicating:
       - skill-clone : delegates to Install-SkillFromRepo.ps1 (clean clone, LICENSE preserved).

--- a/plugins/agentic-board/scripts/Invoke-FieldScan.ps1
+++ b/plugins/agentic-board/scripts/Invoke-FieldScan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     /board telemetry — sweep local session transcripts and report how agentic-board behaved (#476).
 

--- a/plugins/agentic-board/scripts/Invoke-Gh.ps1
+++ b/plugins/agentic-board/scripts/Invoke-Gh.ps1
@@ -1,4 +1,4 @@
-<#  Invoke-Gh.ps1 - run gh so that a failure is a FAILURE, not an empty result (#303).
+﻿<#  Invoke-Gh.ps1 - run gh so that a failure is a FAILURE, not an empty result (#303).
 
     Why this exists. `gh` signals failure ONLY through its exit code, and a native command
     that exits non-zero does NOT throw in PowerShell - not even under

--- a/plugins/agentic-board/scripts/Invoke-KnowledgeHarvest.ps1
+++ b/plugins/agentic-board/scripts/Invoke-KnowledgeHarvest.ps1
@@ -1,4 +1,4 @@
-<#  Invoke-KnowledgeHarvest.ps1 — scan the repo for candidate references (read-only).
+﻿<#  Invoke-KnowledgeHarvest.ps1 — scan the repo for candidate references (read-only).
     Finds docs/**/*.md files and http(s) markdown links in README/docs, dedups against
     the existing registry, and emits candidates. The skill drives the pick + Add. #>
 [CmdletBinding()]

--- a/plugins/agentic-board/scripts/Invoke-SkillAudit.ps1
+++ b/plugins/agentic-board/scripts/Invoke-SkillAudit.ps1
@@ -1,4 +1,4 @@
-<#  Invoke-SkillAudit.ps1 — deterministic health audit over the skill inventory.
+﻿<#  Invoke-SkillAudit.ps1 — deterministic health audit over the skill inventory.
 
     Runs Get-SkillInventory and turns its lint / budget / overlap / misplaced signals
     into classified findings, each routed to its OWNING repo via Resolve-SkillOwner

--- a/plugins/agentic-board/scripts/KnowledgeRegistryIo.ps1
+++ b/plugins/agentic-board/scripts/KnowledgeRegistryIo.ps1
@@ -1,4 +1,4 @@
-<#  KnowledgeRegistryIo.ps1 — read/write the knowledge registry as JSON *or* YAML (#298).
+﻿<#  KnowledgeRegistryIo.ps1 — read/write the knowledge registry as JSON *or* YAML (#298).
 
     `/knowledge` versions its registry in `knowledge/registry.json`. A repo whose pre-commit hook uses
     an allow-list (only code: .py .md .toml .yaml …) blocks a `.json` file — often ON PURPOSE, because

--- a/plugins/agentic-board/scripts/Move-SkillsLayout.ps1
+++ b/plugins/agentic-board/scripts/Move-SkillsLayout.ps1
@@ -1,4 +1,4 @@
-<#  Move-SkillsLayout.ps1 — reorganize scattered project skills into the canonical layout.
+﻿<#  Move-SkillsLayout.ps1 — reorganize scattered project skills into the canonical layout.
 
     Target layout (consumer repo / monorepo):
         <Root>/.claude/skills/<project>/<skill>/SKILL.md

--- a/plugins/agentic-board/scripts/New-BoardPR.ps1
+++ b/plugins/agentic-board/scripts/New-BoardPR.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Cross-account PR workflow for /board work step 5a: push + PR with the RIGHT identity.
 

--- a/plugins/agentic-board/scripts/New-Release.ps1
+++ b/plugins/agentic-board/scripts/New-Release.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Prepare a release: bump the version, fold the CHANGELOG, keep the manifests
     consistent. Prepares files only — never commits, tags, or pushes.

--- a/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
+++ b/plugins/agentic-board/scripts/Post-BoardStatusUpdate.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Post a status update on a GitHub Projects v2 board (/board update).
 

--- a/plugins/agentic-board/scripts/Publish-DocsWiki.ps1
+++ b/plugins/agentic-board/scripts/Publish-DocsWiki.ps1
@@ -1,4 +1,4 @@
-<#  Publish-DocsWiki.ps1 — single publisher for the repo's GitHub Wiki.
+﻿<#  Publish-DocsWiki.ps1 — single publisher for the repo's GitHub Wiki.
 
     Generates ALL wiki pages in one clone → commit → push:
       Product docs (always):

--- a/plugins/agentic-board/scripts/Publish-KnowledgeWiki.ps1
+++ b/plugins/agentic-board/scripts/Publish-KnowledgeWiki.ps1
@@ -1,4 +1,4 @@
-<#  Publish-KnowledgeWiki.ps1 — DEPRECATED alias for Publish-DocsWiki.ps1.
+﻿<#  Publish-KnowledgeWiki.ps1 — DEPRECATED alias for Publish-DocsWiki.ps1.
 
     The GitHub Wiki is a single git repository; having two publishers independently clone
     and push it causes race conditions and lost updates. Publish-DocsWiki.ps1 is now the

--- a/plugins/agentic-board/scripts/Resolve-Board.ps1
+++ b/plugins/agentic-board/scripts/Resolve-Board.ps1
@@ -1,4 +1,4 @@
-<#  Resolve-Board.ps1 - find-or-reuse the board for a repo; create only if none exists.
+﻿<#  Resolve-Board.ps1 - find-or-reuse the board for a repo; create only if none exists.
     Prevents the "new duplicate board every time" bug. Returns the project NUMBER on stdout.
     Requires $env:GH_TOKEN (via gh-account).
     Usage: $num = & ./Resolve-Board.ps1 -Owner CSalcedoDataBI -Repo CSalcedoDataBI/agentic-board

--- a/plugins/agentic-board/scripts/Resolve-GhTokenVar.ps1
+++ b/plugins/agentic-board/scripts/Resolve-GhTokenVar.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Decide WHICH GitHub identity applies here (#550, part of #541).
 

--- a/plugins/agentic-board/scripts/Resolve-SkillOwner.ps1
+++ b/plugins/agentic-board/scripts/Resolve-SkillOwner.ps1
@@ -1,4 +1,4 @@
-<#  Resolve-SkillOwner.ps1 — where does a skill's failure feedback belong?
+﻿<#  Resolve-SkillOwner.ps1 — where does a skill's failure feedback belong?
 
     A skill's issues must go to the repo that OWNS the skill — never to the private
     project you happen to be working in. This resolves the routing:

--- a/plugins/agentic-board/scripts/Set-BoardField.ps1
+++ b/plugins/agentic-board/scripts/Set-BoardField.ps1
@@ -1,4 +1,4 @@
-<#  Set-BoardField.ps1 — bulk-fill ONE custom field across a board's items by a per-item rule.
+﻿<#  Set-BoardField.ps1 — bulk-fill ONE custom field across a board's items by a per-item rule.
     Generalizes the common "fill every column" chore: set a single-select field by a title-prefix
     map, or a text field by a {title} template, or a constant for all items. Idempotent, retries
     transient 5xx (502 Bad Gateway is common at scale), handles single-select vs text automatically.

--- a/plugins/agentic-board/scripts/Show-ToolsCatalog.ps1
+++ b/plugins/agentic-board/scripts/Show-ToolsCatalog.ps1
@@ -1,4 +1,4 @@
-<#  Show-ToolsCatalog.ps1 — browse + research view over Get-ToolsCatalog (#386).
+﻿<#  Show-ToolsCatalog.ps1 — browse + research view over Get-ToolsCatalog (#386).
 
     The read-only presentation layer of the /tools catalog. With no -Id it BROWSES: every
     referenced tool grouped by domain, each row carrying its kind, installed-state and URL — so

--- a/plugins/agentic-board/scripts/SkillAudit-StopHook.ps1
+++ b/plugins/agentic-board/scripts/SkillAudit-StopHook.ps1
@@ -1,4 +1,4 @@
-<#  SkillAudit-StopHook.ps1 — passive, suggest-only skill health nudge (Phase 2).
+﻿<#  SkillAudit-StopHook.ps1 — passive, suggest-only skill health nudge (Phase 2).
 
     Meant to be wired as a Claude Code Stop hook (OPT-IN — see
     skills/skills-audit/references/stop-hook.md). On each stop it runs a fast static

--- a/plugins/agentic-board/scripts/Suggest-HeavyMemory.ps1
+++ b/plugins/agentic-board/scripts/Suggest-HeavyMemory.ps1
@@ -1,4 +1,4 @@
-<#  Suggest-HeavyMemory.ps1 - the security-gated "heavy memory" escalation (#143).
+﻿<#  Suggest-HeavyMemory.ps1 - the security-gated "heavy memory" escalation (#143).
 
     The lightweight, git-committed HANDOFF.md is the DEFAULT. For the HEAVY case only -
     persistent SEMANTIC memory across projects - this script does NOT reinvent memory

--- a/plugins/agentic-board/scripts/Tmdl-DiffReview.ps1
+++ b/plugins/agentic-board/scripts/Tmdl-DiffReview.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     TMDL diff review (M2.2): detect breaking semantic-model schema changes.
 

--- a/plugins/agentic-board/scripts/Update-Docs.ps1
+++ b/plugins/agentic-board/scripts/Update-Docs.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Regenerate the derived parts of README.md so they never drift from the source:
     the command catalog (from each command's frontmatter) and the version string

--- a/plugins/agentic-board/scripts/Welcome-SessionStartHook.ps1
+++ b/plugins/agentic-board/scripts/Welcome-SessionStartHook.ps1
@@ -1,4 +1,4 @@
-<#  Welcome-SessionStartHook.ps1 - first-run welcome banner, shown exactly once.
+﻿<#  Welcome-SessionStartHook.ps1 - first-run welcome banner, shown exactly once.
 
     Wired as an AUTO-REGISTERED Claude Code SessionStart hook (hooks/hooks.json) - not
     opt-in: the whole point is that it "just works" right after `/plugin install`, so the

--- a/plugins/agentic-board/scripts/Worktree-Ghosts.ps1
+++ b/plugins/agentic-board/scripts/Worktree-Ghosts.ps1
@@ -1,4 +1,4 @@
-<#  Worktree-Ghosts.ps1 - inventory of managed worktree directories that git no longer knows.
+﻿<#  Worktree-Ghosts.ps1 - inventory of managed worktree directories that git no longer knows.
 
     THE GAP THIS CLOSES (#618). The doctor's existing ghost check trusts git's own `prunable`
     marker, which git sets when the METADATA survives but the DIRECTORY is gone. The inverse

--- a/plugins/agentic-board/scripts/Worktree-SessionStartHook.ps1
+++ b/plugins/agentic-board/scripts/Worktree-SessionStartHook.ps1
@@ -1,4 +1,4 @@
-<#  Worktree-SessionStartHook.ps1 - sweep empty orphan worktree directories at session start (#618).
+﻿<#  Worktree-SessionStartHook.ps1 - sweep empty orphan worktree directories at session start (#618).
 
     WHY A HOOK AND NOT A COMMAND. These orphans are born from abnormal session termination, so
     the moment a new session starts is exactly when the previous one's wreckage is on disk and

--- a/plugins/agentic-board/scripts/Write-KnowledgeTable.ps1
+++ b/plugins/agentic-board/scripts/Write-KnowledgeTable.ps1
@@ -1,4 +1,4 @@
-<#  Write-KnowledgeTable.ps1 — regenerate knowledge/KNOWLEDGE.md from registry.json,
+﻿<#  Write-KnowledgeTable.ps1 — regenerate knowledge/KNOWLEDGE.md from registry.json,
     grouped by domain. Generated artifact — never hand-edited. #>
 [CmdletBinding()]
 param([string]$Root = (Get-Location).Path)

--- a/plugins/agentic-board/skills/projects-admin/references/board-ops.md
+++ b/plugins/agentic-board/skills/projects-admin/references/board-ops.md
@@ -212,7 +212,7 @@ long-titled tracking issues are skipped; pass your own to widen/narrow the set.
 
 ```bash
 # 1) MANDATORY, unconditional backup (do NOT ask) — JSON snapshot + restorable live clone:
-powershell -File "${CLAUDE_PLUGIN_ROOT}/scripts/Backup-Board.ps1" -Number <num> -Owner <owner>
+pwsh -File "${CLAUDE_PLUGIN_ROOT}/scripts/Backup-Board.ps1" -Number <num> -Owner <owner>
 
 # 2) Then confirm with the user (destructive), then delete.
 #    gh project delete has NO --yes/-y flag — pipe a confirmation to stdin:

--- a/plugins/agentic-board/tests/Add-KnowledgeRef.Tests.ps1
+++ b/plugins/agentic-board/tests/Add-KnowledgeRef.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Add-KnowledgeRef.ps1: inits a seeded registry, appends a record,
     regenerates the table, enforces the domain guard and the local-path-exists guard,
     infers type, and increments ids. #>

--- a/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
+++ b/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Apply-FieldPreset.ps1 - the field-list read must FAIL CLOSED (#313, part of #303).
 
     This is the exact repro named in #303: `$existing = (gh project field-list ... |

--- a/plugins/agentic-board/tests/Assert-BoardComplete.Tests.ps1
+++ b/plugins/agentic-board/tests/Assert-BoardComplete.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Assert-BoardComplete.ps1 — the "board is fully worked" pass/fail check.
 
     Side-effecting (reads the board over gh), so it exposes a dot-source guard: with

--- a/plugins/agentic-board/tests/Backup-Board.Tests.ps1
+++ b/plugins/agentic-board/tests/Backup-Board.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Backup-Board.ps1 and Export-BoardSnapshot.ps1 (#312, part of #303).
 
     These two are the ugliest instance of the silent-gh bug. Every other victim misreports

--- a/plugins/agentic-board/tests/Board-Breakdown.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Breakdown.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Breakdown.ps1 - addSubIssue must FAIL CLOSED on errors[] (#315, part of #303).
 
     addSubIssue is a `gh api graphql` mutation. The old code piped it to Out-Null and only checked

--- a/plugins/agentic-board/tests/Board-Changelog.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Changelog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Changelog.ps1's CHANGELOG-write logic (#324).
 
     Board-Changelog.ps1 is side-effecting (reads the board over gh), so it exposes a dot-source

--- a/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Doctor.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Board-Doctor.ps1 - the git-reality branch/worktree audit (#274).
 
     The whole point of the command is that it does NOT trust `git branch --merged` (this repo

--- a/plugins/agentic-board/tests/Board-Fill.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Fill.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Board-Fill.ps1 - the /board fill gap-filler.
 
     Board-Fill.ps1 is a side-effecting command (gh + Write-Host), so it exposes a

--- a/plugins/agentic-board/tests/Board-Handoff-Knowledge.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Handoff-Knowledge.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for the capture-in-handoff helper Get-HandoffKnowledgeCandidates in
     Board-Handoff.ps1 (the knowledge anti-rot hook, #162). Dot-sourced via the guard so
     only the pure helper runs — zero gh/git/network. Covers URL extraction from the

--- a/plugins/agentic-board/tests/Board-Handoff.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Handoff.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Board-Handoff.ps1 - the /board handoff save driver.
 
     Board-Handoff.ps1 is side-effecting (gh + git + file writes), so it exposes a

--- a/plugins/agentic-board/tests/Board-Merge.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Merge.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Merge.ps1 — specifically the end-to-end brake check (#536).
 
     THE DEFECT THESE EXIST FOR, because it is invisible in a normal reading:

--- a/plugins/agentic-board/tests/Board-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Plan.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Plan.ps1 — the /board plan epic creator.
 
     Side-effecting (creates issues over gh), so it exposes a dot-source guard: with

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-ReviewGate.ps1's pure foreign-commit detection (#309).
 
     Board-ReviewGate.ps1 is side-effecting (reads the PR over gh, waits for CI/review), so it exposes

--- a/plugins/agentic-board/tests/Board-RunLedger.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-RunLedger.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Board-RunLedger.ps1 - the run-ledger writer (epic #348).
 
     The script touches gh + the filesystem, so it exposes a dot-source guard: with

--- a/plugins/agentic-board/tests/Board-Summary.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Summary.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Summary.ps1 — the closing summary every user-facing flow must end with.
 
     The contract is four blocks, always the same four, always in the same order: what I found,

--- a/plugins/agentic-board/tests/Board-Triage.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Triage.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Board-Triage.ps1's pure triage logic (#306).
 
     Board-Triage.ps1 is side-effecting (reads/writes the board over gh), so it exposes a dot-source

--- a/plugins/agentic-board/tests/Board-Work.Grouping.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Grouping.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for the grouped-PR suggestion helpers of Board-Work.ps1 (#662).
 
     These are pure functions over board items, so they run through the script's

--- a/plugins/agentic-board/tests/Board-Work.Preference.Integration.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Preference.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Integration tests for `Board-Work.ps1 -PreferGroupedPRs` (#662).
 
     Pure tests could not have caught what these do. The bug they exist for was not in any

--- a/plugins/agentic-board/tests/Board-Work.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Work.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Board-Work.ps1 - the /board work driver.
 
     Board-Work.ps1 is a side-effecting command (gh + Write-Host), so it exposes a

--- a/plugins/agentic-board/tests/Bpa-GateReview.Tests.ps1
+++ b/plugins/agentic-board/tests/Bpa-GateReview.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Bpa-GateReview.ps1's pure BPA logic (M3.3, issue #16).
 
     Bpa-GateReview.ps1 is side-effecting (runs gh + Tabular Editor), so it exposes a dot-source guard:

--- a/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-Guard.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Brake-Guard.ps1 — the irreversible brake as a mechanical control (#440 / #516).
 
     The defect these guard against: the brake used to be a paragraph in the launch briefing, and

--- a/plugins/agentic-board/tests/Brake-PreToolUseHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Brake-PreToolUseHook.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Brake-PreToolUseHook.ps1 — the half of the brake that does not depend on the agent's
     cooperation (#516), taught the end-to-end order in #536.
 

--- a/plugins/agentic-board/tests/Clear-AbiosState.Tests.ps1
+++ b/plugins/agentic-board/tests/Clear-AbiosState.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Clear-AbiosState.ps1 — the .agentic-board/ garbage collector (#574).
 
     The state dir accumulated 48 files across the project's entire life because nothing ever

--- a/plugins/agentic-board/tests/CommandSurface.Tests.ps1
+++ b/plugins/agentic-board/tests/CommandSurface.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for the Command Surface Contract (CONTRIBUTING.md § "Command surface").
 
     Enforces the invariant that let a menu tell users to type `/abios-feedback` (a command that

--- a/plugins/agentic-board/tests/Compact-PreCompactHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Compact-PreCompactHook.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Compact-PreCompactHook.ps1 - the transcript-snapshot safety net
     (epic #348).
 

--- a/plugins/agentic-board/tests/CopilotAvailability.Tests.ps1
+++ b/plugins/agentic-board/tests/CopilotAvailability.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for CopilotAvailability.ps1 — the per-account "Copilot has no quota, stop waiting" memory (#367).
 
     Pure at load (functions only), so it dot-sources directly. The two decisions the gate depends on:

--- a/plugins/agentic-board/tests/DiagramAuthoring.Tests.ps1
+++ b/plugins/agentic-board/tests/DiagramAuthoring.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for the diagram-authoring skill (#376) and the Diagrams knowledge domain (#378).
 
     Asserts the skill exists as an INTERNAL support skill (never a typed command), and that the

--- a/plugins/agentic-board/tests/ErrorBoundary.Tests.ps1
+++ b/plugins/agentic-board/tests/ErrorBoundary.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Error-boundary tests — exit 1 with no message and raw exceptions (#485).
 
     Field sweep (#476): 945 sessions, 295 failed invocations. Two failure shapes

--- a/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Auto.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-Auto.ps1 — the `auto` verb: compose the autonomous brief and resolve the
     time budget the launch hands to the brake marker (#564). Pure cores (Format-AutoBrief,
     Get-ContractBudgetMinutes, Test-GhScope, Assert-BrakeCompliance, Format-ComplianceReport)

--- a/plugins/agentic-board/tests/Expert-Autonomy.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Autonomy.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-Autonomy.ps1 — the single guard deciding when the autonomous run must
     stop for the human. Autonomy brakes ONLY on the irreversible; everything else proceeds.
     Fail-safe: an UNKNOWN action is treated as irreversible (stop and ask), never waved through.

--- a/plugins/agentic-board/tests/Expert-ClaimsGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-ClaimsGate.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-ClaimsGate.ps1 — the claims verification gate for deliverables (#479).
 
     Five tests from the issue:

--- a/plugins/agentic-board/tests/Expert-Config.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Config.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-Config.ps1 — the /board expert `config` verb: build the contract with a
     synthesized role and persist it. Pure composition (New-ExpertConfig) behind
     ABIOS_EXPERTCONFIG_DOTSOURCE; it reuses ExpertContractIo + Expert-RoleSynthesis. #>

--- a/plugins/agentic-board/tests/Expert-EndToEnd.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-EndToEnd.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-EndToEnd.ps1 — may an autonomous run close its own work? (#530, part of #526)
 
     Four conditions, each covering a failure the others cannot see. The tests that matter are the

--- a/plugins/agentic-board/tests/Expert-Evidence.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Evidence.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-Evidence.ps1 — the recorded test-evidence the auto-expert leaves behind.
 
     Pure formatting behind ABIOS_EXPERTEVIDENCE_DOTSOURCE. These pin the durable [abios-evidence]

--- a/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RoleSynthesis.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-RoleSynthesis.ps1 — the deterministic skeleton the auto-expert fills.
 
     The LLM does the actual prior-art research; this script gives the reproducible parts:

--- a/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-Roles.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-Roles.ps1 — the `roles list` / `roles why` verb: show the effective catalog
     and explain which role a plan resolves to. Pure behind ABIOS_EXPERTROLESCMD_DOTSOURCE. #>
 

--- a/plugins/agentic-board/tests/Expert-RunVerify.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-RunVerify.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-RunVerify.ps1 — the completion check that proves a run wrote its evidence
     instead of asserting it did (#532, part of #526).
 

--- a/plugins/agentic-board/tests/Expert-WorkClass.Tests.ps1
+++ b/plugins/agentic-board/tests/Expert-WorkClass.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Expert-WorkClass.ps1 — classifying a change as CODE or VISUAL (#529, part of #526).
 
     The rule being encoded: code is judged by READING it, so an agent that reviewed it carefully can

--- a/plugins/agentic-board/tests/ExpertContractIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertContractIo.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for ExpertContractIo.ps1 — the /board expert contract (config writes it, auto reads it).
 
     Pure filesystem IO (no gh), guarded by $env:ABIOS_EXPERTCONTRACT_DOTSOURCE. These pin the

--- a/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
+++ b/plugins/agentic-board/tests/ExpertRolesIo.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for ExpertRolesIo.ps1 — loads the shipped role preset plus the optional project-local
     roles.json, validates both, and merges them into the effective catalog. Pure filesystem IO
     (no gh) behind ABIOS_EXPERTROLES_DOTSOURCE. #>

--- a/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
+++ b/plugins/agentic-board/tests/Field-Episodes.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Get-FieldEpisodes.ps1 — stage 2 of /board field (#476).
 
     Pure core behind $env:ABIOS_FIELDEPISODES_DOTSOURCE. Fixtures are normalized event lists, so

--- a/plugins/agentic-board/tests/Field-Ledger.Tests.ps1
+++ b/plugins/agentic-board/tests/Field-Ledger.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Get-FieldLedger.ps1 — the incremental watermark behind /board field.
 
     The pure core loads behind $env:ABIOS_FIELDLEDGER_DOTSOURCE (same convention as the other

--- a/plugins/agentic-board/tests/Find-InternalVocabularyLeak.Tests.ps1
+++ b/plugins/agentic-board/tests/Find-InternalVocabularyLeak.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Find-InternalVocabularyLeak.ps1 — the detector behind the "no internal names in
     user-facing output" regression test (#491/#494). Pure text matching, guarded by
     $env:ABIOS_VOCABLEAK_DOTSOURCE so these run with no filesystem access for the detector half;

--- a/plugins/agentic-board/tests/Fleet-Findings.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Findings.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Fleet-Findings.ps1 - the fleet shared-findings blackboard (P3-1).
 
     Fleet-Findings.ps1 is a side-effecting command (disk + git + Write-Host), so it

--- a/plugins/agentic-board/tests/Fleet-Handoff.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Handoff.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Fleet-Handoff.ps1 - dependency-aware hand-off (P3-4). A dependent
     issue waits for its blockers' PRs to merge, and inherits the upstream findings as
     context. Pure core (readiness + context) behind a dot-source guard

--- a/plugins/agentic-board/tests/Fleet-Ownership.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Ownership.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Fleet-Ownership.ps1 - the fleet file-ownership guard (P3-3,
     "one owner per file"). Side-effecting (disk + git + process liveness), so it
     exposes a dot-source guard ($env:ABIOS_FLEETOWNERSHIP_DOTSOURCE) to unit-test the

--- a/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Plan.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Fleet-Plan.ps1 - the advisory board-lead planner (P3-2). It reads
     pending board issues and emits an assignment map (issue -> CLI -> dependency wave)
     WITHOUT launching anything. Side-effecting at the edges (gh), so a dot-source guard

--- a/plugins/agentic-board/tests/Fleet-Supervisor.Tests.ps1
+++ b/plugins/agentic-board/tests/Fleet-Supervisor.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Fleet-Supervisor.ps1 - stall detection + fleet termination (P3-5).
     Watches the live fleet and decides: which sessions have stalled (running too long with
     no PR), whether the whole run is complete, and whether it should STOP (guard against

--- a/plugins/agentic-board/tests/Get-AbiosStateDir.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-AbiosStateDir.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-AbiosStateDir.ps1 — the single internal state-dir resolver.
 
     Covers the rename hardening (#244): the new name going forward, the one-time

--- a/plugins/agentic-board/tests/Get-BoardConfig.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardConfig.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-BoardConfig.ps1 - the per-repo preference file (#662).
 
     The script is pure at load (functions only), so it is dot-sourced directly.

--- a/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardItems.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Get-BoardItems.ps1 — the board read that reports its own truncation (#484).
 
     The bug being pinned here is not an off-by-N. `gh project item-list --limit 200` returns exit 0

--- a/plugins/agentic-board/tests/Get-BoardVocabulary.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-BoardVocabulary.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-BoardVocabulary.ps1 - the canonical/legacy option map
     behind issue #278 (a board born from GitHub's default template used to be
     silently invisible to /board work, and /board field apply could not migrate it). #>

--- a/plugins/agentic-board/tests/Get-DeepWikiStatus.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-DeepWikiStatus.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Get-DeepWikiStatus.ps1 (#416).
 
     Pure helpers (Get-DeepWikiUrl, Resolve-DeepWikiIndex) are dot-sourced and tested

--- a/plugins/agentic-board/tests/Get-InstalledPlugins.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-InstalledPlugins.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-InstalledPlugins.ps1 — parsing `claude plugin list` output into
     match keys (plugin + marketplace), best-effort. #>
 

--- a/plugins/agentic-board/tests/Get-KnowledgeInventory.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-KnowledgeInventory.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-KnowledgeInventory.ps1. Builds a temp registry with a broken
     local path, a duplicate ref, an orphan domain and a missing note, then asserts the
     health contract. Also asserts the empty-registry seed path. #>

--- a/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ReleaseNotes.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for scripts/Get-ReleaseNotes.ps1 (release L1, #322).
 
     Get-ReleaseNotes.ps1 reads CHANGELOG.md and prints one version's block for the release workflow

--- a/plugins/agentic-board/tests/Get-RepoFromOrigin.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-RepoFromOrigin.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-RepoFromOrigin.ps1 — the single owner/name + issue-number resolver (#281).
 
     Both helpers replace an inline one-liner that was copy-pasted across eleven scripts and got

--- a/plugins/agentic-board/tests/Get-SkillGaps.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-SkillGaps.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-SkillGaps.ps1 — profile catalogs + gap detection against injected
     install sets (skill-clone by name, plugin by detect/marketplace). #>
 

--- a/plugins/agentic-board/tests/Get-SkillInventory.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-SkillInventory.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-SkillInventory.ps1.
     Builds a deliberately messy skill layout in a temp fixture (canonical + misplaced
     + near-duplicate + over-cap + first-person) and asserts the inventory contract. #>

--- a/plugins/agentic-board/tests/Get-ToolkitFreshness.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ToolkitFreshness.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Get-ToolkitFreshness.ps1 — provenance scan + fresh/behind/unknown
     classification against an injected upstream-SHA map (no network). #>
 

--- a/plugins/agentic-board/tests/Get-ToolsCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Get-ToolsCatalog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Get-ToolsCatalog.ps1 (#385) — the unified referenced-tools catalog resolver.
 
     It merges the knowledge registry (references) with the toolkit presets (installers) into one

--- a/plugins/agentic-board/tests/Handoff-SessionStartHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Handoff-SessionStartHook.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Handoff-SessionStartHook.ps1 - the opt-in SessionStart hook.
 
     The hook reads stdin and touches the filesystem, so it exposes a dot-source guard:

--- a/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Install-ToolFromCatalog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Install-ToolFromCatalog.ps1 (#387) — install ONE referenced tool by id.
 
     skill-clone → delegates to the injected installer (real default: Install-SkillFromRepo.ps1).

--- a/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-Gh.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for scripts/Invoke-Gh.ps1 (#311, part of #303).
 
     The whole point of the helper is that a gh failure must NOT be readable as an empty

--- a/plugins/agentic-board/tests/Invoke-KnowledgeHarvest.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-KnowledgeHarvest.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Invoke-KnowledgeHarvest.ps1: finds docs md files + http links,
     dedups against the existing registry, and never writes. #>
 BeforeAll {

--- a/plugins/agentic-board/tests/Invoke-SkillAudit.Tests.ps1
+++ b/plugins/agentic-board/tests/Invoke-SkillAudit.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Invoke-SkillAudit.ps1 and Resolve-SkillOwner.ps1.
     Fixture has one healthy skill and one broken skill (first-person, no triggers,
     no when-not clause) so the classifier's findings can be asserted. #>

--- a/plugins/agentic-board/tests/KnowledgeRegistryIo.Tests.ps1
+++ b/plugins/agentic-board/tests/KnowledgeRegistryIo.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for KnowledgeRegistryIo.ps1 — the JSON-or-YAML knowledge registry (#298).
 
     KnowledgeRegistryIo.ps1 is pure at load (functions only), so it dot-sources directly. The point of

--- a/plugins/agentic-board/tests/Move-SkillsLayout.Tests.ps1
+++ b/plugins/agentic-board/tests/Move-SkillsLayout.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Move-SkillsLayout.ps1.
     Builds a temp git repo with one misplaced skill and one canonical skill, then
     asserts: dry-run changes nothing, -Apply relocates only the misplaced one and

--- a/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
+++ b/plugins/agentic-board/tests/New-BoardPR.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for New-BoardPR.ps1's pure PR-existence check (#336).
 
     New-BoardPR.ps1 is side-effecting (git push + gh pr create), so it exposes a dot-source guard:

--- a/plugins/agentic-board/tests/New-Release.Tests.ps1
+++ b/plugins/agentic-board/tests/New-Release.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for New-Release.ps1 — release prep (#206).
 
     New-Release.ps1 is side-effecting (disk + git + Board-Changelog), so it exposes

--- a/plugins/agentic-board/tests/Pagination-CursorQuoting.Tests.ps1
+++ b/plugins/agentic-board/tests/Pagination-CursorQuoting.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Source-level regression lock for #329 across ALL paginated board reads.
 
     Every Projects-v2 read that paginates once built its page-2 cursor argument by splicing it

--- a/plugins/agentic-board/tests/PluginStructure.Tests.ps1
+++ b/plugins/agentic-board/tests/PluginStructure.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Marketplace structure check: every plugin source must ship a plugin.json (#420).
 
     Motivation, from inbox/IMPROVEMENTS.md (2026-06-26, "plugin packaging: root-as-plugin is

--- a/plugins/agentic-board/tests/Post-BoardStatusUpdate.Tests.ps1
+++ b/plugins/agentic-board/tests/Post-BoardStatusUpdate.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Post-BoardStatusUpdate.ps1 - reads must FAIL CLOSED (#315, part of #303).
 
     The write here is a public status update posted to the board. Two hazards:

--- a/plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1
+++ b/plugins/agentic-board/tests/Publish-DocsWiki.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Publish-DocsWiki.ps1 page generation (-PagesOnly, no git/network).
     Validates:
       - Docs-Home is generated from README.md (HTML stripped, GENERATED marker present)

--- a/plugins/agentic-board/tests/Publish-KnowledgeWiki.Tests.ps1
+++ b/plugins/agentic-board/tests/Publish-KnowledgeWiki.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Publish-KnowledgeWiki.ps1.
 
     Since #405, Publish-KnowledgeWiki.ps1 is a thin alias that delegates entirely to

--- a/plugins/agentic-board/tests/RawGh.Lint.Tests.ps1
+++ b/plugins/agentic-board/tests/RawGh.Lint.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Lint: no NEW raw `gh` call sites outside Invoke-Gh.ps1 (#571).
 
     Invoke-Gh.ps1 exists because bare gh turns a 401 into an empty result (#303/#86) - and yet

--- a/plugins/agentic-board/tests/Resolve-Board.Tests.ps1
+++ b/plugins/agentic-board/tests/Resolve-Board.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Resolve-Board.ps1 - the read must FAIL CLOSED (#313, part of #303).
 
     Resolve-Board's whole job is "find-or-reuse, create only if none exists". The find is a

--- a/plugins/agentic-board/tests/Resolve-GhTokenVar.Tests.ps1
+++ b/plugins/agentic-board/tests/Resolve-GhTokenVar.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Resolve-GhTokenVar.ps1 — which GitHub identity applies (#550, part of #541).
 
     The decision that matters is the FAILURE one. An armed run with no agent token must STOP, not

--- a/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
+++ b/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
@@ -1,0 +1,121 @@
+#Requires -Modules Pester
+<#  Encoding ratchet: every PowerShell file we ship must start with a UTF-8 BOM.
+
+    Field report (2026-08-31): a session on a Spanish Windows could not run Board-Fill.ps1 at all —
+    it died at parse time with "Unexpected token '}' in expression or statement" on lines 370 and
+    508. The script was fine. The reader was not.
+
+    Every .ps1 in this repo was UTF-8 WITHOUT a BOM, and the files are full of box-drawing rules
+    (U+2500) and em dashes (U+2014). Both encode to a byte sequence containing 0x94. Windows
+    PowerShell 5.1 reads a BOM-less file as the machine's ANSI codepage, and on cp1252 the byte
+    0x94 decodes to RIGHT DOUBLE QUOTATION MARK — which the PowerShell tokenizer accepts as a
+    STRING DELIMITER. An odd number of them opens a string that swallows real code, and the next
+    closing brace lands inside a string literal. Hence the phantom '}'.
+
+    26 of 208 files failed to parse outright this way; the rest silently printed mojibake.
+    Scripts.Parse.Tests.ps1 already parses every script and stayed green throughout, because it
+    calls ParseFile from pwsh 7 — which assumes UTF-8 for a BOM-less file. Same parse, different
+    host, and the host is the whole bug. Only Windows PowerShell 5.1 sees it, and the repo's own
+    docs told contributors to launch scripts with `powershell -File` (now `pwsh -File`).
+
+    A BOM makes the file self-describing: 5.1 and 7.x both read it as UTF-8, on any codepage. That
+    is the fix; this is the ratchet that keeps it. Pure filesystem assertion, no network. #>
+
+BeforeDiscovery {
+    # Discovery-time on purpose: `-Skip:` on an It is evaluated while Pester DISCOVERS the file,
+    # long before any BeforeAll runs. Resolving this in BeforeAll made the check skip on every
+    # host, forever — a green suite that proved nothing.
+    $script:WinPs = @(
+        Join-Path $env:SystemRoot 'System32' 'WindowsPowerShell' 'v1.0' 'powershell.exe'
+        (Get-Command 'powershell.exe' -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1).Source
+    ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -First 1
+}
+
+Describe 'PowerShell source encoding' {
+
+    BeforeAll {
+        #   tests/ -> agentic-board/ -> plugins/ -> repo root
+        $script:RepoRoot = (Join-Path $PSScriptRoot '..' '..' '..' | Resolve-Path).Path
+        # git-tracked only: the point is what we SHIP. Untracked/ignored session artifacts (the
+        # .agentic-board/launch-*.ps1 scratch files) are none of this ratchet's business.
+        Push-Location $script:RepoRoot
+        try { $tracked = @(& git ls-files -- '*.ps1' '*.psm1' '*.psd1') } finally { Pop-Location }
+        $script:PsFiles = @(
+            $tracked | ForEach-Object { Get-Item -LiteralPath (Join-Path $script:RepoRoot $_) -ErrorAction SilentlyContinue }
+        )
+    }
+
+    It 'finds PowerShell files to check (fails closed on a broken glob)' {
+        # Without this, a discovery bug would make every assertion below vacuously green.
+        $script:PsFiles.Count | Should -BeGreaterThan 50
+    }
+
+    It 'ships every PowerShell file with a UTF-8 BOM' {
+        $offenders = foreach ($f in $script:PsFiles) {
+            $head = [byte[]]::new(3)
+            $fs = [System.IO.File]::OpenRead($f.FullName)
+            try { $read = $fs.Read($head, 0, 3) } finally { $fs.Dispose() }
+            if (-not ($read -eq 3 -and $head[0] -eq 0xEF -and $head[1] -eq 0xBB -and $head[2] -eq 0xBF)) {
+                $f.FullName.Replace($script:RepoRoot, '').TrimStart('\', '/')
+            }
+        }
+
+        $offenders = @($offenders)
+        if ($offenders.Count) {
+            throw ("$($offenders.Count) PowerShell file(s) have no UTF-8 BOM; Windows PowerShell 5.1 " +
+                   "reads them as ANSI and can mis-tokenize them:`n  " + ($offenders -join "`n  "))
+        }
+    }
+
+    # Windows PowerShell 5.1 — the host that actually mis-read a BOM-less file. Absent on
+    # Linux/macOS dev boxes; present on the windows-latest runner that runs this suite in CI.
+    # -ForEach because the It body runs in a scope where the discovery variable is not visible.
+    It 'is readable by Windows PowerShell 5.1, except the scripts declared pwsh-7-only' -Skip:(-not $script:WinPs) -ForEach @{
+        WinPs = $script:WinPs
+    } {
+        # The end-to-end proof, run in the host that broke in the field: 5.1 reads each file off
+        # disk with its own encoding rules and we assert the tokenizer stays clean. -EncodedCommand
+        # (UTF-16LE base64) so no quoting or codepage of ours can distort the child command.
+        #
+        # The allowlist is NOT a way to wave failures through. These four use operators that only
+        # exist in PowerShell 7 (`??` null-coalescing, `? :` ternary) — a deliberate version
+        # dependency, not an encoding fault, and 5.1 rejects them BOM or no BOM. Declaring them by
+        # name is what keeps this assertion sharp: anything else that 5.1 cannot read is new, and
+        # the first suspect is encoding. Shrink this list, never grow it without a reason in the PR.
+        $pwsh7Only = @(
+            'plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1'
+            'plugins/agentic-board/scripts/Expert-Roles.ps1'
+            'plugins/agentic-board/scripts/KnowledgeRegistryIo.ps1'
+            'plugins/agentic-board/scripts/Resolve-SkillOwner.ps1'
+        )
+
+        $child = @'
+Set-Location -LiteralPath "__ROOT__"
+& git ls-files -- *.ps1 *.psm1 *.psd1 | ForEach-Object {
+        $full = Join-Path "__ROOT__" $_
+        $errors = $null; $tokens = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($full, [ref]$tokens, [ref]$errors) | Out-Null
+        if ($errors.Count) { "{0}|{1}|{2}" -f $_, $errors[0].Extent.StartLineNumber, $errors[0].Message }
+    }
+'@ -replace '__ROOT__', $script:RepoRoot.Replace('"', '""')
+
+        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($child))
+        $reported = @(& $WinPs -NoProfile -NonInteractive -EncodedCommand $encoded)
+
+        $unexpected = @($reported | Where-Object { ($_ -split '\|', 3)[0] -notin $pwsh7Only })
+        if ($unexpected.Count) {
+            $shown = $unexpected | ForEach-Object { $p, $l, $m = $_ -split '\|', 3; "$p (line ${l}: $m)" }
+            throw ("Windows PowerShell 5.1 cannot read $($unexpected.Count) shipped file(s) that are " +
+                   "not declared pwsh-7-only — suspect encoding first:`n  " + ($shown -join "`n  "))
+        }
+
+        # Fail closed the other way too: if an allowlisted script gets fixed or deleted, this test
+        # must say so rather than keep carrying a stale exemption.
+        $stale = @($pwsh7Only | Where-Object { $_ -notin @($reported | ForEach-Object { ($_ -split '\|', 3)[0] }) })
+        if ($stale.Count) {
+            throw ("These scripts no longer need the pwsh-7-only exemption; remove them from the " +
+                   "allowlist in this test:`n  " + ($stale -join "`n  "))
+        }
+    }
+}

--- a/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
+++ b/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Encoding ratchet: every PowerShell file we ship must start with a UTF-8 BOM.
 
     Field report (2026-08-31): a session on a Spanish Windows could not run Board-Fill.ps1 at all —

--- a/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
+++ b/plugins/agentic-board/tests/ScriptEncoding.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Modules Pester
-<#  Encoding ratchet: every PowerShell file we ship must start with a UTF-8 BOM.
+<#  Encoding ratchet: every PowerShell file we ship must declare its own interpreter.
 
     Field report (2026-08-31): a session on a Spanish Windows could not run Board-Fill.ps1 at all —
     it died at parse time with "Unexpected token '}' in expression or statement" on lines 370 and
@@ -12,11 +12,11 @@
     STRING DELIMITER. An odd number of them opens a string that swallows real code, and the next
     closing brace lands inside a string literal. Hence the phantom '}'.
 
-    26 of 208 files failed to parse outright this way; the rest silently printed mojibake.
-    Scripts.Parse.Tests.ps1 already parses every script and stayed green throughout, because it
-    calls ParseFile from pwsh 7 — which assumes UTF-8 for a BOM-less file. Same parse, different
-    host, and the host is the whole bug. Only Windows PowerShell 5.1 sees it, and the repo's own
-    docs told contributors to launch scripts with `powershell -File` (now `pwsh -File`).
+    28 of the 185 shipped files failed to parse outright this way; the rest silently printed
+    mojibake. Scripts.Parse.Tests.ps1 already parses every script and stayed green throughout,
+    because it calls ParseFile from pwsh 7 — which assumes UTF-8 for a BOM-less file. Same parse,
+    different host, and the host is the whole bug. Only Windows PowerShell 5.1 sees it, and the
+    repo's own docs told contributors to launch scripts with `powershell -File` (now `pwsh -File`).
 
     A BOM makes the file self-describing: 5.1 and 7.x both read it as UTF-8, on any codepage. That
     is the fix; this is the ratchet that keeps it. Pure filesystem assertion, no network. #>
@@ -42,7 +42,9 @@ Describe 'PowerShell source encoding' {
         Push-Location $script:RepoRoot
         try { $tracked = @(& git ls-files -- '*.ps1' '*.psm1' '*.psd1') } finally { Pop-Location }
         $script:PsFiles = @(
-            $tracked | ForEach-Object { Get-Item -LiteralPath (Join-Path $script:RepoRoot $_) -ErrorAction SilentlyContinue }
+            $tracked | ForEach-Object {
+                Get-Item -LiteralPath (Join-Path $script:RepoRoot $_) -ErrorAction SilentlyContinue
+            }
         )
     }
 
@@ -51,43 +53,61 @@ Describe 'PowerShell source encoding' {
         $script:PsFiles.Count | Should -BeGreaterThan 50
     }
 
-    It 'ships every PowerShell file with a UTF-8 BOM' {
+    It 'declares an interpreter on every PowerShell file: a BOM, or a shebang, never both' {
+        # BOM xor shebang. Both mechanisms answer "which interpreter reads this file", and they
+        # compete for the same first bytes: a BOM in front of `#!` hides the shebang from the Unix
+        # loader, so a file carries one or the other. Everything we ship takes the BOM, because the
+        # failure being guarded is a Windows PowerShell 5.1 one; the two VHS demo assets under
+        # .github/assets declare `#!/usr/bin/env pwsh` and keep that instead.
         $offenders = foreach ($f in $script:PsFiles) {
-            $head = [byte[]]::new(3)
+            $head = [byte[]]::new(5)
             $fs = [System.IO.File]::OpenRead($f.FullName)
-            try { $read = $fs.Read($head, 0, 3) } finally { $fs.Dispose() }
-            if (-not ($read -eq 3 -and $head[0] -eq 0xEF -and $head[1] -eq 0xBB -and $head[2] -eq 0xBF)) {
-                $f.FullName.Replace($script:RepoRoot, '').TrimStart('\', '/')
-            }
+            try { $read = $fs.Read($head, 0, 5) } finally { $fs.Dispose() }
+            $rel = $f.FullName.Replace($script:RepoRoot, '') -replace '^[\\/]+', ''
+
+            $hasBom      = ($read -ge 3 -and $head[0] -eq 0xEF -and $head[1] -eq 0xBB -and $head[2] -eq 0xBF)
+            $bomHidesIt  = ($hasBom -and $read -ge 5 -and $head[3] -eq 0x23 -and $head[4] -eq 0x21)
+            $shebangOnly = ($read -ge 2 -and $head[0] -eq 0x23 -and $head[1] -eq 0x21)
+
+            if ($bomHidesIt) { "$rel (BOM sits in front of the shebang and hides it)" }
+            elseif (-not $hasBom -and -not $shebangOnly) { "$rel (no BOM)" }
         }
 
         $offenders = @($offenders)
         if ($offenders.Count) {
-            throw ("$($offenders.Count) PowerShell file(s) have no UTF-8 BOM; Windows PowerShell 5.1 " +
-                   "reads them as ANSI and can mis-tokenize them:`n  " + ($offenders -join "`n  "))
+            throw ("$($offenders.Count) PowerShell file(s) declare no interpreter; Windows PowerShell 5.1 " +
+                   "reads a BOM-less file as ANSI and can mis-tokenize it:`n  " + ($offenders -join "`n  "))
         }
     }
 
     # Windows PowerShell 5.1 — the host that actually mis-read a BOM-less file. Absent on
     # Linux/macOS dev boxes; present on the windows-latest runner that runs this suite in CI.
     # -ForEach because the It body runs in a scope where the discovery variable is not visible.
-    It 'is readable by Windows PowerShell 5.1, except the scripts declared pwsh-7-only' -Skip:(-not $script:WinPs) -ForEach @{
+    It 'is readable by Windows PowerShell 5.1, except the files declared otherwise' -Skip:(-not $script:WinPs) -ForEach @{
         WinPs = $script:WinPs
     } {
         # The end-to-end proof, run in the host that broke in the field: 5.1 reads each file off
         # disk with its own encoding rules and we assert the tokenizer stays clean. -EncodedCommand
         # (UTF-16LE base64) so no quoting or codepage of ours can distort the child command.
         #
-        # The allowlist is NOT a way to wave failures through. These four use operators that only
-        # exist in PowerShell 7 (`??` null-coalescing, `? :` ternary) — a deliberate version
-        # dependency, not an encoding fault, and 5.1 rejects them BOM or no BOM. Declaring them by
-        # name is what keeps this assertion sharp: anything else that 5.1 cannot read is new, and
-        # the first suspect is encoding. Shrink this list, never grow it without a reason in the PR.
-        $pwsh7Only = @(
+        # The list below is NOT a way to wave failures through. Every entry carries its reason, and
+        # declaring them by name is what keeps this assertion sharp: anything else 5.1 cannot read
+        # is new, and the first suspect is encoding. Shrink this list, never grow it without a
+        # reason in the PR.
+        $notForWinPs = @(
+            # `??` null-coalescing and `? :` ternary are PowerShell 7 operators. 5.1 rejects them
+            # BOM or no BOM: a deliberate version dependency, not an encoding fault.
             'plugins/agentic-board/scripts/Expert-RoleSynthesis.ps1'
             'plugins/agentic-board/scripts/Expert-Roles.ps1'
             'plugins/agentic-board/scripts/KnowledgeRegistryIo.ps1'
             'plugins/agentic-board/scripts/Resolve-SkillOwner.ps1'
+
+            # Different reason, same conclusion: these two keep a `#!/usr/bin/env pwsh` shebang
+            # instead of a BOM (see the rule above), so 5.1 still reads them as ANSI. They are VHS
+            # demo assets that render the README GIFs, driven by pwsh from a .tape file and never
+            # by 5.1, so the shebang is the more useful of the two declarations.
+            '.github/assets/board-demo.ps1'
+            '.github/assets/board-loop.ps1'
         )
 
         $child = @'
@@ -100,22 +120,23 @@ Set-Location -LiteralPath "__ROOT__"
     }
 '@ -replace '__ROOT__', $script:RepoRoot.Replace('"', '""')
 
-        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($child))
+        $encoded  = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($child))
         $reported = @(& $WinPs -NoProfile -NonInteractive -EncodedCommand $encoded)
+        $names    = @($reported | ForEach-Object { ($_ -split '\|', 3)[0] })
 
-        $unexpected = @($reported | Where-Object { ($_ -split '\|', 3)[0] -notin $pwsh7Only })
+        $unexpected = @($reported | Where-Object { ($_ -split '\|', 3)[0] -notin $notForWinPs })
         if ($unexpected.Count) {
             $shown = $unexpected | ForEach-Object { $p, $l, $m = $_ -split '\|', 3; "$p (line ${l}: $m)" }
             throw ("Windows PowerShell 5.1 cannot read $($unexpected.Count) shipped file(s) that are " +
-                   "not declared pwsh-7-only — suspect encoding first:`n  " + ($shown -join "`n  "))
+                   "not declared otherwise — suspect encoding first:`n  " + ($shown -join "`n  "))
         }
 
-        # Fail closed the other way too: if an allowlisted script gets fixed or deleted, this test
-        # must say so rather than keep carrying a stale exemption.
-        $stale = @($pwsh7Only | Where-Object { $_ -notin @($reported | ForEach-Object { ($_ -split '\|', 3)[0] }) })
+        # Fail closed the other way too: if a declared file gets fixed or deleted, this test must
+        # say so rather than keep carrying a stale exemption.
+        $stale = @($notForWinPs | Where-Object { $_ -notin $names })
         if ($stale.Count) {
-            throw ("These scripts no longer need the pwsh-7-only exemption; remove them from the " +
-                   "allowlist in this test:`n  " + ($stale -join "`n  "))
+            throw ("These files no longer need their Windows PowerShell 5.1 exemption; remove them " +
+                   "from the list in this test:`n  " + ($stale -join "`n  "))
         }
     }
 }

--- a/plugins/agentic-board/tests/Scripts.Parse.Tests.ps1
+++ b/plugins/agentic-board/tests/Scripts.Parse.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Repo-wide syntax check: every plugin script must PARSE (#282).
 
     Motivation, from #274 / PR #280: the string "limite de $PrLimit:" parsed as a scope-qualified

--- a/plugins/agentic-board/tests/Set-BoardField.Tests.ps1
+++ b/plugins/agentic-board/tests/Set-BoardField.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Set-BoardField.ps1 - the reads must FAIL CLOSED (#313, part of #303).
 
     Set-BoardField reads the project id, the field list and the item list up front, then loops

--- a/plugins/agentic-board/tests/Show-ToolsCatalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Show-ToolsCatalog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for Show-ToolsCatalog.ps1 (#386) — the browse + research view over the catalog resolver.
     browse: every tool listed, grouped by domain, each row carrying its URL and installed-state.
     research <id>: surfaces one tool's exact reference (URL + note) before install.

--- a/plugins/agentic-board/tests/SkillAudit-StopHook.Tests.ps1
+++ b/plugins/agentic-board/tests/SkillAudit-StopHook.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for SkillAudit-StopHook.ps1 — passive, suggest-only, never throws. #>
 
 BeforeAll {

--- a/plugins/agentic-board/tests/Suggest-HeavyMemory.Tests.ps1
+++ b/plugins/agentic-board/tests/Suggest-HeavyMemory.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Suggest-HeavyMemory.ps1 - the security-gated heavy-memory escalation.
 
     The script hits PyPI and can install, so it exposes a dot-source guard: with

--- a/plugins/agentic-board/tests/Test-IssueLanguage.Tests.ps1
+++ b/plugins/agentic-board/tests/Test-IssueLanguage.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Tests for scripts/Test-IssueLanguage.ps1 (#305).
 
     A heuristic detector is only worth shipping if its thresholds are pinned, so this asserts BOTH

--- a/plugins/agentic-board/tests/Toolkit-Catalog.Tests.ps1
+++ b/plugins/agentic-board/tests/Toolkit-Catalog.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for the toolkit catalogs (presets/toolkits/*.json) — schema + content. #>
 
 BeforeAll {

--- a/plugins/agentic-board/tests/ToolsCatalog.Integration.Tests.ps1
+++ b/plugins/agentic-board/tests/ToolsCatalog.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Integration coverage for the /tools catalog (#389).
 
     Exercises the resolver + view + installer together against the REAL shipped sources

--- a/plugins/agentic-board/tests/Update-Docs.Tests.ps1
+++ b/plugins/agentic-board/tests/Update-Docs.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Update-Docs.ps1 - README docs generator (#202).
 
     Update-Docs.ps1 is side-effecting (reads command files + plugin.json, rewrites

--- a/plugins/agentic-board/tests/Welcome-SessionStartHook.Tests.ps1
+++ b/plugins/agentic-board/tests/Welcome-SessionStartHook.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Welcome-SessionStartHook.ps1 - the auto-registered first-run banner.
 
     The hook reads stdin and writes a marker file, so it exposes a dot-source guard: with

--- a/plugins/agentic-board/tests/Worktree-Ghosts.Integration.Tests.ps1
+++ b/plugins/agentic-board/tests/Worktree-Ghosts.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Integration tests for Worktree-Ghosts.ps1 against a REAL git repo (#618).
 
     WHY THIS FILE EXISTS, separate from the pure suite. Two bugs shipped past a fully green pure

--- a/plugins/agentic-board/tests/Worktree-Ghosts.Tests.ps1
+++ b/plugins/agentic-board/tests/Worktree-Ghosts.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Worktree-Ghosts.ps1 - the orphan-worktree classifier (#618).
 
     The bug being pinned: the doctor's original check trusted git's `prunable` marker, which

--- a/plugins/agentic-board/tests/Write-KnowledgeTable.Tests.ps1
+++ b/plugins/agentic-board/tests/Write-KnowledgeTable.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Pester
+﻿#Requires -Modules Pester
 <#  Pester tests for Write-KnowledgeTable.ps1. Writes a two-domain registry, regenerates
     the table, and asserts grouping, the generated-header guard, and url link rendering. #>
 BeforeAll {

--- a/scripts/Get-ReleaseNotes.ps1
+++ b/scripts/Get-ReleaseNotes.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Extract one version's notes from a Keep-a-Changelog CHANGELOG (release L1, #322).
 

--- a/scripts/Test-IssueLanguage.ps1
+++ b/scripts/Test-IssueLanguage.ps1
@@ -1,4 +1,4 @@
-<#  Test-IssueLanguage.ps1 — flag issue text that is not in English (#305).
+﻿<#  Test-IssueLanguage.ps1 — flag issue text that is not in English (#305).
 
     This repo is English-only, but `abios-feedback` files its issues from ANY project, usually while
     the conversation with the user is in Spanish. The rule itself lives where the text is drafted

--- a/scripts/guard-no-private.ps1
+++ b/scripts/guard-no-private.ps1
@@ -1,4 +1,4 @@
-<#  guard-no-private.ps1 — block private content / secrets from entering this PUBLIC repo.
+﻿<#  guard-no-private.ps1 — block private content / secrets from entering this PUBLIC repo.
     Wired as a pre-commit and pre-push git hook (see scripts/install-guard.ps1).
     Scans ONLY the ADDED lines of the change against:
       1. built-in secret patterns (tokens, keys, connection strings)

--- a/scripts/install-guard.ps1
+++ b/scripts/install-guard.ps1
@@ -1,5 +1,5 @@
-<#  install-guard.ps1 — wire the private-content guard into THIS clone of the public repo.
-    Run once after cloning:  powershell -File scripts/install-guard.ps1  #>
+﻿<#  install-guard.ps1 — wire the private-content guard into THIS clone of the public repo.
+    Run once after cloning:  pwsh -File scripts/install-guard.ps1  #>
 [CmdletBinding()]
 param()
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## The report

A session on a Spanish Windows could not run `Board-Fill.ps1` at all. It died at parse time:

```
Board-Fill.ps1 (line 370: Token '}' inesperado en la expresión o la instrucción.)
Board-Fill.ps1 (line 508: Token '}' inesperado en la expresión o la instrucción.)
```

The agent that hit it worked around the tool via raw GraphQL and reported it as "a problem reading
it on a Spanish Windows". That was the right instinct and the wrong conclusion about scope: it was
not one file.

## Root cause

The script is fine. The reader is not.

All 185 tracked `.ps1` files were UTF-8 **without a BOM**, and they are full of box-drawing rules
(U+2500 `─`) and em dashes (U+2014 `—`). Both encode to a byte sequence containing `0x94`.

Windows PowerShell 5.1 reads a BOM-less file as the machine's **ANSI codepage**. On cp1252 the byte
`0x94` decodes to `”` RIGHT DOUBLE QUOTATION MARK — which the PowerShell tokenizer accepts as a
**string delimiter**. An odd number of them opens a string that swallows real code, and the next
closing brace lands inside a string literal. Hence the phantom `}`.

**28 shipped files failed to parse this way.** The rest silently printed mojibake.

## Why the suite never caught it

`Scripts.Parse.Tests.ps1` has been parsing every script since #282 and stayed green throughout — it
calls `ParseFile` from **pwsh 7**, which assumes UTF-8 for a BOM-less file. Same parse, different
host, and the host is the whole bug.

Worse, `README.md`, `CONTRIBUTING.md`, `install-guard.ps1` and the `projects-admin` board-ops
reference all told contributors to launch scripts with `powershell -File` — the exact interpreter
that breaks.

## The fix

- **UTF-8 BOM on all 185 tracked PowerShell files.** A BOM makes the file self-describing: 5.1 and
  7.x both read it as UTF-8, on any codepage. The diff is three bytes per file — `git diff --numstat`
  shows exactly `1 1` for every one of them, no content drift.
- **`ScriptEncoding.Tests.ps1`, an encoding ratchet.** Asserts every git-tracked PowerShell file
  starts with a BOM, then proves it end-to-end by having **Windows PowerShell 5.1 itself** parse all
  of them. CI runs Pester on `windows-latest`, so 5.1 is present and the check is not vacuous. It
  fails closed on a broken glob.
- **Four scripts are declared pwsh-7-only by name** (`Expert-Roles.ps1`, `Expert-RoleSynthesis.ps1`,
  `KnowledgeRegistryIo.ps1`, `Resolve-SkillOwner.ps1`). They use `??` and `? :`, which 5.1 rejects
  BOM or no BOM — a deliberate version dependency, not an encoding fault. The test also fails if that
  exemption ever goes **stale**, so the list can only shrink quietly.
- **Docs now say `pwsh -File`**, which the rest of the repo and CI already target.

## Verification

- Full Pester suite: **2402 passed, 0 failed**.
- Ratchet verified by reintroducing the bug: stripping the BOM from `Board-Fill.ps1` turns both
  assertions red with the original field message, `line 370: Token '}' inesperado`. Restored from a
  saved copy, green again.
- Second commit fixes a real self-exclusion: the new test was untracked when the sweep ran, so the
  one file asserting "every shipped script carries a BOM" shipped without one. It would have turned
  CI red on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)