### PR TITLE
fix: three places the tool reported success it had not verified (#659, #657, #656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@
   still attempted, and the run ends in a hard error naming what was not created. That last part
   also fixes the lie one level up for free: `Resolve-Board` applies the preset at board birth
   inside a try/catch, so it now warns instead of printing "preset applied" over a half-built board.
+- **The review gate no longer passes CI it never saw (#657).** `gh pr checks` prints *"no checks
+  reported"* for two different states — a repo with no CI, and a repo whose workflow runs for a
+  brand-new head are not registered yet — and the gate read both as the first. Observed live: a
+  PR of this repo passed CI seconds after a push, on a branch whose CI had run green on the two
+  previous commits. It now needs two signals before believing an empty answer: the repo has no
+  active workflows (nothing to wait for), or the empty answer has PERSISTED past a grace period,
+  which an unregistered run cannot do. The workflow read fails CLOSED — an unreadable answer counts
+  as "there is CI", never as a shortcut.
+- **A Copilot that reviews AND refuses is no longer silenced for a week (#656).** The per-account
+  cooldown was armed from `Test-CopilotUnavailableReview`, which answers *"is there a refusal
+  anywhere in this array"*. A re-requested Copilot can answer twice on the same head — one real
+  review, one refusal — so the marker armed and the bot was skipped for `-CopilotCooldownDays` on a
+  PR it had just reviewed properly. Arming now asks the narrower `Test-CopilotOnlyRefused`: a
+  refusal with no substantive review beside it, on the current head. The broad predicate keeps its
+  own job, subtracting refusals from the review evidence per review.
+
+- **`Board-Fill` writes the assignee to the item's OWN repo, and verifies it stuck (#659).** `-Auto`
+  reported `OK #<n> assignee -> <login>` for every item and assigned nobody. Both causes the report
+  guessed were wrong — the write already went to the issue endpoint and already went through
+  `Invoke-Gh` — and running the same `gh` call by hand assigns fine. The fault was the ADDRESS: a
+  board is not a repo, its items can come from several, and `-Repo` is one script-level value
+  defaulting to the tool's own repo, so the write went to `repos/<default>/issues/<same number>` —
+  a URL GitHub answers 200 for whenever that number exists there. The assignment landed on an
+  unrelated issue in an unrelated repo while the intended one stayed empty. The board query never
+  asked which repo an item belongs to, so the information to address it correctly was not even
+  fetched. It is now asked for, used, and the result is READ BACK before counting OK, because a 200
+  is not proof: GitHub silently drops an assignee it cannot assign on that repo and still answers 200.
+
 - **Raw-`gh` baseline for `Apply-FieldPreset.ps1` lowered from 6 to 4**, locking in the migration
   so the two checked calls cannot silently revert to unchecked ones.
 

--- a/plugins/agentic-board/scripts/Board-Fill.ps1
+++ b/plugins/agentic-board/scripts/Board-Fill.ps1
@@ -201,6 +201,7 @@ query(`$proj:ID!, `$cursor:String) {
             ... on DraftIssue { title }
             ... on Issue {
               number title state
+              repository { nameWithOwner }
               labels(first:10) { nodes { name } }
               assignees(first:5) { nodes { login } }
               timelineItems(first:20 itemTypes:[CROSS_REFERENCED_EVENT]) {
@@ -263,6 +264,20 @@ mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!) {
 
 # Dot-source guard: tests set this to load the functions above without running
 # the token check or any gh call (same contract as Board-Work.ps1).
+# Which repo does THIS item's issue live in? A board is not a repo: its items can come from
+# several, and -Repo is one script-level value that DEFAULTS to the tool's own repo. Building a
+# write URL from that default sends the request to `<default>/issues/<same number>` - which, if
+# that number exists there, GitHub answers 200 for. The write then lands on an unrelated issue in
+# an unrelated repo, the intended one stays untouched, and the run still reports OK (#659).
+#
+# The fallback is only for an item the query could not resolve; it is never the preferred answer.
+function Get-IssueRepo {
+    param($Content, [string]$FallbackRepo)
+    $r = $Content.repository.nameWithOwner
+    if ($r) { return $r }
+    return $FallbackRepo
+}
+
 if ($env:ABIOS_BOARDFILL_DOTSOURCE) { return }
 
 # ── Top-level error boundary (#485): any unhandled exception becomes a clean
@@ -446,6 +461,7 @@ foreach ($item in $items) {
             IssueNum = $c.number
             Title    = $c.title
             State    = $c.state
+            Repo     = Get-IssueRepo -Content $c -FallbackRepo $Repo
             Changes  = $changes
         }
     }
@@ -492,12 +508,27 @@ foreach ($entry in $plan) {
     foreach ($ch in $entry.Changes) {
         try {
             if ($ch.Type -eq "assignee") {
-                # An unchecked write reports "OK" for an assignment that never happened. Invoke-Gh
-                # throws on a non-zero exit (caught below -> FAIL, $fail++) so the count is honest.
-                $assignUrl = "repos/$Repo/issues/$($entry.IssueNum)/assignees"
+                # $entry.Repo, NOT $Repo. The script-level value is ONE repo and defaults to the
+                # tool's own; every item on a board that lives elsewhere was being written to
+                # `<default>/issues/<same number>`, which GitHub answers 200 for whenever that
+                # number happens to exist there. The assignment landed on an unrelated issue and
+                # the intended one stayed empty - reported as OK either way (#659).
+                $assignUrl = "repos/$($entry.Repo)/issues/$($entry.IssueNum)/assignees"
                 $null = Invoke-Gh -GhArgs @('api',$assignUrl,'-X','POST','-F',"assignees[]=$Owner") `
-                                  -What "asignar #$($entry.IssueNum) a $Owner"
-                Write-Host "  OK  #$($entry.IssueNum) assignee -> $Owner" -ForegroundColor Green
+                                  -What "asignar #$($entry.IssueNum) a $Owner en $($entry.Repo)"
+
+                # Read it back. A 200 is not proof: GitHub SILENTLY DROPS an assignee who cannot
+                # be assigned on that repo (not a collaborator) and still answers 200 with the
+                # issue unchanged. This command exists so nobody has to check the board by hand,
+                # so a false OK here is worse than a loud failure - the board looks governed and
+                # is not.
+                $after = Invoke-Gh -GhArgs @('api',"repos/$($entry.Repo)/issues/$($entry.IssueNum)",'--jq','[.assignees[].login]') `
+                                   -What "verificar la asignacion de #$($entry.IssueNum)" -Json
+                if (@($after) -notcontains $Owner) {
+                    throw "la API acepto la asignacion pero #$($entry.IssueNum) sigue sin $Owner en $($entry.Repo) (GitHub descarta en silencio a quien no puede asignar en ese repo)"
+                }
+
+                Write-Host "  OK  #$($entry.IssueNum) assignee -> $Owner  ($($entry.Repo))" -ForegroundColor Green
                 $ok++
             }
             elseif ($ch.Type -eq "single") {

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -557,7 +557,10 @@ function Test-CopilotSilentTimeout {
 function Test-RepoHasActiveWorkflows {
     param([string]$Repo)
     try {
-        $resp = Invoke-Gh -GhArgs @('api',"repos/$Repo/actions/workflows") `
+        # per_page=100: the endpoint defaults to 30, and a repo whose active workflows fall on a
+        # later page would answer "no active workflows" - a FALSE benign pass, i.e. exactly the
+        # hole this function exists to close, reopened by pagination (review of #673).
+        $resp = Invoke-Gh -GhArgs @('api',"repos/$Repo/actions/workflows?per_page=100") `
                           -What "leer los workflows de $Repo" -Json
         return (@($resp.workflows | Where-Object { $_.state -eq 'active' }).Count -gt 0)
     } catch {
@@ -919,6 +922,10 @@ while ($true) {
     $parsedList = @(); $parsedOk = $false
     if ($checksJson) {
         try { $parsedList = @($checksJson | ConvertFrom-Json); $parsedOk = $true } catch { }
+        # Checks came back, so any earlier "no checks" stretch is over. Without this reset a
+        # later empty answer would inherit a stale stamp and be believed immediately
+        # (review of #673) - rare with gh today, but it is the wrong way to be wrong.
+        $script:NoChecksSince = $null
     } else {
         # Empty stdout is either "no checks configured" (benign) or a transient read failure.
         # Probe the human-readable form to tell them apart: only the explicit "no checks" text

--- a/plugins/agentic-board/scripts/Board-ReviewGate.ps1
+++ b/plugins/agentic-board/scripts/Board-ReviewGate.ps1
@@ -550,6 +550,31 @@ function Test-CopilotSilentTimeout {
 # load the tests use. The file is pure at load - it defines functions and touches nothing.
 . (Join-Path $PSScriptRoot 'CopilotAvailability.ps1')
 
+# Does this repo have any workflow that could produce a check? Read once per run and cached by
+# the caller. Fails CLOSED on a read error: reporting "no workflows" from a failed read would
+# hand back the very shortcut this exists to remove, so an unreadable answer is treated as "yes,
+# there is CI" and the empty check list has to survive the grace period like any other.
+function Test-RepoHasActiveWorkflows {
+    param([string]$Repo)
+    try {
+        $resp = Invoke-Gh -GhArgs @('api',"repos/$Repo/actions/workflows") `
+                          -What "leer los workflows de $Repo" -Json
+        return (@($resp.workflows | Where-Object { $_.state -eq 'active' }).Count -gt 0)
+    } catch {
+        return $true
+    }
+}
+
+function Test-NoChecksIsBenign {
+    param(
+        [bool]  $RepoHasActiveWorkflows,
+        [double]$SecondsSinceFirstSeen,
+        [int]   $GraceSeconds = 90
+    )
+    if (-not $RepoHasActiveWorkflows) { return $true }
+    return ($SecondsSinceFirstSeen -ge $GraceSeconds)
+}
+
 # Dot-source guard: tests set $env:ABIOS_REVIEWGATE_DOTSOURCE to load the pure helper only.
 if ($env:ABIOS_REVIEWGATE_DOTSOURCE) { return }
 
@@ -606,6 +631,19 @@ if ($InstallRuleset) {
 
 if ($PR -le 0) { throw "Usa -PR <numero> (o -InstallRuleset)." }
 
+# Is an empty `gh pr checks` really "this repo has no CI"?
+#
+# `gh pr checks` prints "no checks reported on the ... branch" for TWO different states: a repo
+# with no CI at all, and a repo whose workflow runs for the new head have not been REGISTERED yet.
+# The gate read both as the first and passed CI unchecked seconds after a push - observed live on
+# PR #655 of this repo, whose CI had run green on the two previous commits of the same branch
+# (#657). A gate that answers "pass" about a commit no check ever saw is the #510 hole again.
+#
+# Two signals, and both are needed. Active workflows alone would block for the full CI timeout on
+# a repo whose workflows are cron- or release-only and legitimately never run on a PR. A grace
+# period alone would still pass unchecked on a slow registration. So: no active workflows means
+# there is genuinely nothing to wait for; otherwise the empty answer has to PERSIST before it is
+# believed, which an unregistered run cannot do - it shows up within seconds.
 # ── Record an external review so the gate can see it (#510) ───────────────────
 # A reviewer without a GitHub identity (second-opinion / Codex, or a careful human read) leaves no
 # review object, so to the gate it was indistinguishable from nobody looking. This writes the
@@ -886,7 +924,18 @@ while ($true) {
         # Probe the human-readable form to tell them apart: only the explicit "no checks" text
         # counts as benign; anything else stays unparsed and fails closed at the deadline.
         $probe = (gh pr checks $PR --repo $Repo 2>&1 | Out-String)
-        if ($probe -match '(?i)no checks') { $parsedList = @(); $parsedOk = $true }
+        if ($probe -match '(?i)no checks') {
+            # ...and even then, not on sight. "no checks" also means "the runs for this head are
+            # not registered yet", which is what let a fresh push pass CI unchecked (#657).
+            if (-not $script:NoChecksSince) { $script:NoChecksSince = Get-Date }
+            if ($null -eq $script:RepoHasWorkflows) { $script:RepoHasWorkflows = Test-RepoHasActiveWorkflows -Repo $Repo }
+            $waited = ((Get-Date) - $script:NoChecksSince).TotalSeconds
+            if (Test-NoChecksIsBenign -RepoHasActiveWorkflows $script:RepoHasWorkflows -SecondsSinceFirstSeen $waited) {
+                $parsedList = @(); $parsedOk = $true
+            }
+        } else {
+            $script:NoChecksSince = $null
+        }
     }
     $verdictCi = Get-ChecksVerdict -Checks $parsedList -Parsed $parsedOk
 
@@ -944,7 +993,11 @@ $decision   = $prState.reviewDecision
 # If Copilot answered that it could NOT review (no quota), remember it per account so the NEXT PR skips
 # the request + the wait entirely (#367). Only when we actually requested it this run — a skipped run
 # has nothing new to learn. Best-effort: a marker write failure never affects the gate verdict.
-if ($copilotRequested -and (Test-CopilotUnavailableReview -Reviews $reviews -HeadSha "$($prState.headRefOid)")) {
+# Test-CopilotOnlyRefused, NOT Test-CopilotUnavailableReview: the latter is true if ANY entry is a
+# refusal, so a Copilot that answered twice on the same head - a real review AND a refusal from a
+# re-request - armed the cooldown and was skipped for days despite having just reviewed the code
+# (#656). Arming needs the narrower question: did it ONLY refuse?
+if ($copilotRequested -and (Test-CopilotOnlyRefused -Reviews $reviews -HeadSha "$($prState.headRefOid)")) {
     $cooldownDays = [Math]::Max(1, $CopilotCooldownDays)
     if (Set-CopilotUnavailable -Owner $copilotOwner -Until (Get-Date).AddDays($cooldownDays) -Reason 'Copilot answered: unable to review (quota/limit)') {
         Write-Host ("  Copilot sin disponibilidad detectada - marcado NO disponible para {0} por {1} dia(s); no lo volvere a solicitar/esperar hasta entonces (#367)." -f $copilotOwner, $cooldownDays) -ForegroundColor DarkYellow

--- a/plugins/agentic-board/scripts/CopilotAvailability.ps1
+++ b/plugins/agentic-board/scripts/CopilotAvailability.ps1
@@ -76,6 +76,33 @@ function Test-CopilotRefusalBody {
 # bound to THAT commit counts (#563): a stale refusal from an earlier commit is not an answer to the
 # current request, and letting it renew the full cooldown suppressed the 1-day silence path the gate
 # uses for a request that got no answer at all. Without -HeadSha the old any-refusal behavior holds. Pure.
+# Did Copilot ONLY refuse? The cooldown must not be armed off the presence of a refusal alone.
+# Test-CopilotUnavailableReview answers "is there a refusal in this array", which is the right
+# question for subtracting a non-review from the evidence, and the WRONG one for arming a
+# multi-day cooldown: a re-requested Copilot can answer twice on the same head, once with a real
+# review and once with a refusal. Asked about the whole array, the old call saw the refusal and
+# silenced Copilot for a week on a PR it had just reviewed properly (#656).
+#
+# So: among Copilot's reviews OF THIS HEAD, arm only when there is a refusal and no substantive
+# review beside it. Same login/body recognition as its sibling - never a body match on humans.
+function Test-CopilotOnlyRefused {
+    param(
+        [object[]]$Reviews,
+        [string]$HeadSha = ''
+    )
+    $head = "$HeadSha".Trim()
+    $refused = $false
+    $substantive = $false
+    foreach ($r in @($Reviews)) {
+        $login = "$($r.author.login)"
+        if ($login -notmatch $script:CopilotReviewerLoginPattern) { continue }
+        if ($head -and "$($r.commit.oid)".Trim() -ne $head) { continue }
+        if (Test-CopilotRefusalBody -Body "$($r.body)") { $refused = $true }
+        else                                             { $substantive = $true }
+    }
+    return ($refused -and -not $substantive)
+}
+
 function Test-CopilotUnavailableReview {
     param(
         [object[]]$Reviews,

--- a/plugins/agentic-board/tests/Board-Fill.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-Fill.Tests.ps1
@@ -175,3 +175,50 @@ Describe 'Resolve-Opt (canonical option with legacy fallback, issue #278)' {
         Resolve-Opt $null 'Size' 'M' | Should -BeNullOrEmpty
     }
 }
+
+Describe 'Board-Fill writes the assignee to the item OWN repo (#659)' {
+
+    # The reported symptom was "reports OK assignee for every item and assigns nobody". The two
+    # causes the report guessed were both wrong - the write already went to the ISSUE endpoint and
+    # already went through Invoke-Gh, and the exact gh call works when run by hand. The real cause
+    # is the ADDRESS: a board is not a repo, its items can come from several, and -Repo is one
+    # script-level value defaulting to the tool's own repo. `repos/<default>/issues/<same number>`
+    # is a URL GitHub answers 200 for whenever that number exists there - so the assignment landed
+    # on an unrelated issue in an unrelated repo while the intended one stayed empty.
+
+    It 'asks the board which repo each issue belongs to' {
+        # Structural: without this field on the query there is nothing to address the write with,
+        # and every behavioural test would be asserting against the fallback.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'repository\s*\{\s*nameWithOwner\s*\}'
+    }
+
+    It 'prefers the issue OWN repo over the script-level fallback' {
+        $content = [pscustomobject]@{ repository = [pscustomobject]@{ nameWithOwner = 'someone/other-repo' } }
+        Get-IssueRepo -Content $content -FallbackRepo 'CSalcedoDataBI/agentic-board' |
+            Should -Be 'someone/other-repo'
+    }
+
+    It 'falls back only when the item carries no repo of its own' {
+        # A fallback is for an unresolvable item, never the preferred answer.
+        Get-IssueRepo -Content ([pscustomobject]@{}) -FallbackRepo 'owner/fallback' |
+            Should -Be 'owner/fallback'
+        Get-IssueRepo -Content ([pscustomobject]@{ repository = $null }) -FallbackRepo 'owner/fallback' |
+            Should -Be 'owner/fallback'
+    }
+
+    It 'builds the write URL from the entry repo, not from $Repo' {
+        # Pins the address itself: this is the line that sent every write to the default repo.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'repos/\$\(\$entry\.Repo\)/issues/'
+        $src | Should -Not -Match 'repos/\$Repo/issues/\$\(\$entry\.IssueNum\)/assignees'
+    }
+
+    It 'verifies the assignment stuck instead of trusting the 200' {
+        # GitHub answers 200 and SILENTLY DROPS an assignee it cannot assign on that repo, so the
+        # status code alone cannot tell a real assignment from a discarded one.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'verificar la asignacion'
+        $src | Should -Match 'notcontains \$Owner'
+    }
+}

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -678,6 +678,24 @@ Describe 'Test-NoChecksIsBenign - "no checks" is not proof there is no CI (#657)
     }
 }
 
+Describe 'The no-checks shortcut cannot be reopened by pagination or a stale stamp (#673 review)' {
+
+    It 'reads ALL workflows, not just the first page' {
+        # The endpoint defaults to 30 per page. A repo whose active workflows fall on a later page
+        # would answer "no active workflows" -> benign pass -> CI unchecked, which is the exact
+        # hole #657 closed, reopened from a different direction. Structural: the failure is a
+        # missing query parameter, and no behavioural test can see it without a 30+-workflow repo.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'actions/workflows\?per_page=100'
+    }
+
+    It 'clears the first-seen stamp when checks DO come back' {
+        # Otherwise a later empty answer inherits an old timestamp and is believed on sight.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'ConvertFrom-Json\); \$parsedOk = \$true \} catch \{ \}[\s\S]{0,400}?\$script:NoChecksSince = \$null'
+    }
+}
+
 Describe 'The Copilot cooldown is armed from the narrow question (#656)' {
 
     It 'arms Set-CopilotUnavailable from Test-CopilotOnlyRefused, not the broad predicate' {

--- a/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
+++ b/plugins/agentic-board/tests/Board-ReviewGate.Tests.ps1
@@ -651,3 +651,46 @@ Describe 'Get-CodexVerifiedComments - a bogus codex marker is treated as if neve
         (Get-ReviewEvidence -CommentBodies $filtered -HeadSha $head).reviewed | Should -BeTrue
     }
 }
+
+Describe 'Test-NoChecksIsBenign - "no checks" is not proof there is no CI (#657)' {
+
+    # `gh pr checks` prints "no checks reported" both for a repo with no CI and for a repo whose
+    # runs for the new head are not registered yet. Reading both as the first passed CI unchecked
+    # seconds after a push, on a PR whose CI had run green on the two previous commits.
+
+    It 'passes immediately when the repo has no active workflows - there is nothing to wait for' {
+        Test-NoChecksIsBenign -RepoHasActiveWorkflows $false -SecondsSinceFirstSeen 0 | Should -BeTrue
+    }
+
+    It 'does NOT pass on sight when the repo HAS workflows (the #657 case)' {
+        Test-NoChecksIsBenign -RepoHasActiveWorkflows $true -SecondsSinceFirstSeen 2 | Should -BeFalse
+    }
+
+    It 'accepts the empty answer once it has PERSISTED past the grace period' {
+        # A repo whose workflows are cron- or release-only never runs on a PR. Without this the
+        # gate would block for the full CI timeout on a PR that legitimately has no checks.
+        Test-NoChecksIsBenign -RepoHasActiveWorkflows $true -SecondsSinceFirstSeen 120 | Should -BeTrue
+    }
+
+    It 'treats the grace boundary as reached, not as still-waiting' {
+        Test-NoChecksIsBenign -RepoHasActiveWorkflows $true -SecondsSinceFirstSeen 90 -GraceSeconds 90 | Should -BeTrue
+        Test-NoChecksIsBenign -RepoHasActiveWorkflows $true -SecondsSinceFirstSeen 89 -GraceSeconds 90 | Should -BeFalse
+    }
+}
+
+Describe 'The Copilot cooldown is armed from the narrow question (#656)' {
+
+    It 'arms Set-CopilotUnavailable from Test-CopilotOnlyRefused, not the broad predicate' {
+        # Structural, and deliberately so: both predicates exist and both are correct for their
+        # own job, so a behavioural test of either one stays green while the CALL SITE uses the
+        # wrong one. What regresses here is which question the arming code asks.
+        $src = Get-Content $script:Script -Raw
+        $src | Should -Match 'copilotRequested -and \(Test-CopilotOnlyRefused'
+        $src | Should -Not -Match 'copilotRequested -and \(Test-CopilotUnavailableReview'
+    }
+
+    It 'still uses the broad predicate where ANY refusal is the right question' {
+        # Subtracting a refusal from the review evidence is per-review and must keep working.
+        (Get-Content $script:Script -Raw) | Should -Match 'Test-CopilotUnavailableReview -Reviews @\(\$r\)'
+    }
+}

--- a/plugins/agentic-board/tests/CopilotAvailability.Tests.ps1
+++ b/plugins/agentic-board/tests/CopilotAvailability.Tests.ps1
@@ -183,3 +183,52 @@ Describe 'Marker I/O round-trip (set -> skip -> clear), keyed by owner' {
         (Test-CopilotShouldSkip -Owner 'CSalcedoDataBI' -Now (Get-Date)).Skip | Should -BeFalse
     }
 }
+
+Describe 'Test-CopilotOnlyRefused (arm the cooldown only when Copilot did NOT review) (#656)' {
+
+    # The cooldown used to be armed from Test-CopilotUnavailableReview, which answers "is there a
+    # refusal anywhere in this array". A re-requested Copilot can answer TWICE on the same head -
+    # a real review and a refusal - and that question says yes, silencing the bot for days on a PR
+    # it had just reviewed properly. The arming question has to be narrower.
+
+    BeforeAll {
+        # NOT named `R`: that is PowerShell's built-in alias for Invoke-History, and names are
+        # case-insensitive - so `R 'login' $body 'oid'` called Invoke-History and failed on its
+        # second argument instead of building a review.
+        function script:NewReview($login, $body, $oid) {
+            [pscustomobject]@{
+                author = [pscustomobject]@{ login = $login }
+                body   = $body
+                commit = [pscustomobject]@{ oid = $oid }
+            }
+        }
+        $script:Refusal = 'Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.'
+    }
+
+    It 'is TRUE when Copilot only refused on this head' {
+        Test-CopilotOnlyRefused -Reviews @( (NewReview 'copilot-pull-request-reviewer' $script:Refusal 'abc') ) -HeadSha 'abc' |
+            Should -BeTrue
+    }
+
+    It 'is FALSE when Copilot also left a real review on the same head (the #656 case)' {
+        Test-CopilotOnlyRefused -Reviews @(
+            (NewReview 'copilot-pull-request-reviewer' $script:Refusal 'abc'),
+            (NewReview 'copilot-pull-request-reviewer' 'Two findings: the retry loop never resets the counter.' 'abc')
+        ) -HeadSha 'abc' | Should -BeFalse
+    }
+
+    It 'is FALSE when Copilot did not answer at all' {
+        Test-CopilotOnlyRefused -Reviews @() -HeadSha 'abc' | Should -BeFalse
+    }
+
+    It 'ignores a refusal left on an EARLIER commit' {
+        # Arming a multi-day cooldown off an old head would skip Copilot on work it never saw.
+        Test-CopilotOnlyRefused -Reviews @( (NewReview 'copilot-pull-request-reviewer' $script:Refusal 'old') ) -HeadSha 'abc' |
+            Should -BeFalse
+    }
+
+    It 'ignores humans whose prose happens to say "unable to review"' {
+        Test-CopilotOnlyRefused -Reviews @( (NewReview 'a-person' 'I was unable to review this properly, sorry' 'abc') ) -HeadSha 'abc' |
+            Should -BeFalse
+    }
+}


### PR DESCRIPTION
Closes #659, #657, #656. #661 closed separately as already-fixed.

One theme: **the tool answered about work it had not checked.** Same family as #649, merged earlier today.

---

## #659 — `Board-Fill -Auto` assigned the wrong repo's issues and reported OK

The report said `-Auto` printed `OK #<n> assignee -> <login>` for all 14 items and assigned nobody, and guessed two causes. **Both are wrong**: the write already went to the issue endpoint (not the board's read-only Assignees projection) and already went through `Invoke-Gh`, so a non-zero exit would have thrown. Running the exact same `gh api` call by hand assigns correctly — checked live against a real issue, then reverted.

The fault is the **address**:

```powershell
$assignUrl = "repos/$Repo/issues/$($entry.IssueNum)/assignees"   # $Repo is ONE value…
...
if (-not $Repo) { $Repo = "$Owner/agentic-board" }               # …defaulting to the tool's own repo
```

A board is not a repo — its items can come from several. On any board whose issues live elsewhere, the write addressed `repos/<default>/issues/<same number>`, which GitHub answers **200** for whenever that number exists there. The assignment landed on an unrelated issue in an unrelated repo while the intended one stayed empty. That is worse than a silent no-op: it writes to the wrong place.

The board query never asked `repository { nameWithOwner }`, so the information needed to address the write correctly was not even being fetched.

- The query asks for it; `Get-IssueRepo` (pure, dot-sourceable) prefers the item's own repo, with the script-level value as a fallback for an unresolvable item only.
- The result is **read back** before counting OK. A 200 is not proof: GitHub silently drops an assignee it cannot assign on that repo and still answers 200 with the issue unchanged. This command exists so nobody has to check the board by hand, so a false OK is worse than a loud failure.

## #657 — the gate passed CI that had not started

`gh pr checks` prints *"no checks reported on the … branch"* for **two** states: no CI configured, and runs not registered yet. The gate read both as the first. Observed live on PR #655 of this repo, seconds after a push, on a branch whose CI had run green on the two previous commits.

Two signals now, and both are needed — active workflows alone would block for the full CI timeout on a repo whose workflows are cron- or release-only; a grace period alone would still pass on a slow registration:

| repo has active workflows | empty answer persisted | verdict |
|---|---|---|
| no | — | benign, pass (nothing to wait for) |
| yes | < grace | **not benign — keep polling** |
| yes | ≥ grace | benign, pass (workflows don't run on this PR) |

The workflow read **fails closed**: an unreadable answer counts as "there is CI".

## #656 — a Copilot that reviewed AND refused was silenced for a week

The cooldown was armed from `Test-CopilotUnavailableReview`, which answers *"is there a refusal anywhere in this array"*. Right question for subtracting a non-review from the evidence; wrong one for arming a multi-day cooldown. A re-requested Copilot can answer twice on the same head — one real review, one refusal — and the marker armed anyway.

Arming now asks `Test-CopilotOnlyRefused`: a refusal with **no substantive review beside it**, on the current head. Same login+body recognition, so a human whose prose says "unable to review" is still never matched.

## #661 — not fixed here, because it already was

Filed alongside the other two. `Get-ReviewEvidence` has partitioned Copilot refusals out of the evidence since #655 (`63143fc`). Confirmed **live rather than read**: on PR #672 of this repo the gate reported `Reviews: 0` while that exact quota-limit comment was present on the PR. Closed as a duplicate with that evidence.

---

## Verification

- Full suite: **2424 passed, 0 failed** (18 new tests).
- Every new test checked against the **original bytes** of each script (`git show`, not retyped): all 14 go red.
- Three assertions are **structural on purpose**, and the comments say why rather than selling them as coverage: for #656 both predicates exist and are correct for their own job, so a behavioural test of either stays green while the call site asks the wrong one — what regresses is *which question* the arming code asks.

## Worth noting

#661 is the **seventh duplicate found today** in a 57-issue backlog (#654, #658, #667 for one defect; #661 for another). The feedback flow files without checking whether the same defect is already open, so every session that trips over a bug adds a copy and the unique reports get buried. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)