### PR TITLE
fix: never report a field the preset failed to create (#649)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`Apply-FieldPreset` no longer reports a field it failed to create (#649).** It called
+  `gh project field-create` raw and never read the exit code, so `created: <name>` printed
+  whether GitHub created the field or refused it. GitHub now reserves the field name `Type`
+  (verified directly: `Type` is rejected with *Name cannot have a reserved value*, `Task Type`
+  is accepted), so this fired on **every fresh English board** — the run read clean and the board
+  came out missing the field, which is why the same defect was reported four separate times
+  (#649, #654, #658, #667). Both `field-create` calls now go through `Invoke-Gh`, which fails on
+  a non-zero exit; a refusal prints `FAILED: <field> — <reason>` instead, the remaining fields are
+  still attempted, and the run ends in a hard error naming what was not created. That last part
+  also fixes the lie one level up for free: `Resolve-Board` applies the preset at board birth
+  inside a try/catch, so it now warns instead of printing "preset applied" over a half-built board.
+- **Raw-`gh` baseline for `Apply-FieldPreset.ps1` lowered from 6 to 4**, locking in the migration
+  so the two checked calls cannot silently revert to unchecked ones.
+
+
 ## [0.38.1] - 2026-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - **Raw-`gh` baseline for `Apply-FieldPreset.ps1` lowered from 6 to 4**, locking in the migration
   so the two checked calls cannot silently revert to unchecked ones.
 
-
 ## [0.38.1] - 2026-08-31
 
 ### Fixed

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -343,6 +343,13 @@ if ($DryRun -or ($Migrate -and ($renames.Count -gt 0 -or $merges.Count -gt 0))) 
 if ($DryRun) {
   Write-Host "DRY-RUN: no se ejecuto ningun cambio." -ForegroundColor Cyan
   Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan
+
+# A half-applied preset must never read as a clean run. Last, so the report above is complete
+# and every field that COULD be created has been.
+if ($failedFields.Count -gt 0) {
+  Write-Error ("{0} campo(s) del preset NO se crearon: {1}. El board quedo incompleto — mira las lineas FAILED de arriba." -f `
+               $failedFields.Count, ($failedFields -join ', '))
+}
   exit 0
 }
 
@@ -361,19 +368,43 @@ if ($Migrate -and ($willRename -or $willMerge) -and -not $Yes) {
 }
 
 # ── Apply ─────────────────────────────────────────────────────────────────────
+$failedFields = @()
 foreach ($f in $preset.fields) {
   if ($existing -contains $f.name) {
     Write-Host "skip (exists): $($f.name)"
   } else {
-    if ($f.type -eq 'SINGLE_SELECT') {
-      $optNames = @($f.options | ForEach-Object { Get-OptName $_ })
-      gh project field-create $Number --owner $Owner --name $f.name `
-        --data-type SINGLE_SELECT --single-select-options ($optNames -join ',') | Out-Null
+    # Through Invoke-Gh, not bare gh. `field-create` signals a refusal ONLY through its exit
+    # code, and the unchecked call printed `created:` for a field GitHub had rejected — the
+    # run read clean while the board came out missing the field. That is the defect reported
+    # four separate times (#649, #654, #658, #667): GitHub now reserves the field name "Type",
+    # so it fires on every fresh English board.
+    #
+    # Caught PER FIELD rather than left to propagate: one refused name must not strand the
+    # fields after it. The run still ends in a hard error below, so a caller cannot mistake a
+    # half-applied preset for a clean one — Resolve-Board already warns instead of claiming
+    # success when this throws.
+    $createArgs = if ($f.type -eq 'SINGLE_SELECT') {
+      @('project','field-create',"$Number",'--owner',$Owner,'--name',$f.name,
+        '--data-type','SINGLE_SELECT','--single-select-options',
+        (@($f.options | ForEach-Object { Get-OptName $_ }) -join ','))
     } else {
-      gh project field-create $Number --owner $Owner --name $f.name --data-type $f.type | Out-Null
+      @('project','field-create',"$Number",'--owner',$Owner,'--name',$f.name,'--data-type',$f.type)
     }
-    $script:FieldCache.Remove($f.name) | Out-Null   # it exists now — re-read its live options
-    Write-Host "created: $($f.name) ($($f.type))"
+
+    try {
+      $null = Invoke-Gh -GhArgs $createArgs -What "crear el campo '$($f.name)' en el board #$Number"
+      $script:FieldCache.Remove($f.name) | Out-Null   # it exists now — re-read its live options
+      Write-Host "created: $($f.name) ($($f.type))"
+    } catch {
+      $reason = ($_.Exception.Message -replace '\s+', ' ').Trim()
+      Write-Host "FAILED: $($f.name) ($($f.type)) — $reason" -ForegroundColor Red
+      if ($reason -match 'reserved value') {
+        Write-Host ("        GitHub reserva ese nombre de campo, asi que NINGUN reintento lo va a crear. " +
+                    "Renombralo en el preset ($PresetPath) y vuelve a correr.") -ForegroundColor DarkYellow
+      }
+      $failedFields += $f.name
+      continue   # no colors for a field that does not exist
+    }
   }
 
   # Apply canonical colors when the preset provides any (idempotent; also upgrades
@@ -410,3 +441,10 @@ if (-not $Migrate) {
   Write-Host "(Corre sin -NoMigrate para renombrar las opciones legacy -> canonicas y estandarizar el board.)" -ForegroundColor DarkGray
 }
 Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan
+
+# A half-applied preset must never read as a clean run. Last, so the report above is complete
+# and every field that COULD be created has been.
+if ($failedFields.Count -gt 0) {
+  Write-Error ("{0} campo(s) del preset NO se crearon: {1}. El board quedo incompleto — mira las lineas FAILED de arriba." -f `
+               $failedFields.Count, ($failedFields -join ', '))
+}

--- a/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
+++ b/plugins/agentic-board/scripts/Apply-FieldPreset.ps1
@@ -344,12 +344,6 @@ if ($DryRun) {
   Write-Host "DRY-RUN: no se ejecuto ningun cambio." -ForegroundColor Cyan
   Write-Host "Board: https://github.com/users/$Owner/projects/$Number" -ForegroundColor Cyan
 
-# A half-applied preset must never read as a clean run. Last, so the report above is complete
-# and every field that COULD be created has been.
-if ($failedFields.Count -gt 0) {
-  Write-Error ("{0} campo(s) del preset NO se crearon: {1}. El board quedo incompleto — mira las lineas FAILED de arriba." -f `
-               $failedFields.Count, ($failedFields -join ', '))
-}
   exit 0
 }
 

--- a/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
+++ b/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
@@ -42,3 +42,81 @@ Describe 'Apply-FieldPreset invocation ergonomics (#297)' {
             Should -Throw -ExpectedMessage "*Preset file not found: $missing*"
     }
 }
+
+Describe 'Apply-FieldPreset never reports a field it failed to create (#649)' {
+
+    # The lie this pins: `gh project field-create` was called RAW and its exit code was never
+    # read, so `created: <name>` printed whether the field was created or refused. GitHub now
+    # rejects a custom field named "Type" ("Name cannot have a reserved value"), which makes it
+    # fire on every fresh English board - reported four separate times (#649, #654, #658, #667)
+    # because the run reads clean. `gh` is mocked at the executable seam: the field-list read
+    # succeeds and returns an empty board, every field-create fails.
+
+    BeforeAll {
+        $script:Script = Join-Path $PSScriptRoot '..' 'scripts' 'Apply-FieldPreset.ps1' | Resolve-Path
+
+        # All streams to a FILE, and the terminating error swallowed. The run is SUPPOSED to end
+        # in an error now, and `... | Out-String` inside a throwing pipeline never assigns - which
+        # would fail these tests on the very behaviour they exist to prove. A file is written as
+        # the run goes, so everything printed before the error survives it.
+        function script:Get-RunOutput {
+            param([string]$LogDir)
+            $log = Join-Path $LogDir ([guid]::NewGuid().ToString('N') + '.log')
+            try { & $script:Script -Number 13 -Owner 'X' -Lang en -Yes *> $log } catch { }
+            if (Test-Path $log) { return (Get-Content $log -Raw) }
+            return ''
+        }
+    }
+
+    BeforeEach {
+        Mock gh {
+            if ($args -contains 'field-list')   { $global:LASTEXITCODE = 0; return '{"fields":[]}' }
+            # The colour pass reads each single-select field back. On an empty board the honest
+            # answer is "no such field yet" - a graphql body with a null field and NO errors[],
+            # which Invoke-Gh accepts (absent) rather than rejecting (failed).
+            if ($args -contains 'graphql') {
+                $global:LASTEXITCODE = 0
+                return '{"data":{"user":{"projectV2":{"field":null}}}}'
+            }
+            if ($args -contains 'field-create') {
+                $global:LASTEXITCODE = 1
+                # -ErrorAction Continue on purpose: the script runs under
+                # $ErrorActionPreference='Stop', where a plain Write-Error in the mock would
+                # TERMINATE the run and make these tests fail for the wrong reason - the script
+                # would never reach the reporting code under test. A real native gh does not
+                # throw either; it writes to stderr and exits non-zero.
+                Write-Error -ErrorAction Continue 'GraphQL: Name cannot have a reserved value, Name has already been taken (createProjectV2Field)'
+                return
+            }
+            $global:LASTEXITCODE = 0
+        }
+    }
+
+    It 'does NOT print "created:" for a field the API refused' {
+        script:Get-RunOutput -LogDir $TestDrive | Should -Not -Match 'created:\s*Type'
+    }
+
+    It 'prints a FAILED line naming the field and the reason' {
+        $out = script:Get-RunOutput -LogDir $TestDrive
+        $out | Should -Match 'FAILED:\s*Type'
+        $out | Should -Match 'reserved value'
+    }
+
+    It 'ENDS IN A HARD ERROR naming the fields that were not created' {
+        # NOT an assertion on $LASTEXITCODE: the mocked gh sets it itself, so that check passed
+        # even against the unfixed script - green for a reason that had nothing to do with the
+        # behaviour. The terminating error is the real contract, and it is what makes
+        # Resolve-Board warn instead of printing "preset applied" over a half-built board.
+        { & $script:Script -Number 13 -Owner 'X' -Lang en -Yes *> (Join-Path $TestDrive 'throw.log') } |
+            Should -Throw -ExpectedMessage '*NO se crearon*Type*'
+    }
+
+    It 'still attempts the REMAINING fields instead of aborting on the first refusal' {
+        # Honest reporting must not cost coverage: one rejected name must not strand the fields
+        # after it. Target is the last field of the English preset.
+        script:Get-RunOutput -LogDir $TestDrive | Out-Null
+        Should -Invoke gh -ParameterFilter {
+            ($args -contains 'field-create') -and ($args -contains 'Target')
+        } -Times 1
+    }
+}

--- a/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
+++ b/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
@@ -111,6 +111,38 @@ Describe 'Apply-FieldPreset never reports a field it failed to create (#649)' {
             Should -Throw -ExpectedMessage '*NO se crearon*Type*'
     }
 
+    It 'never reads $failedFields before the line that declares it (review of #672)' {
+        # The first cut of this fix pasted the end-of-run failure report into the -DryRun branch
+        # as well, ABOVE the `$failedFields = @()` that feeds it. Today that is only dead code -
+        # $null.Count is not an error without Set-StrictMode - so a behavioural test passes with
+        # the defect in place and proves nothing. The defect is STRUCTURAL, so the assertion is
+        # too: walk the AST and require every read of the variable to come after its assignment.
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                   $script:Script, [ref]$null, [ref]$null)
+
+        $vars = $ast.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $n.VariablePath.UserPath -eq 'failedFields' }, $true)
+
+        $assign = $ast.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $n.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $n.Left.VariablePath.UserPath -eq 'failedFields' }, $true) |
+            Sort-Object { $_.Extent.StartLineNumber } | Select-Object -First 1
+
+        $assign | Should -Not -BeNullOrEmpty -Because 'the accumulator must be declared somewhere'
+
+        $tooEarly = @($vars | Where-Object { $_.Extent.StartLineNumber -lt $assign.Extent.StartLineNumber } |
+                              ForEach-Object { "line $($_.Extent.StartLineNumber)" })
+        $tooEarly -join ', ' | Should -BeNullOrEmpty
+    }
+
+    It '-DryRun still creates nothing' {
+        { & $script:Script -Number 13 -Owner 'X' -Lang en -DryRun *> (Join-Path $TestDrive 'dry.log') } |
+            Should -Not -Throw
+        Should -Invoke gh -ParameterFilter { $args -contains 'field-create' } -Times 0 -Exactly
+    }
+
     It 'still attempts the REMAINING fields instead of aborting on the first refusal' {
         # Honest reporting must not cost coverage: one rejected name must not strand the fields
         # after it. Target is the last field of the English preset.

--- a/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
+++ b/plugins/agentic-board/tests/Apply-FieldPreset.Tests.ps1
@@ -145,10 +145,16 @@ Describe 'Apply-FieldPreset never reports a field it failed to create (#649)' {
 
     It 'still attempts the REMAINING fields instead of aborting on the first refusal' {
         # Honest reporting must not cost coverage: one rejected name must not strand the fields
-        # after it. Target is the last field of the English preset.
+        # after it. The last field is READ FROM THE PRESET rather than spelled here - hardcoding
+        # "Target" would quietly stop testing anything the day someone reorders fields.en.json,
+        # and the test would keep passing while proving nothing (review of #672).
+        $presetPath = Join-Path $PSScriptRoot '..' 'presets' 'fields.en.json' | Resolve-Path
+        $lastField  = (Get-Content $presetPath -Raw -Encoding UTF8 | ConvertFrom-Json).fields[-1].name
+        $lastField | Should -Not -BeNullOrEmpty -Because 'the preset must have fields to test with'
+
         script:Get-RunOutput -LogDir $TestDrive | Out-Null
         Should -Invoke gh -ParameterFilter {
-            ($args -contains 'field-create') -and ($args -contains 'Target')
+            ($args -contains 'field-create') -and ($args -contains $lastField)
         } -Times 1
     }
 }

--- a/plugins/agentic-board/tests/RawGh.Lint.Tests.ps1
+++ b/plugins/agentic-board/tests/RawGh.Lint.Tests.ps1
@@ -27,7 +27,7 @@ BeforeAll {
     # in #571). A file not listed here has ZERO tolerated raw calls.
     $script:Baseline = @{
         'Board-Work.ps1'            = 8
-        'Apply-FieldPreset.ps1'     = 6
+        'Apply-FieldPreset.ps1'     = 4   # 6 -> 4: both field-create calls now go through Invoke-Gh (#649)
         'Board-Plan.ps1'            = 6
         'Board-ReviewGate.ps1'      = 5
         'Board-Merge.ps1'           = 5


### PR DESCRIPTION
Closes #649. Duplicates #654, #658 and #667 closed against it.

## The defect

`Apply-FieldPreset.ps1` called `gh project field-create` raw and never read the exit code:

```powershell
gh project field-create $Number --owner $Owner --name $f.name ... | Out-Null
$script:FieldCache.Remove($f.name) | Out-Null
Write-Host "created: $($f.name) ($($f.type))"     # <- prints either way
```

`gh` signals failure only through its exit code and does not throw, so the success line printed whether GitHub created the field or refused it. The board came out missing the field while the run read clean — which is why the run in #667 looks like this, with the error and the success line referring to **the same field**:

```
created: Size (SINGLE_SELECT)
GraphQL: Name cannot have a reserved value, Name has already been taken (createProjectV2Field)
created: Type (SINGLE_SELECT)
created: Area (TEXT)
```

## Measured, not assumed

GitHub now reserves the field name `Type`. Checked directly against a throwaway board (created and deleted for the check) rather than taken from the reports:

| `--name` | result |
|---|---|
| `Type` | rejected — *Name cannot have a reserved value, Name has already been taken* |
| `Task Type` | created, and present in `field-list` afterwards |

So it fires on **every fresh English board**. That is why the same defect was filed four separate times over eleven days — each session saw a clean run and reported it as new. `presets/fields.es.json` is unaffected: it uses `Tipo`.

## The fix

Both `field-create` calls now go through `Invoke-Gh`, the wrapper that exists precisely because bare `gh` turns a failure into a non-event (#303). On a refusal the run prints `FAILED: <field> — <reason>`, adds a line saying a reserved name will never be created by retrying, **still attempts the remaining fields**, and ends in a terminating error naming everything that was not created.

That last part fixes the same lie one level up **for free**: `Resolve-Board.ps1` applies the preset at board birth inside a `try/catch` and printed *"preset applied — board born on the canonical vocabulary"* unconditionally. Now the throw reaches its `catch`, which already warns and tells the user to apply the preset by hand. No change needed in that file.

Raw-`gh` lint baseline for this file lowered **6 → 4**, so the two checked calls cannot quietly revert to unchecked ones.

## Scope — what this deliberately does NOT do

The English preset still ships the refused name. Renaming it is not a one-liner: `Type` is written by hand in five other places (`Board-Fill`, `Board-Triage` ×4, `Board-Changelog`, `Fleet-Plan`), so a rename without them produces a board the rest of the tool cannot read — and boards created *before* the reservation still have a working `Type` that must not gain a second field beside it. Filed as #671 with the measurements and three options.

## Verification

- Full suite: **2406 passed, 0 failed**.
- The four new tests were written **before** the fix and checked against the **original bytes** of the buggy script (restored with `git show`, not retyped — a first attempt that rewrote the file through an encoding conversion produced a fake red, with unrelated tests failing and one passing vacuously). Three of the four go red on the real buggy code.
- The fourth passes either way **on purpose**: it guards the regression this fix could have introduced — aborting the loop on the first refusal and stranding the fields after it. Its comment says that, rather than presenting it as coverage of the bug.

## A note on the duplicates

Four issues for one defect is a signal in itself: the feedback flow files a new issue without checking whether the same one is already open, so every session that trips over a bug adds a copy and the unique reports get buried. Noted in each closing comment; not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)